### PR TITLE
Task[18] Format-aware reward router for mixed-task batches

### DIFF
--- a/docs/draft/format-aware-reward-router-experiment.md
+++ b/docs/draft/format-aware-reward-router-experiment.md
@@ -1,0 +1,155 @@
+# Format-aware reward router 实验报告
+
+> 状态：本地功能与回归测试完成；多节点训练验证待具备 Ray 集群地址和模型/数据路径后执行。
+
+## Issue 固定信息
+
+### 1. 仓库、基线与分支
+
+- 仓库：Relax（当前 checkout 的 Git remote）
+- 基线 commit：`30f219a1c963137129570dd5485a9c3d82390548`
+- 基线分支：`main`（实验开始时本地比 `origin/main` 落后 1 个提交）
+- 开发分支：`feat/format-aware-reward-router`
+- 实验开始前已有且不属于本任务的工作区内容：
+  `scripts/entrypoint/local.sh`、`contributor-program/`、`reward_curve.png`、
+  `scripts/models/qwen3-0.6B.sh`。本任务不修改这些内容。
+
+### 2. 运行环境
+
+| 项目 | 实测值 |
+| --- | --- |
+| OS | Linux 5.15.0-139-generic x86_64，glibc 2.39 |
+| Python | 3.12.3 |
+| PyTorch | 2.11.0+cu129 |
+| CUDA toolkit | 12.9.86；容器 `CUDA_VERSION=12.9.1` |
+| NVIDIA driver | 580.126.09 |
+| Ray | 2.56.0 |
+| SGLang | 0.5.12.post1 |
+| math-verify | 0.8.0 |
+| GPU | 4 × NVIDIA RTX 6000 Ada Generation，49140 MiB/卡 |
+| CPU | 2 × Intel Xeon Platinum 8570，112 核/224 线程 |
+| 内存 | 881 GiB；采集时 available 839 GiB |
+
+本功能的本地验收只运行 CPU/Ray Actor 测试，没有启动模型训练或占用 GPU。
+
+### 3. 启动脚本与完整命令
+
+本任务没有修改训练脚本和 CLI 参数；现有 `--rm-type` 同时承担旧行为和 fallback：
+
+- 样本存在有效的格式提示时，逐样本路由；
+- 样本提示未知、缺失或冲突时，回退到显式 `--rm-type`；
+- 没有有效 fallback 时返回 `0.0` 并记录 warning；
+- 没有样本提示时，显式 `--rm-type` 保持原来的固定 scorer 行为。
+
+本地复现命令：
+
+```bash
+git switch feat/format-aware-reward-router
+git rev-parse HEAD
+pytest -q tests/engine/rewards/test_reward_worker.py
+pre-commit run --all-files
+```
+
+数据侧通过现有 metadata 字段声明格式，不需要新增启动参数：
+
+```json
+{"label": "42", "extra_info": {"format": "math"}}
+{"label": "<answer>A</answer>", "extra_info": {"format": "multiple-choice"}}
+```
+
+若需要容忍坏数据，可继续在原训练命令中配置 fallback，例如：
+
+```bash
+--rm-type openr1mm
+```
+
+未提交远端训练任务：当前请求没有提供 `RAY_ADDRESS`、`MODEL_DIR` 和指定训练脚本。按开发流程，不猜测集群配置，也不自行启动远端任务。获得这些信息后的提交形式为：
+
+```bash
+ray serve shutdown -y
+RAY_NO_WAIT=1 WORKING_DIR=./ RAY_ADDRESS=<ray-address> MODEL_DIR=<model-dir> \
+  bash -x scripts/entrypoint/ray-job.sh <scripts/training/.../run-script.sh>
+```
+
+### 4. 文件、核心函数、范围与非目标
+
+改动文件：
+
+- `relax/engine/rewards/__init__.py`
+  - `REWARD_REGISTRY` / `register_reward()`：统一注册同步与异步 scorer；
+  - `resolve_rm_type()`：处理 metadata、结构化 label、格式推断、冲突与 fallback；
+  - `RewardWorker.compute()`：由分支链改为 registry 查询；
+  - `RewardExecutor.execute()`：逐样本解析路由，并安全处理零分降级。
+- `tests/engine/rewards/test_reward_worker.py`
+  - 覆盖混合 batch、路由优先级、label 推断、fallback、warning、registry 扩展和旧 CLI 行为。
+- `docs/draft/format-aware-reward-router-experiment.md`
+  - 本实验记录。
+
+明确不做：
+
+- 不修改 `relax/utils/arguments.py`，不新增 CLI 参数；
+- 不修改 Controller、Service、Launcher；
+- 不新增依赖，不删除或重命名公开 API；
+- 不改变 custom reward、`boxed_`、远端 RM 和 GenRM 的调用方式；
+- 不运行需要多节点 GPU 的集成训练。
+
+### 5. 基线、指标与目标
+
+| 指标 | 基线 | 目标 | 当前结果 |
+| --- | ---: | ---: | ---: |
+| reward 测试 | 40 passed / 48.10 s | 相关测试全部通过 | 51 passed（最终结果见下） |
+| math + multiple-choice 混合 batch | 仅 metadata override 的弱覆盖 | 逐样本正确/错误结果均精确匹配 | `[1, 0, 1.0, 0.0]` |
+| 未知/缺失/冲突类型 | 抛异常并使 batch 失败 | fallback 或 0，且 warning | 已覆盖 |
+| registry 扩展 | worker 中修改 `if/elif` | 新 scorer 仅增加注册声明，不改路由 | 已覆盖 |
+| `--rm-type` 兼容 | 固定 scorer；metadata.rm_type 可覆盖 | 保留 | 已覆盖 |
+
+统计口径：pytest 用例数以 pytest 最终汇总为准；路由性能为同一进程连续
+3 个窗口，每窗口 100000 次 `resolve_rm_type()`，样本按 math 和
+multiple-choice 1:1 交替。
+
+## 设计与兼容性
+
+路由提示键为 `rm_type`、`reward_type`、`task_type`、`format`。
+`multiple-choice`、`multiple choice`、`mcq` 统一映射到
+`multiple_choice`。metadata 与结构化 label 中多个非空提示不一致时视为冲突。
+
+优先级：
+
+1. metadata/结构化 label 中一致、已注册的样本级提示；
+2. 未设置全局 `--rm-type` 时，对明确的字符串 label 格式进行保守推断；
+3. 现有 `args.rm_type` fallback；
+4. warning + `0.0`。
+
+为了保持兼容，显式设置 `--rm-type` 且样本没有格式提示时，不根据普通字符串
+label 改写 scorer。动态修改 driver 进程中的 registry 不保证传播到已经启动的
+Ray Actor；内置 reward 必须在模块导入时注册。
+
+## 实验结果
+
+### 正确性
+
+基线：
+
+```text
+40 passed in 48.10s
+```
+
+实现后首次完整运行发现并修复了 `ans_2` 被宽松数字正则误判为 math 的回归。
+修复后相关失败用例单独通过，完整 reward 测试通过。最终测试和 pre-commit
+结果应以交付前最后一次复跑记录为准。
+
+warning 测试不记录 prompt 或 label 内容，只验证未知、缺失和冲突路径确实发出
+warning。测试输出未出现未解释异常、NaN/Inf 或数据丢失。
+
+### 路由性能
+
+| 窗口 | 样本数 | 耗时 | 吞吐 | 平均延迟 |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 100000 | 0.144276 s | 693118.20 samples/s | 1.443 µs/sample |
+| 2 | 100000 | 0.139798 s | 715316.83 samples/s | 1.398 µs/sample |
+| 3 | 100000 | 0.141100 s | 708716.17 samples/s | 1.411 µs/sample |
+| 均值 | 100000 | 0.141725 s | 705717.07 samples/s | 1.417 µs/sample |
+
+该微基准只衡量 CPU 路由开销，不包含实际 reward 函数、Ray 调度或模型推理。
+GPU 利用率和峰值显存为 N/A（未执行 GPU 工作负载），不能据此推断训练吞吐。
+正确性护栏是同一提交下完整 reward 测试和 mixed-batch 精确结果。

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import random
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 
 import aiohttp
 import ray
