### PR TITLE
fix(deps): pin FastAPI for Ray Serve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ray[serve]
-fastapi
+fastapi==0.139.1
 uvicorn
 apprise
 clearml==2.1.3


### PR DESCRIPTION
## Summary

- Pin FastAPI to `0.139.1` in `requirements.txt`.
- Restore compatibility with Ray Serve 2.56 ingress serialization.

## Root cause

FastAPI 0.139.2 added a `threading.Lock` to `_IncludedRouter`. Ray Serve's class-based FastAPI integration calls `include_router()` and then serializes the complete ASGI app, so the new lock causes `TypeError: cannot pickle '_thread.lock' object` during import and deployment.

This dependency drift caused all Python 3.10, 3.11, and 3.12 test jobs in [CI run 29574553786](https://github.com/redai-infra/Relax/actions/runs/29574553786) to fail during test collection. The preceding successful run used FastAPI 0.139.1 with the same Ray 2.56.0 version.

The pin applies to package and container installations as well as CI. This is intentional because production Agentic Serve deployment is affected by the same serialization failure.

## Validation

- `pre-commit run --all-files --show-diff-on-failure`
- CPU-only isolated smoke test: a FastAPI app using `include_router()` serializes successfully with FastAPI 0.139.1.
- Confirmed FastAPI 0.139.2 reproduces the same `_thread.lock` serialization error.

## Not run

- GPU/NPU and multi-node Ray Serve integration tests were not run because the local macOS environment has no GPU hardware.

## Follow-up

Remove or update the pin after FastAPI or Ray ships and validates an upstream serialization-compatible fix.
