### PR TITLE
test(data): cover sequence length balancing

### DIFF
--- a/tests/utils/data/test_seqlen_balancing.py
+++ b/tests/utils/data/test_seqlen_balancing.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import pytest
+
+from relax.utils.data.seqlen_balancing import get_reverse_idx, get_seqlen_balanced_partitions
+
+
+def _partition_loads(seqlen_list: list[int], partitions: list[list[int]]) -> list[int]:
+    return [sum(seqlen_list[idx] for idx in partition) for partition in partitions]
+
+
+def _assert_complete_partition(seqlen_list: list[int], partitions: list[list[int]], k_partitions: int) -> None:
+    flattened = [idx for partition in partitions for idx in partition]
+
+    assert len(partitions) == k_partitions
+    assert len(flattened) == len(seqlen_list)
+    assert len(set(flattened)) == len(seqlen_list)
+    assert set(flattened) == set(range(len(seqlen_list)))
+    assert sum(_partition_loads(seqlen_list, partitions)) == sum(seqlen_list)
+
+
+def test_get_seqlen_balanced_partitions_equal_size() -> None:
+    seqlen_list = [1, 2, 3, 4, 5, 6, 7, 8]
+
+    partitions = get_seqlen_balanced_partitions(seqlen_list, k_partitions=2, equal_size=True)
+
+    _assert_complete_partition(seqlen_list, partitions, k_partitions=2)
+    assert all(len(partition) == 4 for partition in partitions)
+    assert len(set(_partition_loads(seqlen_list, partitions))) == 1
+
+
+def test_get_seqlen_balanced_partitions_variable_size() -> None:
+    seqlen_list = [100, 1, 1, 1]
+
+    partitions = get_seqlen_balanced_partitions(seqlen_list, k_partitions=2, equal_size=False)
+
+    _assert_complete_partition(seqlen_list, partitions, k_partitions=2)
+    assert sorted(len(partition) for partition in partitions) == [1, 3]
+
+
+def test_get_seqlen_balanced_partitions_preserves_duplicate_length_indices() -> None:
+    seqlen_list = [8, 8, 8, 8, 8, 8]
+
+    partitions = get_seqlen_balanced_partitions(seqlen_list, k_partitions=3, equal_size=True)
+
+    _assert_complete_partition(seqlen_list, partitions, k_partitions=3)
+    assert all(len(partition) == 2 for partition in partitions)
+    assert _partition_loads(seqlen_list, partitions) == [16, 16, 16]
+
+
+def test_get_seqlen_balanced_partitions_rejects_too_many_partitions() -> None:
+    with pytest.raises(AssertionError, match="number of items"):
+        get_seqlen_balanced_partitions([4, 8], k_partitions=3, equal_size=False)
+
+
+def test_get_seqlen_balanced_partitions_rejects_non_divisible_equal_size() -> None:
+    with pytest.raises(AssertionError, match=r"5 % 2 != 0"):
+        get_seqlen_balanced_partitions([1, 2, 3, 4, 5], k_partitions=2, equal_size=True)
+
+
+def test_get_reverse_idx_returns_inverse_permutation_without_mutating_input() -> None:
+    idx_map = [2, 0, 3, 1]
+
+    reverse_idx = get_reverse_idx(idx_map)
+
+    assert reverse_idx == [1, 3, 0, 2]
+    assert [reverse_idx[idx] for idx in idx_map] == list(range(len(idx_map)))
+    assert idx_map == [2, 0, 3, 1]


### PR DESCRIPTION
# Tests

## Cover sequence length partition utilities

- Validate equal-size and variable-size partition properties.
- Check index coverage, uniqueness, duplicate lengths, and invalid inputs.
- Verify reverse index construction without mutating the input.
https://github.com/redai-infra/Relax/issues/89
## What

This PR adds `tests/utils/data/test_seqlen_balancing.py` with six unit tests for:

- `get_seqlen_balanced_partitions`
- `get_reverse_idx`

The tests cover equal-size and variable-size partitions, complete index coverage, duplicate sequence lengths, invalid partition requests, and inverse permutation construction.

## Why

The sequence length balancing utilities are used to distribute variable-length samples across data-parallel ranks and microbatches, but they did not have focused unit test coverage.

These tests protect the stable behavioral contract without depending on the internal ordering selected by the partition algorithm. This makes future balancing changes easier to validate while avoiding brittle assertions.

Relates to task 11: sequence length balancing partition unit tests.

## How

The tests use only Python lists and `pytest`; they do not require NumPy, PyTorch, CUDA, models, or datasets.

A shared assertion helper verifies stable partition properties:

- The requested number of partitions is returned.
- Every input index appears exactly once.
- No index is duplicated or omitted.
- The sum of sequence lengths across all partitions equals the input total.

Additional assertions verify equal partition cardinality when `equal_size=True`, allow different cardinalities when `equal_size=False`, validate error cases, and confirm that `get_reverse_idx` returns the inverse permutation without changing its input.

## Testing

Target test command:

```bash
.venv/bin/python -m pytest -v tests/utils/data/test_seqlen_balancing.py
```

Result:

```text
collected 6 items
6 passed in 0.01s
```

Related test directory:

```bash
.venv/bin/python -m pytest -q tests/utils/data
```

Result:

```text
50 passed, 1 failed
```

The unrelated failure is `test_adapt_processor_kwargs_kimi_warns_on_unsupported_modalities` in `test_processing_utils.py`. The expected warnings are emitted to stderr, but the existing test does not receive them through `caplog`. This PR does not modify that test or its logging behavior.

- [ ] `pre-commit run --all-files` passes (not run: `pre-commit` is not installed in the current environment)
- [ ] Tests pass (`pytest tests/`) (full repository suite was not run)
- [x] New tests added (if applicable)
- [ ] Documentation updated (not applicable; this is a test-only change)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes
- [x] Tests only (no production code changes)

## Screenshots / Logs

```text
tests/utils/data/test_seqlen_balancing.py::test_get_seqlen_balanced_partitions_equal_size PASSED
tests/utils/data/test_seqlen_balancing.py::test_get_seqlen_balanced_partitions_variable_size PASSED
tests/utils/data/test_seqlen_balancing.py::test_get_seqlen_balanced_partitions_preserves_duplicate_length_indices PASSED
tests/utils/data/test_seqlen_balancing.py::test_get_seqlen_balanced_partitions_rejects_too_many_partitions PASSED
tests/utils/data/test_seqlen_balancing.py::test_get_seqlen_balanced_partitions_rejects_non_divisible_equal_size PASSED
tests/utils/data/test_seqlen_balancing.py::test_get_reverse_idx_returns_inverse_permutation_without_mutating_input PASSED
```