@@ -23,6 +26,165 @@ from .openr1mm import get_openr1mm_rule_based_reward
 
 logger = get_logger(__name__)
 _shared_session: aiohttp.ClientSession | None = None
+
+
+@dataclass(frozen=True)
+class RewardHandler:
+    function: Callable
+    is_async: bool = False
+
+
+REWARD_REGISTRY: dict[str, RewardHandler] = {}
+
+
+def register_reward(name: str, *, is_async: bool = False):
+    """Register a reward implementation without changing router branches."""
+
+    def decorator(function: Callable) -> Callable:
+        if name in REWARD_REGISTRY:
+            raise ValueError(f"Reward type {name!r} is already registered")
+        REWARD_REGISTRY[name] = RewardHandler(function=function, is_async=is_async)
+        return function
+
+    return decorator
+
+
+@register_reward("deepscaler")
+def _deepscaler_reward(response, label, metadata):
+    return get_deepscaler_rule_based_reward(response, label)
+
+
+@register_reward("geo3k")
+def _geo3k_reward(response, label, metadata):
+    from .geo3k import get_geo3k_reward
+
+    return get_geo3k_reward(response, label)
+
+
+@register_reward("openr1mm")
+def _openr1mm_reward(response, label, metadata):
+    return get_openr1mm_rule_based_reward(response, label)
+
+
+@register_reward("multiple_choice")
+def _multiple_choice_reward(response, label, metadata):
+    return get_multiple_choice_reward(response, label)
+
+
+@register_reward("dapo")
+def _dapo_reward(response, label, metadata):
+    return compute_score_dapo(response, label)
+
+
+@register_reward("math")
+def _math_reward(response, label, metadata):
+    return 1 if grade_answer_verl(response, label) else 0
+
+
+@register_reward("mopd")
+def _mopd_reward(response, label, metadata):
+    from .mopd import get_mopd_reward
+
+    return get_mopd_reward(response, label, metadata)
+
+
+@register_reward("f1")
+def _f1_reward(response, label, metadata):
+    return f1_score(response, label)[0]
+
+
+@register_reward("gpqa")
+def _gpqa_reward(response, label, metadata):
+    return compute_gpqa_reward(response, label, metadata=metadata)
+
+
+@register_reward("ifbench")
+def _ifbench_reward(response, label, metadata):
+    from .ifbench import compute_ifbench_reward
+
+    return compute_ifbench_reward(response, label, metadata=metadata)
+
+
+@register_reward("random")
+def _random_reward(response, label, metadata):
+    return random.randint(0, 1)
+
+
+@register_reward("remote_rm", is_async=True)
+async def _remote_reward(args, sample):
+    return await remote_rm(args, sample)
+
+
+@register_reward("dapo-genrm", is_async=True)
+async def _dapo_genrm_reward(args, sample):
+    return await async_compute_score_genrm(args, sample)
+
+
+@register_reward("dummy", is_async=True)
+async def _registered_dummy_reward(args, sample):
+    return await _dummy_reward(args)
+
+
+_ROUTE_KEYS = ("rm_type", "reward_type", "task_type", "format")
+_ROUTE_ALIASES = {
+    "multiple-choice": "multiple_choice",
+    "multiple choice": "multiple_choice",
+    "mcq": "multiple_choice",
+}
+_MULTIPLE_CHOICE_LABEL = re.compile(r"^\s*(?:<answer>\s*)?([A-Za-z])(?:\s*</answer>)?\s*$", re.DOTALL)
+_NUMERIC_LABEL = re.compile(r"^\s*-?(?:\d+(?:\.\d*)?|\.\d+)\s*$")
+
+
+def _normalize_rm_type(value) -> str:
+    if not isinstance(value, str):
+        return ""
+    value = value.strip().lower()
+    return _ROUTE_ALIASES.get(value, value)
+
+
+def _routing_hints(value) -> set[str]:
+    if not isinstance(value, Mapping):
+        return set()
+    return {_normalize_rm_type(value.get(key)) for key in _ROUTE_KEYS if _normalize_rm_type(value.get(key))}
+
+
+def _infer_rm_type_from_label(label) -> str:
+    if isinstance(label, Mapping):
+        label = label.get("answer", label.get("label"))
+    if not isinstance(label, str):
+        return ""
+    if _MULTIPLE_CHOICE_LABEL.fullmatch(label):
+        return "multiple_choice"
+    if "\\boxed{" in label or "\\frac{" in label or "\\sqrt{" in label or _NUMERIC_LABEL.fullmatch(label):
+        return "math"
+    return ""
+
+
+def resolve_rm_type(args, sample: Sample) -> str | None:
+    """Resolve one sample's reward type, using ``args.rm_type`` as fallback."""
+    metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
+    hints = _routing_hints(metadata) | _routing_hints(sample.label)
+    fallback = _normalize_rm_type(getattr(args, "rm_type", None))
+
+    if len(hints) > 1:
+        logger.warning("Conflicting reward types %s; using fallback %r", sorted(hints), fallback or None)
+    elif len(hints) == 1:
+        candidate = next(iter(hints))
+        if candidate in REWARD_REGISTRY or candidate.startswith("boxed_"):
+            return candidate
+        logger.warning("Unknown sample reward type %r; using fallback %r", candidate, fallback or None)
+    elif not fallback:
+        inferred = _infer_rm_type_from_label(sample.label)
+        if inferred:
+            return inferred
+
+    if fallback in REWARD_REGISTRY or fallback.startswith("boxed_"):
+        return fallback
+    if fallback:
+        logger.warning("Unknown fallback reward type %r; returning zero reward", fallback)
+    else:
+        logger.warning("Reward type is missing and label format is unknown; returning zero reward")
+    return None
 
 
 def _get_shared_session() -> aiohttp.ClientSession:
