### PR TITLE
test(multimodal): cover image preprocessing utilities

### DIFF
--- a/tests/utils/multimodal/test_image_utils.py
+++ b/tests/utils/multimodal/test_image_utils.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import base64
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from relax.utils.multimodal.image_utils import (
+    decode_data_uri,
+    get_resize_height_width,
+    image_smart_resize,
+    load_image,
+    to_rgb,
+)
+
+
+def _png_bytes(image: Image.Image) -> bytes:
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_get_resize_height_width_downscales_and_aligns_to_scale_factor():
+    height, width = get_resize_height_width(None, 1000, 2000, 14, 200_000, 196)
+
+    assert (height, width) == (308, 630)
+    assert height % 14 == 0 and width % 14 == 0
+    assert 196 <= height * width <= 200_000
+
+
+def test_get_resize_height_width_upscales_to_minimum_pixels():
+    height, width = get_resize_height_width(None, 10, 20, 4, 2_000, 1_000)
+
+    assert (height, width) == (24, 48)
+    assert height % 4 == 0 and width % 4 == 0
+    assert 1_000 <= height * width <= 2_000
+
+
+def test_get_resize_height_width_rejects_excessive_aspect_ratio():
+    with pytest.raises(ValueError, match="Absolute aspect ratio"):
+        get_resize_height_width(3.0, 100, 400, 2, 100_000, 1)
+
+
+def test_get_resize_height_width_keeps_size_when_already_in_range():
+    height, width = get_resize_height_width(None, 112, 112, 28, 28 * 28 * 1024, 28 * 28)
+
+    assert (height, width) == (112, 112)
+
+
+def test_get_resize_height_width_rounds_to_scale_factor_28():
+    height, width = get_resize_height_width(None, 100, 100, 28, 28 * 28 * 1024, 28 * 28)
+
+    assert (height, width) == (112, 112)
+
+
+def test_image_smart_resize_preserves_mode_and_patch_alignment():
+    image = Image.new("RGB", (200, 100), (12, 34, 56))
+
+    resized = image_smart_resize(
+        image,
+        height=100,
+        width=200,
+        scale_factor=28,
+        image_min_pixels=28 * 28,
+        image_max_pixels=4 * 28 * 28,
+    )
+
+    assert resized.mode == "RGB"
+    assert resized.size == (56, 28)
+    assert resized.size[0] % 28 == 0 and resized.size[1] % 28 == 0
+    assert 28 * 28 <= resized.width * resized.height <= 4 * 28 * 28
+
+
+def test_to_rgb_composites_rgba_over_white():
+    image = Image.new("RGBA", (1, 1), (255, 0, 0, 128))
+
+    converted = to_rgb(image)
+
+    assert converted.mode == "RGB"
+    assert converted.getpixel((0, 0)) == (255, 127, 127)
+
+
+def test_to_rgb_converts_non_rgba_image():
+    image = Image.new("L", (1, 1), 42)
+
+    converted = to_rgb(image)
+
+    assert converted.mode == "RGB"
+    assert converted.getpixel((0, 0)) == (42, 42, 42)
+
+
+def test_to_rgb_composites_fully_transparent_over_white():
+    image = Image.new("RGBA", (1, 1), (10, 20, 30, 0))
+
+    converted = to_rgb(image)
+
+    assert converted.mode == "RGB"
+    assert converted.getpixel((0, 0)) == (255, 255, 255)
+
+
+def test_decode_data_uri_supports_base64_and_url_encoded_payloads():
+    payload = b"image bytes / 1, 2"
+    base64_uri = "data:image/png;base64," + base64.b64encode(payload).decode()
+    text_uri = "data:text/plain," + "image%20bytes%20%2F%201%2C%202"
+
+    assert decode_data_uri(base64_uri) == payload
+    assert decode_data_uri(text_uri) == payload
+
+
+def test_decode_data_uri_rejects_missing_payload():
+    with pytest.raises(ValueError, match="Malformed data URI"):
+        decode_data_uri("data:image/png;base64,")
+
+
+@pytest.mark.parametrize("input_kind", ["pil", "bytes", "bytearray", "dict_bytes", "dict_base64", "data_uri"])
+def test_load_image_supports_memory_input_types(input_kind):
+    source = Image.new("RGB", (3, 2), (1, 2, 3))
+    encoded = _png_bytes(source)
+    inputs = {
+        "pil": source,
+        "bytes": encoded,
+        "bytearray": bytearray(encoded),
+        "dict_bytes": {"bytes": encoded},
+        "dict_base64": {"base64": base64.b64encode(encoded).decode()},
+        "data_uri": "data:image/png;base64," + base64.b64encode(encoded).decode(),
+    }
+
+    loaded = load_image(inputs[input_kind])
+
+    assert loaded.size == (3, 2)
+    assert loaded.convert("RGB").getpixel((0, 0)) == (1, 2, 3)
+
+
+def test_load_image_supports_local_path_and_file_uri(tmp_path):
+    source = Image.new("RGB", (2, 2), (9, 8, 7))
+    path = tmp_path / "sample.png"
+    source.save(path)
+
+    from_path = load_image(str(path))
+    from_uri = load_image(path.as_uri())
+
+    assert from_path.size == (2, 2)
+    assert from_uri.getpixel((1, 1)) == (9, 8, 7)
+
+
+def test_load_image_rejects_unsupported_type():
+    with pytest.raises(NotImplementedError, match="Unsupported image input type"):
+        load_image(123)


