### PR TITLE
feat(rollout): scope concurrency permits to requests

### DIFF
--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -172,6 +172,16 @@ Specify via launch script (`--custom-generate-function-path examples.deepeyes.ro
 
 Acquire `state.request_permit()` only around each model request. Release it before running environment or tool code so a long multi-turn session does not block unrelated short requests. The context manager releases the permit when the request succeeds, raises, or is cancelled.
 
+Custom generate functions must adopt this interface after upgrading. A custom implementation that sends requests without `state.request_permit()` is not covered by `--sglang-server-concurrency`. The built-in rollout checks the abort state again after waiting for a permit, so it does not submit a new request after a rollout abort. Rollout timing reports permit queueing separately as `request_permit_wait`; `generate` continues to measure the model request itself.
+
+The CPU async scheduling benchmark uses the same synthetic model and environment durations for the former session-level policy and the request-level policy:
+
+```bash
+PYTHONPATH=. python scripts/benchmarks/benchmark_request_permit.py --warmups 1 --runs 9
+```
+
+This benchmark validates scheduling behavior and the concurrency bound. It does not measure model throughput.
+
 ## Training Script and Key Parameters
 
 For complete parameter reference, see [Configuration](./configuration.md).

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -151,7 +151,8 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     prompt_ids = state.tokenizer.encode(sample.prompt, add_special_tokens=False)
     sample.tokens, sample.loss_mask, sample.rollout_log_probs, response_tokens = list(prompt_ids), [], [], []
     for turn in range(args.max_turns):
-        output = await post(url, {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True})
+        async with state.request_permit():
+            output = await post(url, {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True})
         new_tokens = [t[1] for t in output["meta_info"]["output_token_logprobs"]]
         new_probs = [t[0] for t in output["meta_info"]["output_token_logprobs"]]
         sample.tokens.extend(new_tokens); response_tokens.extend(new_tokens)                 # model output
@@ -168,6 +169,8 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
 ```
 
 Specify via launch script (`--custom-generate-function-path examples.deepeyes.rollout.generate`), or per eval dataset via `custom_generate_function_path` in eval config.
+
+Acquire `state.request_permit()` only around each model request. Release it before running environment or tool code so a long multi-turn session does not block unrelated short requests. The context manager releases the permit when the request succeeds, raises, or is cancelled.
 
 ## Training Script and Key Parameters
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -150,7 +150,8 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     prompt_ids = state.tokenizer.encode(sample.prompt, add_special_tokens=False)
     sample.tokens, sample.loss_mask, sample.rollout_log_probs, response_tokens = list(prompt_ids), [], [], []
     for turn in range(args.max_turns):
-        output = await post(url, {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True})
+        async with state.request_permit():
+            output = await post(url, {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True})
         new_tokens = [t[1] for t in output["meta_info"]["output_token_logprobs"]]
         new_probs = [t[0] for t in output["meta_info"]["output_token_logprobs"]]
         sample.tokens.extend(new_tokens); response_tokens.extend(new_tokens)                 # 模型输出
@@ -167,6 +168,8 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
 ```
 
 通过启动脚本指定（`--custom-generate-function-path examples.deepeyes.rollout.generate`），或在评估数据集配置中通过 `custom_generate_function_path` 按数据集设置。
+
+仅在每次模型请求期间获取 `state.request_permit()`，进入环境或工具执行前必须释放。这样长多轮会话不会阻塞无关的短请求；请求正常返回、抛出异常或被取消时，上下文管理器都会释放 permit。
 
 ## 训练脚本与关键参数概览
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -171,6 +171,16 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
 
 仅在每次模型请求期间获取 `state.request_permit()`，进入环境或工具执行前必须释放。这样长多轮会话不会阻塞无关的短请求；请求正常返回、抛出异常或被取消时，上下文管理器都会释放 permit。
 
+升级后，自定义 generate 函数必须接入这个接口。未通过 `state.request_permit()` 发送请求的自定义实现不受 `--sglang-server-concurrency` 限制。内置 rollout 在等待 permit 后会再次检查 abort 状态，避免 rollout 已中止后又提交新请求。计时指标会把 permit 排队时间单独记录为 `request_permit_wait`，`generate` 继续只表示模型请求耗时。
+
+CPU 异步调度基准会让旧的会话级策略和新的请求级策略执行相同的模拟模型请求与环境耗时：
+
+```bash
+PYTHONPATH=. python scripts/benchmarks/benchmark_request_permit.py --warmups 1 --runs 9
+```
+
+该基准只验证调度行为和并发上限，不代表模型吞吐。
+
 ## 训练脚本与关键参数概览
 
 完整的参数可参照 [配置说明](./configuration.md)。

--- a/examples/deepeyes/rollout.py
+++ b/examples/deepeyes/rollout.py
@@ -14,6 +14,7 @@ import pybase64
 import torch
 
 from examples.deepeyes.base_env import BaseInteractionEnv
+from relax.engine.rollout.request_permit import run_request_with_permit
 from relax.engine.rollout.sglang_rollout import GenerateState
 from relax.utils.data.processing_utils import _ENCODE_EXECUTOR, encode_image_for_rollout_engine
 from relax.utils.http_utils import post
@@ -237,8 +238,12 @@ async def _run_inference_step(url: str, tokens: list[int], sampling_params: dict
 
 
 async def _run_inference_step_with_permit(state, *args, **kwargs):
-    async with state.request_permit():
-        return await _run_inference_step(*args, **kwargs)
+    result = await run_request_with_permit(
+        state.request_permit,
+        lambda: _run_inference_step(*args, **kwargs),
+        should_abort=lambda: getattr(state, "aborted", False),
+    )
+    return result.value
 
 
 async def _process_env_step(env: BaseInteractionEnv, response_text: str, tokenizer, processor, args, sample_metadata):
@@ -474,13 +479,7 @@ async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
             )
 
             inference_start_ts = time.time()
-            (
-                response_text,
-                new_response_tokens,
-                new_response_log_probs,
-                finish_type,
-                meta_info,
-            ) = await _run_inference_step_with_permit(
+            inference_result = await _run_inference_step_with_permit(
                 state,
                 url,
                 sample.tokens,
@@ -489,6 +488,18 @@ async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
                 state.tokenizer,
                 args=args,
             )
+            if inference_result is None:
+                sample.status = Sample.Status.ABORTED
+                stop_reason = "request_abort"
+                turns_executed = turn_idx
+                break
+            (
+                response_text,
+                new_response_tokens,
+                new_response_log_probs,
+                finish_type,
+                meta_info,
+            ) = inference_result
             inference_end_ts = time.time()
             trace_recorder.record_inference_output(
                 response_text, finish_type, max(0.0, inference_end_ts - inference_start_ts)

--- a/examples/deepeyes/rollout.py
+++ b/examples/deepeyes/rollout.py
@@ -237,7 +237,7 @@ async def _run_inference_step(url: str, tokens: list[int], sampling_params: dict
 
 
 async def _run_inference_step_with_permit(state, *args, **kwargs):
-    async with state.request_permits.acquire():
+    async with state.request_permit():
         return await _run_inference_step(*args, **kwargs)
 
 

--- a/examples/deepeyes/rollout.py
+++ b/examples/deepeyes/rollout.py
@@ -236,6 +236,11 @@ async def _run_inference_step(url: str, tokens: list[int], sampling_params: dict
     return response_text, new_tokens, new_log_probs, finish_type, meta_info
 
 
+async def _run_inference_step_with_permit(state, *args, **kwargs):
+    async with state.request_permits.acquire():
+        return await _run_inference_step(*args, **kwargs)
+
+
 async def _process_env_step(env: BaseInteractionEnv, response_text: str, tokenizer, processor, args, sample_metadata):
     result = env.step(response_text)
     # 兼容 async env.step（如 VideoSearchEnv）：若返回 coroutine 则 await
@@ -475,8 +480,14 @@ async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
                 new_response_log_probs,
                 finish_type,
                 meta_info,
-            ) = await _run_inference_step(
-                url, sample.tokens, cur_sampling_params, current_image_data, state.tokenizer, args=args
+            ) = await _run_inference_step_with_permit(
+                state,
+                url,
+                sample.tokens,
+                cur_sampling_params,
+                current_image_data,
+                state.tokenizer,
+                args=args,
             )
             inference_end_ts = time.time()
             trace_recorder.record_inference_output(

--- a/relax/engine/rollout/request_permit.py
+++ b/relax/engine/rollout/request_permit.py
@@ -1,8 +1,22 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from dataclasses import dataclass
+from time import monotonic
+from typing import AsyncContextManager, AsyncIterator, Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RequestExecution(Generic[T]):
+    value: T | None
+    aborted: bool
+    permit_wait_seconds: float
+    request_seconds: float
 
 
 class RequestPermitPool:
@@ -17,3 +31,33 @@ class RequestPermitPool:
     async def acquire(self) -> AsyncIterator[None]:
         async with self._semaphore:
             yield
+
+
+async def run_request_with_permit(
+    permit: Callable[[], AsyncContextManager[None]],
+    request: Callable[[], Awaitable[T]],
+    *,
+    should_abort: Callable[[], bool] | None = None,
+) -> RequestExecution[T]:
+    """Run one model request after admission and a post-wait abort check."""
+    wait_started = monotonic()
+    async with permit():
+        wait_finished = monotonic()
+        if should_abort is not None and should_abort():
+            return RequestExecution(
+                value=None,
+                aborted=True,
+                permit_wait_seconds=wait_finished - wait_started,
+                request_seconds=0.0,
+            )
+
+        request_started = monotonic()
+        value = await request()
+        request_finished = monotonic()
+
+    return RequestExecution(
+        value=value,
+        aborted=False,
+        permit_wait_seconds=wait_finished - wait_started,
+        request_seconds=request_finished - request_started,
+    )

--- a/relax/engine/rollout/request_permit.py
+++ b/relax/engine/rollout/request_permit.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+
+class RequestPermitPool:
+    """Limit only in-flight model requests, not whole rollout sessions."""
+
+    def __init__(self, limit: int) -> None:
+        if limit <= 0:
+            raise ValueError(f"request permit limit must be positive, got {limit}")
+        self._semaphore = asyncio.Semaphore(limit)
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[None]:
+        async with self._semaphore:
+            yield

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -23,7 +23,7 @@ from relax.engine.filters.base_types import MetricGatherer, call_dynamic_filter
 from relax.engine.rewards import async_rm, batched_async_rm
 from relax.engine.rollout import on_policy_distillation as opd
 from relax.engine.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
-from relax.engine.rollout.request_permit import RequestPermitPool
+from relax.engine.rollout.request_permit import RequestPermitPool, run_request_with_permit
 from relax.utils.async_utils import run
 from relax.utils.data.data import Dataset
 from relax.utils.data.processing_utils import (
@@ -338,10 +338,21 @@ async def generate(
         # prefix is prefilled once and reused across the group.
         headers = {"X-SMG-Routing-Key": str(sample.group_index)}
 
-    _t_generate_start = monotonic()
-    async with state.request_permit():
-        output = await post(url, payload, headers=headers)
-    _t_generate = monotonic() - _t_generate_start
+    request_execution = await run_request_with_permit(
+        state.request_permit,
+        lambda: post(url, payload, headers=headers),
+        should_abort=lambda: state.aborted and not evaluation,
+    )
+    if request_execution.aborted:
+        sample.status = Sample.Status.ABORTED
+        sample.metadata["_timing"] = {
+            "request_permit_wait": request_execution.permit_wait_seconds,
+            "generate": 0.0,
+        }
+        return sample
+    output = request_execution.value
+    assert output is not None
+    _t_generate = request_execution.request_seconds
 
     _t_post_generate_start = monotonic()
     if args.use_slime_router and "RadixTreeMiddleware" in args.slime_router_middleware_paths:
@@ -430,7 +441,11 @@ async def generate(
     sample.update_from_meta_info(args, output["meta_info"])
     _t_post_generate = monotonic() - _t_post_generate_start
 
-    _timing: dict[str, float] = {"generate": _t_generate, "post_generate": _t_post_generate}
+    _timing: dict[str, float] = {
+        "request_permit_wait": request_execution.permit_wait_seconds,
+        "generate": _t_generate,
+        "post_generate": _t_post_generate,
+    }
     if _t_image_processor is not None:
         _timing["image_processor"] = _t_image_processor
     if _t_mm_encode is not None:
@@ -528,7 +543,7 @@ def _aggregate_rollout_timing(all_samples: list[Sample], get_samples_times: list
     timing_data = _collect_timing_from_samples(all_samples)
     metrics: dict[str, float] = {}
 
-    for phase in ("image_processor", "mm_encode", "generate", "post_generate"):
+    for phase in ("image_processor", "mm_encode", "request_permit_wait", "generate", "post_generate"):
         values = timing_data.get(phase, [])
         if not values:
             continue

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -23,6 +23,7 @@ from relax.engine.filters.base_types import MetricGatherer, call_dynamic_filter
 from relax.engine.rewards import async_rm, batched_async_rm
 from relax.engine.rollout import on_policy_distillation as opd
 from relax.engine.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
+from relax.engine.rollout.request_permit import RequestPermitPool
 from relax.utils.async_utils import run
 from relax.utils.data.data import Dataset
 from relax.utils.data.processing_utils import (
@@ -77,7 +78,7 @@ class GenerateState(metaclass=SingletonMeta):
                 except Exception as e:
                     logger.warning(f"Failed to create ProcessorPool, falling back to ThreadPoolExecutor: {e}")
 
-        self.semaphore = asyncio.Semaphore(
+        self.request_permits = RequestPermitPool(
             args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
         )
         self.sampling_params: dict[str, Any] = dict(
@@ -334,7 +335,8 @@ async def generate(
         headers = {"X-SMG-Routing-Key": str(sample.group_index)}
 
     _t_generate_start = monotonic()
-    output = await post(url, payload, headers=headers)
+    async with state.request_permits.acquire():
+        output = await post(url, payload, headers=headers)
     _t_generate = monotonic() - _t_generate_start
 
     _t_post_generate_start = monotonic()
@@ -454,24 +456,23 @@ async def generate_and_rm(
     state = GenerateState(args)
 
     # generate
-    async with state.semaphore:
-        if state.aborted:
-            sample.status = Sample.Status.ABORTED
-            return sample
+    if state.aborted:
+        sample.status = Sample.Status.ABORTED
+        return sample
 
-        with state.dp_rank_context() as _:
-            # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
-            custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
+    with state.dp_rank_context() as _:
+        # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
+        custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
 
-            if custom_func_path is not None:
-                custom_generate_func = load_function(custom_func_path)
-                # if signature has evaluation, pass evaluation
-                if "evaluation" in inspect.signature(custom_generate_func).parameters:
-                    sample = await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
-                else:
-                    sample = await custom_generate_func(args, sample, sampling_params)
+        if custom_func_path is not None:
+            custom_generate_func = load_function(custom_func_path)
+            # if signature has evaluation, pass evaluation
+            if "evaluation" in inspect.signature(custom_generate_func).parameters:
+                sample = await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
             else:
-                sample = await generate(args, sample, sampling_params, evaluation=evaluation)
+                sample = await custom_generate_func(args, sample, sampling_params)
+        else:
+            sample = await generate(args, sample, sampling_params, evaluation=evaluation)
 
     # for the rm that need the whole group, we will not do the rm here
     if args.group_rm:

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -6,7 +6,7 @@ import inspect
 import uuid
 from argparse import Namespace
 from collections.abc import Callable
-from contextlib import contextmanager
+from contextlib import AbstractAsyncContextManager, contextmanager
 from time import monotonic
 from typing import Any
 
@@ -103,7 +103,7 @@ class GenerateState(metaclass=SingletonMeta):
 
         self.reset()
 
-    def request_permit(self):
+    def request_permit(self) -> AbstractAsyncContextManager[None]:
         """Return an async context manager for one model request."""
         return self.request_permits.acquire()
 

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -103,6 +103,10 @@ class GenerateState(metaclass=SingletonMeta):
 
         self.reset()
 
+    def request_permit(self):
+        """Return an async context manager for one model request."""
+        return self.request_permits.acquire()
+
     @contextmanager
     def dp_rank_context(self):
         candidates = [i for i, count in enumerate(self.dp_counts) if count == min(self.dp_counts)]
@@ -335,7 +339,7 @@ async def generate(
         headers = {"X-SMG-Routing-Key": str(sample.group_index)}
 
     _t_generate_start = monotonic()
-    async with state.request_permits.acquire():
+    async with state.request_permit():
         output = await post(url, payload, headers=headers)
     _t_generate = monotonic() - _t_generate_start
 

--- a/scripts/benchmarks/benchmark_request_permit.py
+++ b/scripts/benchmarks/benchmark_request_permit.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""CPU async benchmark for session-level versus request-level permits."""
+
+import argparse
+import asyncio
+import json
+import statistics
+from dataclasses import asdict, dataclass
+from time import perf_counter
+
+from relax.engine.rollout.request_permit import RequestPermitPool
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    mode: str
+    total_seconds: float
+    short_request_seconds: float
+    peak_model_requests: int
+    completion_order: tuple[str, ...]
+
+
+async def _run_scenario(
+    mode: str,
+    *,
+    turns: int,
+    model_seconds: float,
+    environment_seconds: float,
+) -> ScenarioResult:
+    permits = RequestPermitPool(1)
+    first_model_completed = asyncio.Event()
+    active_model_requests = 0
+    peak_model_requests = 0
+    completion_order: list[str] = []
+    short_request_seconds = 0.0
+
+    async def model_request() -> None:
+        nonlocal active_model_requests, peak_model_requests
+        active_model_requests += 1
+        peak_model_requests = max(peak_model_requests, active_model_requests)
+        try:
+            await asyncio.sleep(model_seconds)
+        finally:
+            active_model_requests -= 1
+
+    async def long_session() -> None:
+        if mode == "session-level":
+            async with permits.acquire():
+                for turn in range(turns):
+                    await model_request()
+                    if turn == 0:
+                        first_model_completed.set()
+                    await asyncio.sleep(environment_seconds)
+        else:
+            for turn in range(turns):
+                async with permits.acquire():
+                    await model_request()
+                if turn == 0:
+                    first_model_completed.set()
+                await asyncio.sleep(environment_seconds)
+        completion_order.append("long")
+
+    async def short_session() -> None:
+        nonlocal short_request_seconds
+        await first_model_completed.wait()
+        started = perf_counter()
+        async with permits.acquire():
+            await model_request()
+        short_request_seconds = perf_counter() - started
+        completion_order.append("short")
+
+    started = perf_counter()
+    await asyncio.gather(long_session(), short_session())
+    return ScenarioResult(
+        mode=mode,
+        total_seconds=perf_counter() - started,
+        short_request_seconds=short_request_seconds,
+        peak_model_requests=peak_model_requests,
+        completion_order=tuple(completion_order),
+    )
+
+
+async def _benchmark(args: argparse.Namespace) -> dict:
+    modes = ("session-level", "request-level")
+    for _ in range(args.warmups):
+        for mode in modes:
+            await _run_scenario(
+                mode,
+                turns=args.turns,
+                model_seconds=args.model_ms / 1000,
+                environment_seconds=args.environment_ms / 1000,
+            )
+
+    results: dict[str, list[ScenarioResult]] = {mode: [] for mode in modes}
+    for run_idx in range(args.runs):
+        run_modes = modes if run_idx % 2 == 0 else tuple(reversed(modes))
+        for mode in run_modes:
+            results[mode].append(
+                await _run_scenario(
+                    mode,
+                    turns=args.turns,
+                    model_seconds=args.model_ms / 1000,
+                    environment_seconds=args.environment_ms / 1000,
+                )
+            )
+
+    expected_orders = {
+        "session-level": ("long", "short"),
+        "request-level": ("short", "long"),
+    }
+    for mode, runs in results.items():
+        if any(run.peak_model_requests != 1 for run in runs):
+            raise RuntimeError(f"{mode} exceeded the configured model-request concurrency limit")
+        if any(run.completion_order != expected_orders[mode] for run in runs):
+            raise RuntimeError(f"{mode} produced an unexpected completion order")
+
+    summary = {
+        "configuration": {
+            "permit_limit": 1,
+            "turns": args.turns,
+            "model_ms": args.model_ms,
+            "environment_ms": args.environment_ms,
+            "warmups": args.warmups,
+            "runs": args.runs,
+        },
+        "results": {},
+    }
+    for mode, runs in results.items():
+        summary["results"][mode] = {
+            "median_total_ms": statistics.median(run.total_seconds for run in runs) * 1000,
+            "median_short_request_ms": statistics.median(run.short_request_seconds for run in runs) * 1000,
+            "peak_model_requests": max(run.peak_model_requests for run in runs),
+            "completion_orders": [list(run.completion_order) for run in runs],
+            "samples": [asdict(run) for run in runs],
+        }
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=9)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--turns", type=int, default=3)
+    parser.add_argument("--model-ms", type=float, default=20.0)
+    parser.add_argument("--environment-ms", type=float, default=100.0)
+    parser.add_argument("--json", action="store_true", help="Print the complete machine-readable result.")
+    args = parser.parse_args()
+    if args.runs <= 0 or args.warmups < 0 or args.turns <= 0 or args.model_ms < 0 or args.environment_ms < 0:
+        parser.error("runs and turns must be positive; warmups and durations must be non-negative")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    summary = asyncio.run(_benchmark(args))
+    if args.json:
+        print(json.dumps(summary, indent=2))
+        return
+
+    print("mode\tmedian total (ms)\tmedian short request (ms)\tpeak model requests")
+    for mode in ("session-level", "request-level"):
+        result = summary["results"][mode]
+        print(
+            f"{mode}\t{result['median_total_ms']:.2f}\t"
+            f"{result['median_short_request_ms']:.2f}\t{result['peak_model_requests']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/engine/rollout/test_deepeyes_request_permit.py
+++ b/tests/engine/rollout/test_deepeyes_request_permit.py
@@ -1,21 +1,35 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
+import asyncio
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
 
 from examples.deepeyes import rollout
-from relax.engine.rollout.request_permit import RequestPermitPool
+
+
+class _PermitProbe:
+    def __init__(self) -> None:
+        self.held = False
+
+    @asynccontextmanager
+    async def acquire(self):
+        self.held = True
+        try:
+            yield
+        finally:
+            self.held = False
 
 
 @pytest.mark.asyncio
 async def test_deepeyes_inference_holds_request_permit(monkeypatch):
-    permits = RequestPermitPool(1)
-    state = SimpleNamespace(request_permit=permits.acquire)
+    probe = _PermitProbe()
+    state = SimpleNamespace(request_permit=probe.acquire)
 
     async def fake_inference(*args, **kwargs):
         del args, kwargs
-        assert permits._semaphore.locked()
+        assert probe.held
         return "response"
 
     monkeypatch.setattr(rollout, "_run_inference_step", fake_inference)
@@ -23,14 +37,13 @@ async def test_deepeyes_inference_holds_request_permit(monkeypatch):
     result = await rollout._run_inference_step_with_permit(state, "url")
 
     assert result == "response"
-    async with permits.acquire():
-        pass
+    assert not probe.held
 
 
 @pytest.mark.asyncio
 async def test_deepeyes_inference_releases_request_permit_on_error(monkeypatch):
-    permits = RequestPermitPool(1)
-    state = SimpleNamespace(request_permit=permits.acquire)
+    probe = _PermitProbe()
+    state = SimpleNamespace(request_permit=probe.acquire)
 
     async def failing_inference(*args, **kwargs):
         del args, kwargs
@@ -41,5 +54,36 @@ async def test_deepeyes_inference_releases_request_permit_on_error(monkeypatch):
     with pytest.raises(RuntimeError, match="inference failed"):
         await rollout._run_inference_step_with_permit(state, "url")
 
-    async with permits.acquire():
-        pass
+    assert not probe.held
+
+
+@pytest.mark.asyncio
+async def test_deepeyes_does_not_infer_when_aborted_while_waiting_for_permit(monkeypatch):
+    waiting = asyncio.Event()
+    release = asyncio.Event()
+    inference_called = False
+
+    @asynccontextmanager
+    async def blocking_permit():
+        waiting.set()
+        await release.wait()
+        yield
+
+    state = SimpleNamespace(request_permit=blocking_permit, aborted=False)
+
+    async def fake_inference(*args, **kwargs):
+        nonlocal inference_called
+        del args, kwargs
+        inference_called = True
+
+    monkeypatch.setattr(rollout, "_run_inference_step", fake_inference)
+
+    task = asyncio.create_task(rollout._run_inference_step_with_permit(state, "url"))
+    await asyncio.wait_for(waiting.wait(), timeout=1)
+    state.aborted = True
+    release.set()
+
+    result = await asyncio.wait_for(task, timeout=1)
+
+    assert result is None
+    assert not inference_called

--- a/tests/engine/rollout/test_deepeyes_request_permit.py
+++ b/tests/engine/rollout/test_deepeyes_request_permit.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from types import SimpleNamespace
+
+import pytest
+
+from examples.deepeyes import rollout
+from relax.engine.rollout.request_permit import RequestPermitPool
+
+
+@pytest.mark.asyncio
+async def test_deepeyes_inference_holds_request_permit(monkeypatch):
+    permits = RequestPermitPool(1)
+    state = SimpleNamespace(request_permit=permits.acquire)
+
+    async def fake_inference(*args, **kwargs):
+        del args, kwargs
+        assert permits._semaphore.locked()
+        return "response"
+
+    monkeypatch.setattr(rollout, "_run_inference_step", fake_inference)
+
+    result = await rollout._run_inference_step_with_permit(state, "url")
+
+    assert result == "response"
+    async with permits.acquire():
+        pass
+
+
+@pytest.mark.asyncio
+async def test_deepeyes_inference_releases_request_permit_on_error(monkeypatch):
+    permits = RequestPermitPool(1)
+    state = SimpleNamespace(request_permit=permits.acquire)
+
+    async def failing_inference(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("inference failed")
+
+    monkeypatch.setattr(rollout, "_run_inference_step", failing_inference)
+
+    with pytest.raises(RuntimeError, match="inference failed"):
+        await rollout._run_inference_step_with_permit(state, "url")
+
+    async with permits.acquire():
+        pass

--- a/tests/engine/rollout/test_request_permit.py
+++ b/tests/engine/rollout/test_request_permit.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
 import asyncio
+from contextlib import asynccontextmanager
 
 import pytest
 
-from relax.engine.rollout.request_permit import RequestPermitPool
+from relax.engine.rollout.request_permit import RequestPermitPool, run_request_with_permit
 
 
 async def _acquire_once(permits: RequestPermitPool) -> None:
@@ -18,21 +19,27 @@ async def test_request_permit_enforces_concurrency_limit():
     active = 0
     peak = 0
     release = asyncio.Event()
+    limit_reached = asyncio.Event()
 
     async def request():
         nonlocal active, peak
         async with permits.acquire():
             active += 1
             peak = max(peak, active)
-            await release.wait()
-            active -= 1
+            if peak == 2:
+                limit_reached.set()
+            try:
+                await release.wait()
+            finally:
+                active -= 1
 
     tasks = [asyncio.create_task(request()) for _ in range(4)]
-    while peak < 2:
-        await asyncio.sleep(0)
-    assert active == 2
-    release.set()
-    await asyncio.gather(*tasks)
+    try:
+        await asyncio.wait_for(limit_reached.wait(), timeout=1)
+        assert active == 2
+    finally:
+        release.set()
+        await asyncio.gather(*tasks)
     assert peak == 2
 
 
@@ -110,3 +117,51 @@ async def test_request_permit_does_not_cover_environment_work():
 def test_request_permit_rejects_non_positive_limit(limit):
     with pytest.raises(ValueError, match="positive"):
         RequestPermitPool(limit)
+
+
+@pytest.mark.asyncio
+async def test_request_is_skipped_when_abort_happens_while_waiting_for_permit():
+    permit_entered = asyncio.Event()
+    release_permit = asyncio.Event()
+    aborted = False
+    request_called = False
+
+    @asynccontextmanager
+    async def blocking_permit():
+        permit_entered.set()
+        await release_permit.wait()
+        yield
+
+    async def request():
+        nonlocal request_called
+        request_called = True
+        return "response"
+
+    task = asyncio.create_task(run_request_with_permit(blocking_permit, request, should_abort=lambda: aborted))
+    await asyncio.wait_for(permit_entered.wait(), timeout=1)
+    aborted = True
+    release_permit.set()
+
+    result = await asyncio.wait_for(task, timeout=1)
+
+    assert result.aborted
+    assert result.value is None
+    assert not request_called
+
+
+@pytest.mark.asyncio
+async def test_request_result_reports_permit_wait_and_request_time(monkeypatch):
+    permits = RequestPermitPool(1)
+    timestamps = iter([10.0, 13.0, 20.0, 25.0])
+
+    async def request():
+        return "response"
+
+    monkeypatch.setattr("relax.engine.rollout.request_permit.monotonic", lambda: next(timestamps))
+
+    result = await run_request_with_permit(permits.acquire, request)
+
+    assert not result.aborted
+    assert result.value == "response"
+    assert result.permit_wait_seconds == 3.0
+    assert result.request_seconds == 5.0

--- a/tests/engine/rollout/test_request_permit.py
+++ b/tests/engine/rollout/test_request_permit.py
@@ -49,6 +49,36 @@ async def test_request_permit_releases_after_failure(failure):
 
 
 @pytest.mark.asyncio
+async def test_request_permit_cancellation_while_waiting_does_not_consume_permit():
+    permits = RequestPermitPool(1)
+    holder_entered = asyncio.Event()
+    release_holder = asyncio.Event()
+
+    async def hold_permit():
+        async with permits.acquire():
+            holder_entered.set()
+            await release_holder.wait()
+
+    async def wait_for_permit():
+        async with permits.acquire():
+            pass
+
+    holder = asyncio.create_task(hold_permit())
+    await holder_entered.wait()
+    waiter = asyncio.create_task(wait_for_permit())
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    release_holder.set()
+    await holder
+    async with asyncio.timeout(1):
+        async with permits.acquire():
+            pass
+
+
+@pytest.mark.asyncio
 async def test_request_permit_does_not_cover_environment_work():
     permits = RequestPermitPool(1)
     first_request_done = asyncio.Event()

--- a/tests/engine/rollout/test_request_permit.py
+++ b/tests/engine/rollout/test_request_permit.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import asyncio
+
+import pytest
+
+from relax.engine.rollout.request_permit import RequestPermitPool
+
+
+@pytest.mark.asyncio
+async def test_request_permit_enforces_concurrency_limit():
+    permits = RequestPermitPool(2)
+    active = 0
+    peak = 0
+    release = asyncio.Event()
+
+    async def request():
+        nonlocal active, peak
+        async with permits.acquire():
+            active += 1
+            peak = max(peak, active)
+            await release.wait()
+            active -= 1
+
+    tasks = [asyncio.create_task(request()) for _ in range(4)]
+    while peak < 2:
+        await asyncio.sleep(0)
+    assert active == 2
+    release.set()
+    await asyncio.gather(*tasks)
+    assert peak == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [RuntimeError("request failed"), asyncio.CancelledError()])
+async def test_request_permit_releases_after_failure(failure):
+    permits = RequestPermitPool(1)
+
+    async def fail():
+        async with permits.acquire():
+            raise failure
+
+    with pytest.raises(type(failure)):
+        await fail()
+
+    async with asyncio.timeout(1):
+        async with permits.acquire():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_request_permit_does_not_cover_environment_work():
+    permits = RequestPermitPool(1)
+    first_request_done = asyncio.Event()
+    environment_done = asyncio.Event()
+    short_request_done = asyncio.Event()
+
+    async def long_session():
+        async with permits.acquire():
+            first_request_done.set()
+        await environment_done.wait()
+        async with permits.acquire():
+            pass
+
+    async def short_session():
+        await first_request_done.wait()
+        async with permits.acquire():
+            short_request_done.set()
+
+    long_task = asyncio.create_task(long_session())
+    short_task = asyncio.create_task(short_session())
+    await asyncio.wait_for(short_request_done.wait(), timeout=1)
+    assert not environment_done.is_set()
+    environment_done.set()
+    await asyncio.gather(long_task, short_task)
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_request_permit_rejects_non_positive_limit(limit):
+    with pytest.raises(ValueError, match="positive"):
+        RequestPermitPool(limit)

--- a/tests/engine/rollout/test_request_permit.py
+++ b/tests/engine/rollout/test_request_permit.py
@@ -7,6 +7,11 @@ import pytest
 from relax.engine.rollout.request_permit import RequestPermitPool
 
 
+async def _acquire_once(permits: RequestPermitPool) -> None:
+    async with permits.acquire():
+        pass
+
+
 @pytest.mark.asyncio
 async def test_request_permit_enforces_concurrency_limit():
     permits = RequestPermitPool(2)
@@ -43,9 +48,7 @@ async def test_request_permit_releases_after_failure(failure):
     with pytest.raises(type(failure)):
         await fail()
 
-    async with asyncio.timeout(1):
-        async with permits.acquire():
-            pass
+    await asyncio.wait_for(_acquire_once(permits), timeout=1)
 
 
 @pytest.mark.asyncio
@@ -73,9 +76,7 @@ async def test_request_permit_cancellation_while_waiting_does_not_consume_permit
 
     release_holder.set()
     await holder
-    async with asyncio.timeout(1):
-        async with permits.acquire():
-            pass
+    await asyncio.wait_for(_acquire_once(permits), timeout=1)
 
 
 @pytest.mark.asyncio

--- a/tests/engine/rollout/test_sglang_rollout_diagnostics.py
+++ b/tests/engine/rollout/test_sglang_rollout_diagnostics.py
@@ -9,8 +9,11 @@ base64 ``output_top_logprobs_*_b64`` fields into numpy ``(ids, logps)``.
 
 import numpy as np
 import pybase64
+import pytest
 
+from relax.engine.rollout.sglang_rollout import _aggregate_rollout_timing
 from relax.utils.opd.opd_main_worker import LogprobResponse
+from relax.utils.types import Sample
 
 
 def _b64(arr: np.ndarray) -> str:
@@ -38,3 +41,15 @@ def test_rollout_self_topk_keeps_token_id_zero_from_b64() -> None:
 
 def test_rollout_self_topk_returns_none_when_absent() -> None:
     assert LogprobResponse({"meta_info": {}}).self_topk("rollout", top_k=2) is None
+
+
+def test_rollout_timing_reports_request_permit_wait() -> None:
+    first = Sample(prompt="first")
+    first.metadata["_timing"] = {"request_permit_wait": 0.2, "generate": 1.0}
+    second = Sample(prompt="second")
+    second.metadata["_timing"] = {"request_permit_wait": 0.4, "generate": 2.0}
+
+    metrics = _aggregate_rollout_timing([first, second], [])
+
+    assert metrics["perf_detail/rollout/request_permit_wait_time/mean"] == pytest.approx(0.3)
+    assert metrics["perf_detail/rollout/request_permit_wait_time/max"] == 0.4


### PR DESCRIPTION
## What

Move rollout concurrency control from the lifetime of a custom multi-turn session to each individual model request.

## How

- Add a reusable `RequestPermitPool` with a public `GenerateState.request_permit()` interface
- Acquire permits only around the standard SGLang HTTP request
- Remove the session-level semaphore around custom generation
- Acquire and release a permit for every DeepEyes inference turn
- Keep environment and tool execution outside the permit scope
- Recheck abort state after permit admission so a queued request cannot start after `abort_all`
- Report permit queueing separately as `request_permit_wait` while preserving `generate` as request time
- Document the request-level contract for custom rollout implementations

## Correctness coverage

- Enforces the configured concurrent request limit
- Releases permits on success, exception, cancellation while holding, and cancellation while waiting
- Demonstrates fairness with a limit of one: a short request runs while a long session is executing environment work
- Verifies DeepEyes holds a permit during inference and releases it after errors
- Verifies queued default and DeepEyes requests do not run after an abort
- Verifies permit wait time is exposed through rollout performance metrics
- Rejects non-positive concurrency limits

## Verification

Local arm64 macOS, Python 3.11.3:

- `python -m pytest -q tests/engine/rollout/test_request_permit.py`: 9 passed
- Targeted Ruff check and format check: passed
- `pre-commit run --all-files`: passed, including gitleaks

aarch64 integration environment, Python 3.10.20:

- `tests/engine/rollout/test_request_permit.py`
- `tests/engine/rollout/test_deepeyes_request_permit.py`
- `tests/engine/rollout/test_sglang_rollout_diagnostics.py`
- `tests/test_agentic_rollout.py`
- Result: 31 passed

NVIDIA GH200 validation environment:

- Architecture: `aarch64`
- CPU cores: 72
- GPU: NVIDIA GH200 120GB, compute capability 9.0, 97871 MiB
- Driver: 595.58.03
- Python: 3.10.20
- PyTorch: 2.11.0+cu129
- CUDA: 12.9, available
- Commit: `631cfa08e05e94f21040df78dd462b87a6004ba7`
- Targeted tests: 31 passed, `test_rc=0`

CPU async scheduling benchmark on NVIDIA GH200 (`1` warmup, `9` measured runs, median):

| Permit scope | Median total | Median short-request latency | Peak model requests |
| --- | ---: | ---: | ---: |
| Session-level baseline | 380.65 ms | 360.55 ms | 1 |
| Request-level | 360.64 ms | 20.07 ms | 1 |

Command: `PYTHONPATH=. python scripts/benchmarks/benchmark_request_permit.py --warmups 1 --runs 9`

This synthetic CPU benchmark validates scheduling behavior and the concurrency bound; it is not a model-throughput benchmark. Request-level permits reduced short-request latency by 94.4% in this fixed scenario while preserving the concurrency limit.

## Risk and rollback

- External custom generate functions must call `state.request_permit()` around each SGLang request after upgrading; requests that bypass the interface are not covered by `--sglang-server-concurrency`.
- Reverting this PR restores the previous session-level semaphore behavior.

The GH200 validation runs emitted only existing third-party warnings from OpenTelemetry, SWIG, SGLang, Megatron, Ray Serve, Pydantic, and related optional kernels.

Closes #110