@@ -63,36 +225,10 @@ class RewardWorker:
 
         Returns the same value the original function would return.
         """
-        if rm_type == "deepscaler":
-            return get_deepscaler_rule_based_reward(response, label)
-        elif rm_type == "geo3k":
-            from .geo3k import get_geo3k_reward
-
-            return get_geo3k_reward(response, label)
-        elif rm_type == "openr1mm":
-            return get_openr1mm_rule_based_reward(response, label)
-        elif rm_type == "multiple_choice":
-            return get_multiple_choice_reward(response, label)
-        elif rm_type == "dapo":
-            return compute_score_dapo(response, label)
-        elif rm_type == "math":
-            return 1 if grade_answer_verl(response, label) else 0
-        elif rm_type == "mopd":
-            from .mopd import get_mopd_reward
-
-            return get_mopd_reward(response, label, metadata)
-        elif rm_type == "f1":
-            return f1_score(response, label)[0]
-        elif rm_type == "gpqa":
-            return compute_gpqa_reward(response, label, metadata=metadata)
-        elif rm_type == "ifbench":
-            from .ifbench import compute_ifbench_reward
-
-            return compute_ifbench_reward(response, label, metadata=metadata)
-        elif rm_type == "random":
-            return random.randint(0, 1)
-        else:
+        handler = REWARD_REGISTRY.get(rm_type)
+        if handler is None or handler.is_async:
             raise NotImplementedError(f"RewardWorker: unknown rm_type={rm_type!r}")
+        return handler.function(response, label, metadata)
 
 
 # ---------------------------------------------------------------------------
@@ -149,33 +285,6 @@ class RewardExecutor:
 
     # -- public API -----------------------------------------------------------
 
-    # Async rm_types run in the event loop (not dispatched to worker pool).
-    _ASYNC_RM_DISPATCH = {
-        "remote_rm": lambda args, sample: remote_rm(args, sample),
-        "dapo-genrm": lambda args, sample: async_compute_score_genrm(args, sample),
-        # `dummy` returns 0 without any computation. Use it when the real
-        # reward is produced elsewhere (e.g., --custom-reward-post-process-path
-        # does batched GenRM scoring after all rollout finishes).
-        "dummy": lambda args, sample: _dummy_reward(args),
-    }
-
-    # CPU-bound / thread-unsafe rm_types dispatched to the Ray worker pool.
-    _SYNC_RM_TYPES = frozenset(
-        {
-            "deepscaler",
-            "geo3k",
-            "openr1mm",
-            "multiple_choice",
-            "dapo",
-            "math",
-            "mopd",
-            "f1",
-            "gpqa",
-            "ifbench",
-            "random",
-        }
-    )
-
     async def execute(self, args, sample: Sample, **kwargs):
         """Execute a single reward computation with concurrency control.
 
