### PR TITLE
【No.16】feat(data): make encode executor configurable

### DIFF
--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -114,6 +114,15 @@ For common configuration usage and examples, see the [Quick Start Guide](./quick
 | `--audio-sample-rate` | int | None | Sample rate for audio processing. Default is 16000 if not set |
 | `--frame-factor` | int | None | Frame alignment factor. Default is 2 if not set |
 | `--mm-processor-pool-size` | int | 0 | Size of the multimodal processor pool. 0 (default) disables the pool and uses ThreadPoolExecutor. When set to a positive integer, creates a ProcessPoolExecutor with the specified number of workers for true parallelism without GIL contention |
+| `--encode-max-workers` | int | `min(32, CPU count or 8)` | Maximum threads in the shared pool used for image, video, audio, and multimodal prompt encoding |
+
+`--encode-max-workers` controls the shared media-encoding `ThreadPoolExecutor`. It is separate from
+`--mm-processor-pool-size`, which controls the HuggingFace processor `ProcessPoolExecutor`. On high-core-count
+systems such as NVIDIA Grace, try values such as 32 and 64 and tune them for the workload:
+
+```bash
+--encode-max-workers 64
+```
 
 ---
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -114,6 +114,15 @@
 | `--audio-sample-rate` | int | None | 音频处理的采样率。未设置时使用默认值 16000 |
 | `--frame-factor` | int | None | 帧数对齐因子。未设置时使用默认值 2 |
 | `--mm-processor-pool-size` | int | 0 | 多模态处理器池大小。0（默认）禁用进程池，使用 ThreadPoolExecutor。设置为正整数时，创建指定数量 worker 的 ProcessPoolExecutor，实现无 GIL 竞争的真正并行 |
+| `--encode-max-workers` | int | `min(32, CPU count or 8)` | 图片、视频、音频和多模态 prompt 编码所用共享线程池的最大线程数 |
+
+`--encode-max-workers` 控制媒体编码所用的共享 `ThreadPoolExecutor`。它与
+`--mm-processor-pool-size` 不同，后者控制 HuggingFace processor 所用的 `ProcessPoolExecutor`。在 NVIDIA
+Grace 等高核数系统上，可以尝试 32 和 64，并根据实际 workload 调整：
+
+```bash
+--encode-max-workers 64
+```
 
 ---
 

--- a/examples/deepeyes/rollout.py
+++ b/examples/deepeyes/rollout.py
@@ -15,7 +15,7 @@ import torch
 
 from examples.deepeyes.base_env import BaseInteractionEnv
 from relax.engine.rollout.sglang_rollout import GenerateState
-from relax.utils.data.processing_utils import _ENCODE_EXECUTOR, encode_image_for_rollout_engine
+from relax.utils.data.processing_utils import encode_image_for_rollout_engine
 from relax.utils.http_utils import post
 from relax.utils.types import Sample
 
@@ -175,7 +175,7 @@ def _prepare_initial_inputs(sample: Sample, processor, tokenizer):
 async def _prepare_start_state(sample: Sample, state, args: Any, sampling_params: dict, is_resuming: bool = False):
     loop = asyncio.get_running_loop()
     prompt_ids, image_data, init_mm_train = await loop.run_in_executor(
-        _ENCODE_EXECUTOR,
+        state.encode_executor,
         _prepare_initial_inputs,
         sample,
         state.processor,
@@ -236,7 +236,15 @@ async def _run_inference_step(url: str, tokens: list[int], sampling_params: dict
     return response_text, new_tokens, new_log_probs, finish_type, meta_info
 
 
-async def _process_env_step(env: BaseInteractionEnv, response_text: str, tokenizer, processor, args, sample_metadata):
+async def _process_env_step(
+    env: BaseInteractionEnv,
+    response_text: str,
+    tokenizer,
+    processor,
+    encode_executor,
+    args,
+    sample_metadata,
+):
     result = env.step(response_text)
     # 兼容 async env.step（如 VideoSearchEnv）：若返回 coroutine 则 await
     if inspect.isawaitable(result):
@@ -248,7 +256,7 @@ async def _process_env_step(env: BaseInteractionEnv, response_text: str, tokeniz
     next_user_message = env.format_observation(observation)
     loop = asyncio.get_running_loop()
     obs_prompt_ids, obs_image_data, obs_multimodal_inputs, obs_multimodal_train_inputs = await loop.run_in_executor(
-        _ENCODE_EXECUTOR,
+        encode_executor,
         _encode_observation_for_generation,
         tokenizer,
         processor,
@@ -513,7 +521,15 @@ async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
                 obs_multimodal_train_inputs,
                 done,
                 info,
-            ) = await _process_env_step(env, response_text, state.tokenizer, state.processor, args, sample.metadata)
+            ) = await _process_env_step(
+                env,
+                response_text,
+                state.tokenizer,
+                state.processor,
+                state.encode_executor,
+                args,
+                sample.metadata,
+            )
             env_end_ts = time.time()
 
             trace_recorder.record_env_step(

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -26,10 +26,10 @@ from relax.engine.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainO
 from relax.utils.async_utils import run
 from relax.utils.data.data import Dataset
 from relax.utils.data.processing_utils import (
-    _ENCODE_EXECUTOR,
     async_encode_audio_for_rollout_engine,
     async_encode_image_for_rollout_engine,
     async_encode_video_tensor_for_rollout_engine,
+    configure_encode_executor,
     load_processor,
     load_tokenizer,
 )
@@ -56,6 +56,7 @@ class GenerateState(metaclass=SingletonMeta):
     def __init__(self, args: Namespace) -> None:
         # persistent state for the generation process
         self.args = args
+        self.encode_executor = configure_encode_executor(getattr(args, "encode_max_workers", None))
         self.tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
         self.processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
 
@@ -206,7 +207,7 @@ async def _run_image_processor(
             prompt_ids = expand_kimi_k25_placeholders(state.processor, prompt_ids, train_inputs)
             return prompt_ids, train_inputs
 
-        processor_prompt_ids, mm_train_inputs = await loop.run_in_executor(_ENCODE_EXECUTOR, _run_processor)
+        processor_prompt_ids, mm_train_inputs = await loop.run_in_executor(state.encode_executor, _run_processor)
 
     return processor_prompt_ids, mm_train_inputs, monotonic() - t_start
 

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -31,6 +31,13 @@ from relax.utils.training.eval_config import (
 logger = get_logger(__name__)
 
 
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
+
+
 def reset_arg(parser, name, **kwargs):
     """Reset the default value of a Megatron argument.
 
@@ -1104,6 +1111,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "0 (default) disables the processor pool and uses ThreadPoolExecutor instead. "
                     "When set to a positive integer, creates a ProcessPoolExecutor with the specified number of workers "
                     "for true parallelism without GIL contention."
+                ),
+            )
+            parser.add_argument(
+                "--encode-max-workers",
+                type=_positive_int,
+                default=None,
+                help=(
+                    "Maximum number of threads used for image, video, audio, and multimodal prompt encoding. "
+                    "If unset, defaults to min(32, os.cpu_count() or 8)."
                 ),
             )
             parser.add_argument(

--- a/relax/utils/data/processing_utils.py
+++ b/relax/utils/data/processing_utils.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import tempfile
+import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 
@@ -24,8 +25,62 @@ logger = get_logger(__name__)
 # PNG compression (libpng), H.264 encoding (libx264), and base64 encoding are all C-level
 # operations that release the GIL, so a thread pool achieves true parallelism without the
 # serialization overhead of a process pool.
-# FIXME: hardcode
-_ENCODE_EXECUTOR = ThreadPoolExecutor(max_workers=32)
+_ENCODE_EXECUTOR: ThreadPoolExecutor | None = None
+_ENCODE_EXECUTOR_MAX_WORKERS: int | None = None
+_ENCODE_EXECUTOR_LOCK = threading.Lock()
+
+
+def resolve_encode_max_workers(max_workers: int | None) -> int:
+    if max_workers is None:
+        return min(32, os.cpu_count() or 8)
+    if isinstance(max_workers, bool) or not isinstance(max_workers, int):
+        raise TypeError(f"encode max workers must be an integer, got {max_workers!r}")
+    if max_workers <= 0:
+        raise ValueError(f"encode max workers must be a positive integer, got {max_workers!r}")
+    return max_workers
+
+
+def configure_encode_executor(max_workers: int | None = None) -> ThreadPoolExecutor:
+    global _ENCODE_EXECUTOR
+    global _ENCODE_EXECUTOR_MAX_WORKERS
+
+    resolved = resolve_encode_max_workers(max_workers)
+    with _ENCODE_EXECUTOR_LOCK:
+        if _ENCODE_EXECUTOR is None:
+            _ENCODE_EXECUTOR = ThreadPoolExecutor(
+                max_workers=resolved,
+                thread_name_prefix="relax-encode",
+            )
+            _ENCODE_EXECUTOR_MAX_WORKERS = resolved
+            logger.info("Initialized encode executor with %d workers", resolved)
+        elif _ENCODE_EXECUTOR_MAX_WORKERS != resolved:
+            raise RuntimeError(
+                f"Encode executor is already initialized with {_ENCODE_EXECUTOR_MAX_WORKERS} workers; "
+                f"cannot reconfigure it to {resolved} workers."
+            )
+
+        return _ENCODE_EXECUTOR
+
+
+def get_encode_executor() -> ThreadPoolExecutor:
+    executor = _ENCODE_EXECUTOR
+    if executor is not None:
+        return executor
+    return configure_encode_executor()
+
+
+def shutdown_encode_executor() -> None:
+    global _ENCODE_EXECUTOR
+    global _ENCODE_EXECUTOR_MAX_WORKERS
+
+    with _ENCODE_EXECUTOR_LOCK:
+        executor = _ENCODE_EXECUTOR
+        _ENCODE_EXECUTOR = None
+        _ENCODE_EXECUTOR_MAX_WORKERS = None
+
+    if executor is not None:
+        executor.shutdown(wait=True, cancel_futures=True)
+
 
 # Default image patch size for vision-language models
 # Note: Qwen3-VL uses 16, Qwen2.5-VL uses 14
@@ -383,12 +438,12 @@ def encode_audio_for_rollout_engine(
 
 async def async_encode_image_for_rollout_engine(image) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_ENCODE_EXECUTOR, encode_image_for_rollout_engine, image)
+    return await loop.run_in_executor(get_encode_executor(), encode_image_for_rollout_engine, image)
 
 
 async def async_encode_video_tensor_for_rollout_engine(video: torch.Tensor) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_ENCODE_EXECUTOR, encode_video_tensor_for_rollout_engine, video)
+    return await loop.run_in_executor(get_encode_executor(), encode_video_tensor_for_rollout_engine, video)
 
 
 async def async_encode_audio_for_rollout_engine(
@@ -396,4 +451,4 @@ async def async_encode_audio_for_rollout_engine(
     sample_rate: int = 16000,
 ) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_ENCODE_EXECUTOR, encode_audio_for_rollout_engine, audio, sample_rate)
+    return await loop.run_in_executor(get_encode_executor(), encode_audio_for_rollout_engine, audio, sample_rate)

--- a/tests/utils/data/test_processing_utils.py
+++ b/tests/utils/data/test_processing_utils.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""Tests for relax.utils.data.processing_utils.adapt_processor_kwargs.
+"""Tests for relax.utils.data.processing_utils.
 
 Imports are deferred to fixtures because processing_utils pulls in the heavy
 imageio / soundfile / transformers / torch stack at module level, which trips a
 numpy ABI mismatch in this CI image during pytest collection.
 """
+
+import threading
 
 import pytest
 
@@ -15,6 +17,90 @@ def adapt_processor_kwargs():
     from relax.utils.data.processing_utils import adapt_processor_kwargs as fn
 
     return fn
+
+
+@pytest.fixture()
+def processing_utils():
+    from relax.utils.data import processing_utils as module
+
+    module.shutdown_encode_executor()
+    yield module
+    module.shutdown_encode_executor()
+
+
+@pytest.mark.parametrize(
+    ("cpu_count", "expected"),
+    [(4, 4), (12, 12), (32, 32), (72, 32), (128, 32), (None, 8)],
+)
+def test_encode_executor_uses_cpu_aware_default(monkeypatch, processing_utils, cpu_count, expected):
+    monkeypatch.setattr(processing_utils.os, "cpu_count", lambda: cpu_count)
+
+    executor = processing_utils.configure_encode_executor()
+
+    assert executor._max_workers == expected
+
+
+@pytest.mark.parametrize("workers", [1, 8, 32, 64])
+def test_encode_executor_uses_explicit_worker_count(processing_utils, workers):
+    executor = processing_utils.configure_encode_executor(workers)
+
+    assert executor._max_workers == workers
+
+
+@pytest.mark.parametrize("workers", [0, -1, -32])
+def test_encode_executor_rejects_non_positive_values(processing_utils, workers):
+    with pytest.raises(ValueError, match="positive integer"):
+        processing_utils.configure_encode_executor(workers)
+
+
+@pytest.mark.parametrize("workers", [True, 1.5, "8"])
+def test_encode_executor_rejects_non_integer_values(processing_utils, workers):
+    with pytest.raises(TypeError, match="integer"):
+        processing_utils.configure_encode_executor(workers)
+
+
+def test_encode_executor_same_configuration_is_idempotent(processing_utils):
+    first = processing_utils.configure_encode_executor(8)
+    second = processing_utils.configure_encode_executor(8)
+
+    assert first is second
+    assert processing_utils.get_encode_executor() is first
+
+
+def test_encode_executor_rejects_reconfiguration(processing_utils):
+    original = processing_utils.configure_encode_executor(8)
+
+    with pytest.raises(RuntimeError, match="already initialized with 8 workers"):
+        processing_utils.configure_encode_executor(16)
+
+    assert processing_utils.get_encode_executor() is original
+
+
+def test_encode_executor_shutdown_allows_reinitialization(processing_utils):
+    first = processing_utils.configure_encode_executor(4)
+
+    processing_utils.shutdown_encode_executor()
+
+    with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+        first.submit(lambda: None)
+
+    second = processing_utils.configure_encode_executor(4)
+    assert second is not first
+
+
+@pytest.mark.asyncio
+async def test_async_encode_uses_configured_executor(monkeypatch, processing_utils):
+    processing_utils.configure_encode_executor(1)
+    monkeypatch.setattr(
+        processing_utils,
+        "encode_image_for_rollout_engine",
+        lambda image: (image, threading.current_thread().name),
+    )
+
+    image, thread_name = await processing_utils.async_encode_image_for_rollout_engine("image")
+
+    assert image == "image"
+    assert thread_name.startswith("relax-encode")
 
 
 class _FakeQwenVLProcessor:

--- a/tests/utils/test_arguments_encode_executor.py
+++ b/tests/utils/test_arguments_encode_executor.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import argparse
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def parser():
+    module_names = ("relax.backends.sglang.arguments", "relax.utils.arguments")
+    saved_modules = {name: sys.modules.get(name) for name in module_names}
+
+    sglang_arguments = types.ModuleType("relax.backends.sglang.arguments")
+
+    def no_op(*args, **kwargs):
+        return None
+
+    sglang_arguments.sglang_parse_args = no_op
+    sglang_arguments.validate_args = no_op
+    sys.modules["relax.backends.sglang.arguments"] = sglang_arguments
+    sys.modules.pop("relax.utils.arguments", None)
+
+    arguments = importlib.import_module("relax.utils.arguments")
+    parser = argparse.ArgumentParser()
+    arguments.get_slime_extra_args_provider()(parser)
+    yield parser
+
+    for name, module in saved_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def test_encode_max_workers_cli_defaults_to_none(parser):
+    args = parser.parse_args([])
+
+    assert args.encode_max_workers is None
+    assert args.mm_processor_pool_size == 0
+
+
+@pytest.mark.parametrize("value", ["1", "8", "32", "64"])
+def test_encode_max_workers_cli_accepts_positive_integer(parser, value):
+    args = parser.parse_args(["--encode-max-workers", value])
+
+    assert args.encode_max_workers == int(value)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "abc"])
+def test_encode_max_workers_cli_rejects_invalid_value(parser, value):
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--encode-max-workers", value])


### PR DESCRIPTION
#### Summary

- Closes #93.
- Adds `--encode-max-workers` and replaces the hard-coded media-encoding executor with a lazily initialized, process-wide shared executor.
- Keeps the media-encoding thread pool separate from `--mm-processor-pool-size`.

#### Changes

- Validates positive integer CLI values and rejects zero, negative, non-integer, and boolean programmatic values.
- Defaults to `min(32, os.cpu_count() or 8)` when the option is unset.
- Makes repeated initialization idempotent and conflicting reconfiguration fail fast.
- Provides explicit shutdown and reset for lifecycle tests.
- Uses one shared executor for SGLang rollout processing, asynchronous media encoding, and DeepEyes.
- Documents the option in English and Chinese.

#### Verification

Local arm64 macOS, Python 3.11.13:

- `python -m pytest -v tests/utils/data/test_processing_utils.py tests/utils/test_arguments_encode_executor.py`: 42 passed
- Targeted `ruff check`: passed
- Targeted `ruff format --check`: passed
- Python compile check for all changed Python files: passed
- `pre-commit run --all-files`: passed, including gitleaks

NVIDIA GH200 validation environment:

- Architecture: `aarch64`
- CPU cores: 72
- GPU: NVIDIA GH200, compute capability 9.0, 97871 MiB
- Driver: 595.58.03
- Python: 3.10.20
- PyTorch: 2.11.0+cu129
- CUDA: 12.9, available
- Commit: `b2757fe2e6713b8c78cd8832a70d62b9b9630467`
- `python -m pytest -v tests/utils/data/test_processing_utils.py tests/utils/test_arguments_encode_executor.py`: 42 passed
- `python -m pytest -v tests/test_agentic_rollout.py`: 16 passed

The runs completed with only existing third-party deprecation warnings from OpenTelemetry, SWIG, Ray Serve, and Pydantic.

#### Risk & Rollback

- Known limit: a live `ThreadPoolExecutor` cannot be resized; requesting a different size after initialization fails explicitly.
- Risk is limited to media-encoding executor initialization and consumers; `--mm-processor-pool-size` is unchanged.
- Revert this PR to restore the fixed import-time 32-worker executor.

#### Checklist

- [x] Diff contains only changes necessary for this task
- [x] New and related targeted tests pass
- [x] English and Chinese documentation and defaults are updated
- [x] No secrets, datasets, checkpoints, or machine-private identifiers are included
- [x] Review comments addressed (the automated review raised no inline comments)