### PR DESCRIPTION
Closes #106

#### Summary
- Add focused unit tests for image preprocessing utilities.
- Keep all test inputs in memory or pytest temporary files; no network access or model inference is required.
- Address review feedback by covering unchanged resize behavior, 28-pixel rounding, fully transparent RGBA compositing, and unsupported input types.

#### Changes
- Add `tests/utils/multimodal/test_image_utils.py`.
- Cover `get_resize_height_width`, `image_smart_resize`, `to_rgb`, `decode_data_uri`, and `load_image`.
- No production code, CLI, configuration, or compatibility changes.

#### Verification
- Environment: Python 3.13.9, pytest 9.0.2, CPU-only.
- Baseline commit: `05b2fb0`; implementation commit: `b4638c0`.
- Command:

```bash
RELAX_TEST_QWEN3_VL_4B=~/model/Qwen3-VL-4B-Instruct \
  python -m pytest -v tests/utils/multimodal/test_image_utils.py
```

- Test output (absolute local paths omitted):

```text
collected 19 items

test_get_resize_height_width_downscales_and_aligns_to_scale_factor PASSED
test_get_resize_height_width_upscales_to_minimum_pixels PASSED
test_get_resize_height_width_rejects_excessive_aspect_ratio PASSED
test_get_resize_height_width_keeps_size_when_already_in_range PASSED
test_get_resize_height_width_rounds_to_scale_factor_28 PASSED
test_image_smart_resize_preserves_mode_and_patch_alignment PASSED
test_to_rgb_composites_rgba_over_white PASSED
test_to_rgb_converts_non_rgba_image PASSED
test_to_rgb_composites_fully_transparent_over_white PASSED
test_decode_data_uri_supports_base64_and_url_encoded_payloads PASSED
test_decode_data_uri_rejects_missing_payload PASSED
test_load_image_supports_memory_input_types[pil] PASSED
test_load_image_supports_memory_input_types[bytes] PASSED
test_load_image_supports_memory_input_types[bytearray] PASSED
test_load_image_supports_memory_input_types[dict_bytes] PASSED
test_load_image_supports_memory_input_types[dict_base64] PASSED
test_load_image_supports_memory_input_types[data_uri] PASSED
test_load_image_supports_local_path_and_file_uri PASSED
test_load_image_rejects_unsupported_type PASSED

======================== 19 passed, 1 warning in 0.20s =========================
```

- Warning: pytest reports the repository's existing `Unknown config option: asyncio_mode` warning because `pytest-asyncio` is not installed in this local environment. It does not affect these synchronous tests.
- Additional checks:
  - `python -m compileall -q tests/utils/multimodal/test_image_utils.py`: passed
  - `git diff --check`: passed
  - 119-character line-length scan: passed

#### Risk & Rollback
- Known limitation: remote HTTP image loading is not covered to avoid network-dependent tests.
- Risk: tests only; no runtime behavior changes.
- Rollback: revert commit `b4638c0`.

#### Checklist
- [x] Diff contains only changes required for this task
- [x] New and related tests pass
- [x] Review feedback addressed
- [x] No secrets, datasets, checkpoints, or machine-private information
- [ ] CI passes