@@ -193,7 +302,9 @@ class RewardExecutor:
                 return await rm_function(args, sample, **kwargs)
 
             metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
-            rm_type = (metadata.get("rm_type") or args.rm_type or "").strip()
+            rm_type = resolve_rm_type(args, sample)
+            if rm_type is None:
+                return 0.0
             response = sample.response
             label = sample.label
             if rm_type.startswith("boxed_"):
@@ -201,20 +312,20 @@ class RewardExecutor:
                 rm_type = rm_type[len("boxed_") :]
 
             # --- async rm types: run in event loop -----------------------
-            async_handler = self._ASYNC_RM_DISPATCH.get(rm_type)
-            if async_handler is not None:
-                return await async_handler(args, sample)
+            handler = REWARD_REGISTRY.get(rm_type)
+            if handler is not None and handler.is_async:
+                return await handler.function(args, sample)
 
             # --- sync rm types: dispatch to worker pool ------------------
             # Default to sync path for any non-empty rm_type not in async dispatch
-            if rm_type:
+            if handler is not None:
                 self._ensure_workers()
                 worker = self._next_worker()
                 ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
                 return await ref
 
-            # --- no rm_type specified -----------------------------------------
-            raise NotImplementedError("Rule-based RM type is not specified.")
+            logger.warning("Unknown resolved reward type %r; returning zero reward", rm_type)
+            return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/rewards/test_reward_worker.py
+++ b/tests/engine/rewards/test_reward_worker.py
@@ -15,6 +15,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -42,10 +43,13 @@ try:
                 raise
 
     from relax.engine.rewards import (
+        REWARD_REGISTRY,
         RewardExecutor,
         RewardWorker,
         async_rm,
         batched_async_rm,
+        register_reward,
+        resolve_rm_type,
     )
     from relax.engine.rewards.openr1mm import get_openr1mm_rule_based_reward
     from relax.utils.types import Sample
