### PR TITLE
【No.16】feat(data): configurable media-encoding thread pool via --encode-max-workers

### DIFF
--- a/examples/deepeyes/rollout.py
+++ b/examples/deepeyes/rollout.py
@@ -15,7 +15,7 @@ import torch
 
 from examples.deepeyes.base_env import BaseInteractionEnv
 from relax.engine.rollout.sglang_rollout import GenerateState
-from relax.utils.data.processing_utils import _ENCODE_EXECUTOR, encode_image_for_rollout_engine
+from relax.utils.data.processing_utils import encode_image_for_rollout_engine, get_encode_executor
 from relax.utils.http_utils import post
 from relax.utils.types import Sample
 
@@ -175,7 +175,7 @@ def _prepare_initial_inputs(sample: Sample, processor, tokenizer):
 async def _prepare_start_state(sample: Sample, state, args: Any, sampling_params: dict, is_resuming: bool = False):
     loop = asyncio.get_running_loop()
     prompt_ids, image_data, init_mm_train = await loop.run_in_executor(
-        _ENCODE_EXECUTOR,
+        get_encode_executor(),
         _prepare_initial_inputs,
         sample,
         state.processor,
@@ -248,7 +248,7 @@ async def _process_env_step(env: BaseInteractionEnv, response_text: str, tokeniz
     next_user_message = env.format_observation(observation)
     loop = asyncio.get_running_loop()
     obs_prompt_ids, obs_image_data, obs_multimodal_inputs, obs_multimodal_train_inputs = await loop.run_in_executor(
-        _ENCODE_EXECUTOR,
+        get_encode_executor(),
         _encode_observation_for_generation,
         tokenizer,
         processor,

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -26,10 +26,10 @@ from relax.engine.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainO
 from relax.utils.async_utils import run
 from relax.utils.data.data import Dataset
 from relax.utils.data.processing_utils import (
-    _ENCODE_EXECUTOR,
     async_encode_audio_for_rollout_engine,
     async_encode_image_for_rollout_engine,
     async_encode_video_tensor_for_rollout_engine,
+    configure_encode_executor,
     load_processor,
     load_tokenizer,
 )
@@ -61,6 +61,11 @@ class GenerateState(metaclass=SingletonMeta):
 
         # OPD manager (singleton — one OpdManager per GenerateState)
         self.opd_manager = opd.OpdManager(args) if opd.is_opd_enabled(args) else None
+
+        # Media-encoding thread pool for this rollout worker process, sized by
+        # --encode-max-workers (falls back to $RELAX_ENCODE_MAX_WORKERS, then an
+        # affinity-aware default). Held on state so consumers use it explicitly.
+        self.encode_executor = configure_encode_executor(getattr(args, "encode_max_workers", None))
 
         # Process pool for running HuggingFace processor without GIL contention.
         # Controlled by --mm-processor-pool-size (0 = disabled).
@@ -206,7 +211,7 @@ async def _run_image_processor(
             prompt_ids = expand_kimi_k25_placeholders(state.processor, prompt_ids, train_inputs)
             return prompt_ids, train_inputs
 
-        processor_prompt_ids, mm_train_inputs = await loop.run_in_executor(_ENCODE_EXECUTOR, _run_processor)
+        processor_prompt_ids, mm_train_inputs = await loop.run_in_executor(state.encode_executor, _run_processor)
 
     return processor_prompt_ids, mm_train_inputs, monotonic() - t_start
 

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -65,6 +65,14 @@ def check_transfer_queue_version() -> None:
         )
 
 
+def _positive_int(value: str) -> int:
+    """argparse type that rejects non-positive integers at parse time."""
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
+
+
 def reset_arg(parser, name, **kwargs):
     """Reset the default value of a Megatron argument.
 
@@ -1138,6 +1146,16 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "0 (default) disables the processor pool and uses ThreadPoolExecutor instead. "
                     "When set to a positive integer, creates a ProcessPoolExecutor with the specified number of workers "
                     "for true parallelism without GIL contention."
+                ),
+            )
+            parser.add_argument(
+                "--encode-max-workers",
+                type=_positive_int,
+                default=None,
+                help=(
+                    "Worker threads for the shared media-encoding thread pool (image/video/audio "
+                    "encoding offloaded from the asyncio event loop). Positive integer. If unset, "
+                    "falls back to $RELAX_ENCODE_MAX_WORKERS, then to min(32, usable CPU count)."
                 ),
             )
             parser.add_argument(

--- a/relax/utils/data/processing_utils.py
+++ b/relax/utils/data/processing_utils.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
 import asyncio
+import atexit
 import base64
 import io
 import json
 import os
 import tempfile
+import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 
@@ -24,8 +26,92 @@ logger = get_logger(__name__)
 # PNG compression (libpng), H.264 encoding (libx264), and base64 encoding are all C-level
 # operations that release the GIL, so a thread pool achieves true parallelism without the
 # serialization overhead of a process pool.
-# FIXME: hardcode
-_ENCODE_EXECUTOR = ThreadPoolExecutor(max_workers=32)
+#
+# Built lazily (not at import) so --encode-max-workers, parsed after import, can size the pool.
+_ENCODE_MAX_WORKERS_ENV = "RELAX_ENCODE_MAX_WORKERS"
+_encode_executor: ThreadPoolExecutor | None = None
+_encode_executor_workers: int | None = None
+_encode_executor_lock = threading.Lock()
+
+
+def _usable_cpu_count() -> int:
+    """CPUs this process may actually run on, respecting cgroup/cpuset
+    affinity.
+
+    ``os.sched_getaffinity`` reflects Ray/container CPU pinning;
+    ``os.cpu_count`` reports every host core and would oversubscribe on a
+    shared or limited node.
+    """
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:  # non-Linux platforms
+        return os.cpu_count() or 8
+
+
+def _validate_encode_max_workers(max_workers) -> int:
+    # bool is rejected explicitly since bool is a subclass of int.
+    if isinstance(max_workers, bool) or not isinstance(max_workers, int):
+        raise TypeError(f"encode_max_workers must be an integer, got {max_workers!r}")
+    if max_workers <= 0:
+        raise ValueError(f"encode_max_workers must be a positive integer, got {max_workers}")
+    return max_workers
+
+
+def resolve_encode_max_workers(max_workers: int | None) -> tuple[int, str]:
+    """Resolve the worker count and its source, in priority order: explicit
+    ``--encode-max-workers`` > ``$RELAX_ENCODE_MAX_WORKERS`` > affinity-aware
+    default."""
+    if max_workers is not None:
+        return _validate_encode_max_workers(max_workers), "flag"
+    env_value = os.environ.get(_ENCODE_MAX_WORKERS_ENV)
+    if env_value is not None:
+        return _validate_encode_max_workers(int(env_value)), f"${_ENCODE_MAX_WORKERS_ENV}"
+    return min(32, _usable_cpu_count()), "default"
+
+
+def configure_encode_executor(max_workers: int | None = None) -> ThreadPoolExecutor:
+    """Create the shared media-encoding thread pool once and return it.
+
+    Called from the rollout worker init. Idempotent for a matching size; raises
+    if asked to reconfigure a live pool to a different size, since a
+    ThreadPoolExecutor cannot be resized.
+    """
+    global _encode_executor, _encode_executor_workers
+    workers, source = resolve_encode_max_workers(max_workers)
+    with _encode_executor_lock:
+        if _encode_executor is None:
+            _encode_executor = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="relax-encode")
+            _encode_executor_workers = workers
+            atexit.register(shutdown_encode_executor)
+            logger.info("Initialized encode executor with %d workers (source: %s)", workers, source)
+        elif _encode_executor_workers != workers:
+            raise RuntimeError(
+                f"Encode executor already initialized with {_encode_executor_workers} workers; "
+                f"cannot reconfigure to {workers}."
+            )
+        return _encode_executor
+
+
+def get_encode_executor() -> ThreadPoolExecutor:
+    """Return the shared encode pool, lazily creating it with defaults if
+    needed."""
+    executor = _encode_executor
+    if executor is not None:
+        return executor
+    return configure_encode_executor()
+
+
+def shutdown_encode_executor() -> None:
+    """Tear down the shared encode pool (registered with atexit on
+    creation)."""
+    global _encode_executor, _encode_executor_workers
+    with _encode_executor_lock:
+        executor = _encode_executor
+        _encode_executor = None
+        _encode_executor_workers = None
+    if executor is not None:
+        executor.shutdown(wait=False, cancel_futures=True)
+
 
 # Default image patch size for vision-language models
 # Note: Qwen3-VL uses 16, Qwen2.5-VL uses 14
@@ -383,12 +469,12 @@ def encode_audio_for_rollout_engine(
 
 async def async_encode_image_for_rollout_engine(image) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_ENCODE_EXECUTOR, encode_image_for_rollout_engine, image)
+    return await loop.run_in_executor(get_encode_executor(), encode_image_for_rollout_engine, image)
 
 
 async def async_encode_video_tensor_for_rollout_engine(video: torch.Tensor) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_ENCODE_EXECUTOR, encode_video_tensor_for_rollout_engine, video)
+    return await loop.run_in_executor(get_encode_executor(), encode_video_tensor_for_rollout_engine, video)
 
 
 async def async_encode_audio_for_rollout_engine(
@@ -396,4 +482,4 @@ async def async_encode_audio_for_rollout_engine(
     sample_rate: int = 16000,
 ) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_ENCODE_EXECUTOR, encode_audio_for_rollout_engine, audio, sample_rate)
+    return await loop.run_in_executor(get_encode_executor(), encode_audio_for_rollout_engine, audio, sample_rate)

--- a/tests/utils/data/test_encode_executor.py
+++ b/tests/utils/data/test_encode_executor.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the configurable media-encoding thread pool in processing_utils.
+
+Imports are deferred to a fixture because processing_utils pulls in the heavy
+imageio / soundfile / transformers / torch stack at module level.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def pu():
+    """processing_utils with encode-executor + env state reset around each
+    test."""
+    from relax.utils.data import processing_utils as mod
+
+    saved_env = os.environ.get(mod._ENCODE_MAX_WORKERS_ENV)
+    saved_executor = mod._encode_executor
+    saved_workers = mod._encode_executor_workers
+    os.environ.pop(mod._ENCODE_MAX_WORKERS_ENV, None)
+    mod._encode_executor = None
+    mod._encode_executor_workers = None
+    try:
+        yield mod
+    finally:
+        if mod._encode_executor is not None and mod._encode_executor is not saved_executor:
+            mod._encode_executor.shutdown(wait=False)
+        mod._encode_executor = saved_executor
+        mod._encode_executor_workers = saved_workers
+        if saved_env is None:
+            os.environ.pop(mod._ENCODE_MAX_WORKERS_ENV, None)
+        else:
+            os.environ[mod._ENCODE_MAX_WORKERS_ENV] = saved_env
+
+
+def test_default_uses_affinity_aware_cpu_count(pu):
+    workers, source = pu.resolve_encode_max_workers(None)
+    assert source == "default"
+    assert workers == min(32, pu._usable_cpu_count())
+    assert 1 <= workers <= 32
+
+
+def test_explicit_flag_takes_priority_over_env(pu):
+    os.environ[pu._ENCODE_MAX_WORKERS_ENV] = "9"
+    workers, source = pu.resolve_encode_max_workers(4)
+    assert (workers, source) == (4, "flag")
+
+
+def test_env_var_used_when_flag_unset(pu):
+    os.environ[pu._ENCODE_MAX_WORKERS_ENV] = "7"
+    workers, source = pu.resolve_encode_max_workers(None)
+    assert workers == 7
+    assert source == f"${pu._ENCODE_MAX_WORKERS_ENV}"
+
+
+@pytest.mark.parametrize("bad", [0, -1, -32])
+def test_non_positive_raises_value_error(pu, bad):
+    with pytest.raises(ValueError):
+        pu.resolve_encode_max_workers(bad)
+
+
+@pytest.mark.parametrize("bad", [3.5, "8", True])
+def test_non_int_raises_type_error(pu, bad):
+    # bool is rejected explicitly even though it subclasses int.
+    with pytest.raises(TypeError):
+        pu.resolve_encode_max_workers(bad)
+
+
+def test_illegal_env_value_raises(pu):
+    os.environ[pu._ENCODE_MAX_WORKERS_ENV] = "0"
+    with pytest.raises(ValueError):
+        pu.resolve_encode_max_workers(None)
+    os.environ[pu._ENCODE_MAX_WORKERS_ENV] = "not-an-int"
+    with pytest.raises(ValueError):
+        pu.resolve_encode_max_workers(None)
+
+
+def test_configure_creates_pool_with_requested_size(pu):
+    executor = pu.configure_encode_executor(5)
+    assert executor._max_workers == 5
+    assert pu.get_encode_executor() is executor
+
+
+def test_configure_is_idempotent_for_same_size(pu):
+    first = pu.configure_encode_executor(6)
+    second = pu.configure_encode_executor(6)
+    assert first is second
+
+
+def test_reconfigure_to_different_size_raises(pu):
+    pu.configure_encode_executor(4)
+    with pytest.raises(RuntimeError, match="already initialized"):
+        pu.configure_encode_executor(8)
+
+
+def test_get_encode_executor_lazily_creates_default(pu):
+    assert pu._encode_executor is None
+    executor = pu.get_encode_executor()
+    assert executor is not None
+    assert executor._max_workers == min(32, pu._usable_cpu_count())
+
+
+def test_shutdown_resets_state_and_allows_new_size(pu):
+    pu.configure_encode_executor(4)
+    pu.shutdown_encode_executor()
+    assert pu._encode_executor is None
+    assert pu._encode_executor_workers is None
+    executor = pu.configure_encode_executor(8)
+    assert executor._max_workers == 8


### PR DESCRIPTION
#### Summary

- Closes #157 — Task 16 (per-task issue with the frozen environment and acceptance criteria).
- **Problem**: the media-encoding thread pool was hardcoded to `max_workers=32` (`# FIXME: hardcode`) and could not adapt to the host CPU shape.
- **Approach**: a lazily-created, configurable pool sized by `--encode-max-workers`, with an environment-variable fallback and an affinity-aware default.

#### Changes

- `relax/utils/data/processing_utils.py`: replace the eager module global `_ENCODE_EXECUTOR = ThreadPoolExecutor(32)` with:
  - `resolve_encode_max_workers()` — priority: `--encode-max-workers` > `$RELAX_ENCODE_MAX_WORKERS` > default `min(32, len(os.sched_getaffinity(0)))`. The default is **affinity-aware**: `os.sched_getaffinity` reflects cgroup/Ray CPU pinning, so we don't oversubscribe on shared/limited nodes the way raw `os.cpu_count()` (host core count) would.
  - `configure_encode_executor()` — builds the pool once (double-checked lock, `thread_name_prefix="relax-encode"`, logs the resolved worker count **and its source**), returns it; raises if asked to reconfigure a live pool to a different size.
  - `get_encode_executor()` — lazy accessor; `shutdown_encode_executor()` — reclaims threads, **registered via `atexit`** so they are released on process exit.
  - FIXME removed.
- `relax/utils/arguments.py`: add `--encode-max-workers` with a `_positive_int` argparse validator (rejects `<= 0` at parse time).
- `relax/engine/rollout/sglang_rollout.py`: hold the pool on `GenerateState.encode_executor`; consumers use it / the accessor.
- `examples/deepeyes/rollout.py`: route both encode sites through `get_encode_executor()` (no call-signature changes).
- **Compatibility**: opt-in flag. Default is unchanged (`32`) on hosts with ≥32 usable CPUs; CPU-scaled (smaller) on smaller/limited ones. Illegal values fail fast.

#### Verification

All in the official `ghcr.io/redai-infra/relaxrl` image; single H100 80GB for the GPU smoke. Base commit `8a54679` (rebased onto `upstream/main`; the `relax/utils/arguments.py` conflict with `check_transfer_queue_version` was resolved by keeping both additions).

- **Unit** — `pytest tests/utils/data/test_encode_executor.py` → **15 passed**: affinity-aware default, `flag > env > default` priority, env fallback, illegal (`ValueError` for `<=0`, `TypeError` for non-int, bad env value), pool sizing, idempotent same-size, **reconfigure-conflict `RuntimeError`**, lazy creation, **shutdown resets state**.
- **Argparse** — `--encode-max-workers 4` → `args.encode_max_workers == 4`; `--encode-max-workers 0` rejected at parse time.
- **CPU integration** — after `configure_encode_executor(4)`, the real `async_encode_image_for_rollout_engine(<PIL image>)` returns a non-empty base64 string and the pool has 4 workers; with the flag unset, `$RELAX_ENCODE_MAX_WORKERS=6` resolves to 6.
- **End-to-end GPU** (single H100, `--debug-rollout-only --encode-max-workers 3`, Qwen3-VL-2B-Instruct + geo3k) — log shows `Initialized encode executor with 3 workers (source: flag)`; SGLang loaded `Qwen3VLForConditionalGeneration`; `rollout_id 0` completed (2 samples, 0 aborted) with images encoded into vision tokens (`<|image_pad|>` ×2); exit 0.
- **Regression** — full suite in the image (`pytest tests/ --ignore=tests/autoscale`): baseline `8a54679` = **724 passed**, 7 skipped; this branch = **739 passed**, 7 skipped. The +15 delta is exactly the new cases; no regressions.
- `ruff check relax/ tests/` and `ruff format --check relax/ tests/` pass (359 files already formatted); `pre-commit run` — all hooks pass (ruff, ruff-format, docformatter, gitleaks, check-merge-conflict, check-conflict-markers, …).

#### Risk & Rollback

- **Known limits**: a live `ThreadPoolExecutor` cannot be resized, so reconfiguring to a different size raises (fail-loud rather than silently ignoring).
- **Risk**: low — opt-in; default preserved on large hosts; the affinity-aware default only *lowers* the count where the host is actually limited.
- **Rollback**: revert the commit; behavior returns to the fixed 32-worker pool.

#### Checklist

- [x] Diff contains only changes necessary for this task
- [x] New / related tests all pass (15)
- [x] Docs / scripts / defaults updated (flag help documents the env fallback + default)
- [x] No secrets, datasets, checkpoints, or machine-private info
- [ ] Review comments addressed one by one (none yet)