@@ -310,11 +314,79 @@ class TestRewardExecutorSingleSample:
         assert result == 1.0
 
     @pytest.mark.asyncio
-    async def test_execute_unknown_rm_type_raises(self):
+    async def test_execute_unknown_rm_type_returns_zero_with_warning(self):
         args = _make_args(rm_type="totally_unknown_type")
         sample = _make_sample(response="foo", label="bar")
-        with pytest.raises(NotImplementedError, match="totally_unknown_type"):
-            await async_rm(args, sample)
+        with patch("relax.engine.rewards.logger.warning") as warning:
+            assert await async_rm(args, sample) == 0.0
+        warning.assert_called_once()
+
+
+@requires_full_pipeline
+class TestFormatAwareRewardRouter:
+    def test_metadata_route_overrides_legacy_fallback(self):
+        args = _make_args(rm_type="openr1mm")
+        sample = _make_sample("", "42", {"rm_type": "math"})
+        assert resolve_rm_type(args, sample) == "math"
+
+    def test_explicit_rm_type_keeps_legacy_behavior_without_sample_hint(self):
+        args = _make_args(rm_type="openr1mm")
+        assert resolve_rm_type(args, _make_sample("", "42")) == "openr1mm"
+
+    def test_label_mapping_route(self):
+        args = _make_args(rm_type="math")
+        sample = _make_sample("", {"answer": "A", "format": "multiple-choice"})
+        assert resolve_rm_type(args, sample) == "multiple_choice"
+
+    def test_label_format_inference(self):
+        args = _make_args(rm_type=None)
+        assert resolve_rm_type(args, _make_sample("", "<answer>B</answer>")) == "multiple_choice"
+        assert resolve_rm_type(args, _make_sample("", "\\boxed{12}")) == "math"
+
+    def test_unknown_route_uses_configured_fallback_and_warns(self):
+        args = _make_args(rm_type="openr1mm")
+        sample = _make_sample("", "not-formatted", {"rm_type": "unknown"})
+        with patch("relax.engine.rewards.logger.warning") as warning:
+            assert resolve_rm_type(args, sample) == "openr1mm"
+        warning.assert_called_once()
+
+    def test_conflict_uses_configured_fallback_and_warns(self):
+        args = _make_args(rm_type="openr1mm")
+        sample = _make_sample("", {"answer": "A", "rm_type": "multiple_choice"}, {"rm_type": "math"})
+        with patch("relax.engine.rewards.logger.warning") as warning:
+            assert resolve_rm_type(args, sample) == "openr1mm"
+        warning.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("args", "sample"),
+        [
+            (_make_args(rm_type=None), _make_sample("", "not-formatted")),
+            (_make_args(rm_type=None), _make_sample("", "not-formatted", {"rm_type": "unknown"})),
+            (_make_args(rm_type="unknown"), _make_sample("", "not-formatted")),
+        ],
+    )
+    def test_missing_or_unknown_without_valid_fallback_returns_none_and_warns(self, args, sample):
+        with patch("relax.engine.rewards.logger.warning") as warning:
+            assert resolve_rm_type(args, sample) is None
+        warning.assert_called()
+
+    def test_registry_contains_sync_and_async_rewards(self):
+        assert REWARD_REGISTRY["math"].is_async is False
+        assert REWARD_REGISTRY["multiple_choice"].is_async is False
+        assert REWARD_REGISTRY["remote_rm"].is_async is True
+
+    def test_registry_extension_requires_no_router_change(self):
+        name = "test_one_line_reward"
+        try:
+
+            @register_reward(name)
+            def reward(response, label, metadata):
+                return 0.25
+
+            assert resolve_rm_type(_make_args(rm_type=name), _make_sample("", "not-formatted")) == name
+            assert REWARD_REGISTRY[name].function("", "", {}) == 0.25
+        finally:
+            REWARD_REGISTRY.pop(name, None)
 
 
 @requires_full_pipeline
@@ -433,15 +505,20 @@ class TestHighConcurrency:
     @pytest.mark.asyncio
     async def test_concurrent_mixed_rm_types_via_metadata(self):
         """Different rm_types in the same batch should all route correctly."""
-        args = _make_args(rm_type="openr1mm")
+        args = _make_args(rm_type=None)
         samples = [
-            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="A", label="A", metadata={"rm_type": "multiple_choice"}),
+            _make_sample(response="\\boxed{42}", label="42", metadata={"format": "math"}),
+            _make_sample(response="\\boxed{41}", label="42", metadata={"format": "math"}),
+            _make_sample(
+                response="<answer>A</answer>",
+                label="<answer>A</answer>",
+                metadata={"format": "multiple-choice"},
+            ),
+            _make_sample(
+                response="<answer>B</answer>",
+                label="<answer>A</answer>",
+                metadata={"format": "multiple-choice"},
+            ),
         ]
         rewards = await asyncio.wait_for(
             batched_async_rm(args, samples),
@@ -449,8 +526,7 @@ class TestHighConcurrency:
         )
         rewards = list(rewards)
         assert len(rewards) == len(samples)
-        # All three should be correct (1.0)
-        assert all(r == 1.0 for r in rewards), f"Got {rewards}"
+        assert rewards == [1, 0, 1.0, 0.0]
 
     @pytest.mark.asyncio
     async def test_concurrent_repeated_identical_requests(self):


### PR DESCRIPTION
  #### Summary

  - Closes #104 
  - 解决了什么问题：
    - 支持同一 batch 内的 math、multiple-choice 等混合任务逐样本选择 reward。
    - 未知、缺失或冲突类型不再导致整个 batch 失败，而是使用配置的 fallback 或返回零分并记录 warning。
    - 消除同步 reward 的硬编码分支链。
  - 为什么采用该方案：
    - 复用现有 `--rm-type` 作为 fallback，不新增 CLI 参数。
    - 保留当前 `metadata.rm_type` 覆盖全局类型的兼容语义。
    - 通过统一 registry 隔离路由和 reward 实现，新增 reward 不需要修改路由分支。
    - 对普通字符串 label 采用保守推断，避免显式 `--rm-type` 训练任务发生行为变化。

  #### Changes

  - 文件 / 核心函数 / 行为变化：
    - `relax/engine/rewards/__init__.py`
      - 新增 `REWARD_REGISTRY` 和 `register_reward()`。
      - 新增 `resolve_rm_type()`，处理 metadata、结构化 label、格式推断、冲突和 fallback。
      - `RewardWorker.compute()` 从 `if/elif` 改为 registry 查询。
      - `RewardExecutor.execute()` 支持逐样本路由及 warning + zero fallback。
    - `tests/engine/rewards/test_reward_worker.py`
      - 新增路由、fallback、warning、registry、兼容性和 mixed-batch 测试。
    - `docs/draft/format-aware-reward-router-experiment.md`
      - 增加可复现实验记录、环境、命令和原始结果。
  - CLI、配置或兼容性变化：
    - 没有新增或修改 CLI 参数。
    - 显式 `--rm-type` 在没有样本格式提示时保持原行为。
    - metadata 或结构化 label 中的样本级格式提示可以覆盖全局类型。
    - 未知、缺失或冲突提示使用 `--rm-type` fallback；无有效 fallback 时返回 `0.0` 并记录 warning。
    - `multiple-choice`、`multiple choice` 和 `mcq` 归一化为 `multiple_choice`。
    - 没有修改训练脚本、配置默认值或公开 API。

  #### Verification

  - 环境、硬件、commit：
    - Baseline commit: `30f219a1c963137129570dd5485a9c3d82390548`
    - Implementation commit: `e7eab2edbc406b5efcf1693de6f086958dcfbfcd`
    - Python: 3.12.3
    - PyTorch: 2.11.0+cu129
    - CUDA toolkit: 12.9.86
    - Ray: 2.56.0
    - SGLang: 0.5.12.post1
    - GPU: 4 × NVIDIA RTX 6000 Ada Generation
    - CPU: 2 × Intel Xeon Platinum 8570
    - Memory: 881 GiB
  - 可复制命令：

  ```bash
  git checkout e7eab2edbc406b5efcf1693de6f086958dcfbfcd
  pytest -q tests/engine/rewards
  pre-commit run --all-files
  git diff --check HEAD^ HEAD
  ```

  - 单元/集成/端到端测试结果：
    - Baseline: `40 passed in 48.10s`
    - Current: `51 passed in 42.86s`
    - Mixed-batch result: `[1, 0, 1.0, 0.0]`
    - `pre-commit run --all-files`: all hooks passed
    - `git diff --check HEAD^ HEAD`: passed
    - 未运行模型训练端到端测试：Issue 的功能验收标准要求 reward 路由和针对性测试，不要求启动训练集群。
  - 性能 before/after（若适用）：
    - 本任务不是性能优化题。
    - CPU router microbenchmark，100,000 samples/window：
      - Run 1: 693118.20 samples/s, 1.443 µs/sample
      - Run 2: 715316.83 samples/s, 1.398 µs/sample
      - Run 3: 708716.17 samples/s, 1.411 µs/sample
      - Mean: 705717.07 samples/s, 1.417 µs/sample
    - 该结果只衡量 `resolve_rm_type()`，不包含 reward 计算、Ray 调度或模型推理。
    - GPU utilization / peak memory: N/A，本验证没有执行 GPU workload。
  - 日志、曲线、profile 链接：
    - 实验报告：`docs/draft/format-aware-reward-router-experiment.md`
    - CI 链接：PR 创建并运行 CI 后补充。
    - 本任务没有生成训练曲线或 GPU profile。

  #### Risk & Rollback

  - 已知限制：
    - 动态修改 driver 进程中的 registry 不保证传播到已经启动的 Ray Actor；内置 reward 必须在模块导入时注册。
    - 普通字符串 label 只在没有显式 `--rm-type` 时进行保守格式推断。
    - 不明确的文本 label 不会被强制分类。
  - 风险：
    - metadata 与结构化 label 中的格式提示可能冲突；冲突时会记录 warning 并使用 fallback。
    - 未配置有效 fallback 时，未知或缺失类型返回 `0.0`。虽然不会中断 batch，但需要通过 warning 监控数据质量。
    - 数据集如果误用了 `format`、`task_type` 等字段，可能选择非预期 scorer。
  - 关闭开关或回退方式：
    - 不提供样本级格式提示，并继续显式设置 `--rm-type`，即可保持原来的固定 scorer 行为。
    - 如需完全撤销代码改动，可执行：

  ```bash
  git revert e7eab2edbc406b5efcf1693de6f086958dcfbfcd
  ```

  #### Checklist

  - [x] Diff 仅包含本任务必要改动
  - [x] 新增/相关测试全部通过
  - [x] 文档已更新；本任务无需修改训练脚本或默认值
  - [x] 不含密钥、数据集、checkpoint 或机器隐私信息
  - [ ] 已逐条回复 review commen