### PR TITLE
【No.19】feat(rewards): run sync custom rewards in worker pool

### DIFF
--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -420,7 +420,7 @@ SFT also uses the general dataset flags from [Data Configuration](#data-configur
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--rm-type` | str | None | Built-in reward model type |
-| `--custom-rm-path` | str | None | Custom reward function path. Sync functions run in the `RewardWorker` process pool; async functions are directly awaited. Function signature: `def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | Custom reward function path. Sync functions run in the `RewardWorker` process pool; async functions are directly awaited. Single-sample signature: `def custom_rm(args, sample) -> float \| dict`; with `--group-rm`: `def custom_rm(args, samples) -> list[float \| dict]` |
 | `--reward-key` | str | None | Key to extract reward value when reward function returns dict |
 | `--eval-reward-key` | str | None | Reward key for evaluation. When None, equals `--reward-key` |
 | `--group-rm` | flag | False | Whether to compute reward for entire group |

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -420,7 +420,7 @@ SFT also uses the general dataset flags from [Data Configuration](#data-configur
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--rm-type` | str | None | Built-in reward model type |
-| `--custom-rm-path` | str | None | Custom reward function path. Function signature: `def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | Custom reward function path. Sync functions run in the `RewardWorker` process pool; async functions are directly awaited. Function signature: `def custom_rm(args, sample) -> float` |
 | `--reward-key` | str | None | Key to extract reward value when reward function returns dict |
 | `--eval-reward-key` | str | None | Reward key for evaluation. When None, equals `--reward-key` |
 | `--group-rm` | flag | False | Whether to compute reward for entire group |

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -124,6 +124,14 @@ You can define `reward_func(args, sample: Sample, **kwargs) -> float` in your ow
 --reward-key score
 ```
 
+Synchronous `reward_func` runs in the `RewardWorker` process pool so it does
+not block the rollout event loop. Asynchronous `async def reward_func(...)`
+continues to run in the event loop and is directly awaited. The concurrency
+limit is controlled by `--reward-max-concurrency`, and the number of worker
+processes is controlled by `--reward-num-workers`. When `--group-rm` is set,
+the custom reward receives the whole group as a `samples` list and returns one
+reward per sample.
+
 ## Custom Generate Function
 
 For multi-turn dialogue, tool calling, or agentic rollout, define a custom `generate` function to replace the default single-turn logic. The function signature is:

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -116,7 +116,7 @@ python scripts/tools/process_avqa.py \
 
 ## Custom Reward Methods
 
-You can define `reward_func(args, sample: Sample, **kwargs) -> float` in your own `.py` file, then add it to your task launch script. See [DeepEyes](../examples/deepeyes.md) for a concrete example.
+You can define `reward_func(args, sample: Sample, **kwargs) -> float | dict` in your own `.py` file, then add it to your task launch script. See [DeepEyes](../examples/deepeyes.md) for a concrete example.
 
 ```bash
 --custom-rm-path examples.deepeyes.reward_deepeyes.reward_func

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -420,7 +420,7 @@ SFT 还会用到通用的[数据配置](#数据配置)参数，特别是 `--inpu
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `--rm-type` | str | None | 内置 Reward 模型类型 |
-| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。函数签名：`def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。同步函数走 `RewardWorker` 进程池，异步函数直接 `await`。函数签名：`def custom_rm(args, sample) -> float` |
 | `--reward-key` | str | None | Reward 函数返回 dict 时提取 reward 值的 key |
 | `--eval-reward-key` | str | None | 评估时的 reward key。None 时等于 `--reward-key` |
 | `--group-rm` | flag | False | 是否对整个 group 做 Reward 计算 |

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -420,7 +420,7 @@ SFT 还会用到通用的[数据配置](#数据配置)参数，特别是 `--inpu
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `--rm-type` | str | None | 内置 Reward 模型类型 |
-| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。同步函数走 `RewardWorker` 进程池，异步函数直接 `await`。函数签名：`def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。同步函数走 `RewardWorker` 进程池，异步函数直接 `await`。单样本签名：`def custom_rm(args, sample) -> float \| dict`；`--group-rm` 时签名：`def custom_rm(args, samples) -> list[float \| dict]` |
 | `--reward-key` | str | None | Reward 函数返回 dict 时提取 reward 值的 key |
 | `--eval-reward-key` | str | None | 评估时的 reward key。None 时等于 `--reward-key` |
 | `--group-rm` | flag | False | 是否对整个 group 做 Reward 计算 |

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -115,7 +115,7 @@ python scripts/tools/process_avqa.py \
 
 ## 自定义 Reward 方法
 
-您可以在自己的 `.py` 文件内定义 `reward_func(args, sample: Sample, **kwargs) -> float`，然后在任务启动脚本内加入调用即可，具体使用可参考 [DeepEyes](../examples/deepeyes.md)。
+您可以在自己的 `.py` 文件内定义 `reward_func(args, sample: Sample, **kwargs) -> float | dict`，然后在任务启动脚本内加入调用即可，具体使用可参考 [DeepEyes](../examples/deepeyes.md)。
 
 ```bash
 --custom-rm-path examples.deepeyes.reward_deepeyes.reward_func

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -123,6 +123,12 @@ python scripts/tools/process_avqa.py \
 --reward-key score
 ```
 
+同步 `reward_func` 会在 `RewardWorker` 进程池内执行，避免阻塞 rollout 的 event loop；
+异步 `async def reward_func(...)` 会保持在 event loop 内直接 `await`。并发上限由
+`--reward-max-concurrency` 控制，worker 进程数量由 `--reward-num-workers` 控制。
+开启 `--group-rm` 时，custom reward 接收整个 group 的 `samples` 列表并返回逐样本
+reward 列表。
+
 ## 自定义 Generate 函数
 
 对于多轮对话、工具调用、Agent 交互等场景，可自定义 `generate` 函数替换默认的单轮生成逻辑。函数签名如下：

--- a/relax/agentic/pipeline/reward.py
+++ b/relax/agentic/pipeline/reward.py
@@ -31,6 +31,8 @@ def _effective_reward_concurrency(args, *, explicit_limit: int | None = None) ->
 
 
 async def _async_rm(args, sample):
+    # Use the shared reward executor so custom reward isolation and concurrency
+    # are identical between regular rollout and agentic rollout.
     from relax.engine.rewards import async_rm
 
     return await async_rm(args, sample)

--- a/relax/agentic/pipeline/reward.py
+++ b/relax/agentic/pipeline/reward.py
@@ -31,24 +31,12 @@ def _effective_reward_concurrency(args, *, explicit_limit: int | None = None) ->
 
 
 async def _async_rm(args, sample):
-    custom_rm_path = args.custom_rm_path
-    if custom_rm_path:
-        from relax.utils.utils import load_function
-
-        rm_function = load_function(custom_rm_path)
-        return await rm_function(args, sample)
     from relax.engine.rewards import async_rm
 
     return await async_rm(args, sample)
 
 
 async def _batched_async_rm(args, samples):
-    custom_rm_path = args.custom_rm_path
-    if custom_rm_path:
-        from relax.utils.utils import load_function
-
-        rm_function = load_function(custom_rm_path)
-        return await rm_function(args, samples)
     from relax.engine.rewards import batched_async_rm
 
     return await batched_async_rm(args, samples)

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -26,6 +26,7 @@ from .openr1mm import get_openr1mm_rule_based_reward
 logger = get_logger(__name__)
 _shared_session: aiohttp.ClientSession | None = None
 RewardValue = int | float | dict[str, Any]
+_MAX_ERROR_CONTEXT_SAMPLES = 5
 
 
 def _sample_context(sample: Sample) -> str:
@@ -38,8 +39,13 @@ def _sample_context(sample: Sample) -> str:
     )
 
 
-def _sample_group_context(samples: list[Sample]) -> str:
-    return "[" + ", ".join(_sample_context(sample) for sample in samples) + "]"
+def _sample_group_context(samples: list[Sample], max_samples: int = _MAX_ERROR_CONTEXT_SAMPLES) -> str:
+    visible_samples = samples[:max_samples]
+    context = "[" + ", ".join(_sample_context(sample) for sample in visible_samples) + "]"
+    omitted = len(samples) - len(visible_samples)
+    if omitted > 0:
+        context += f" (omitted {omitted} samples)"
+    return context
 
 
 def _get_shared_session() -> aiohttp.ClientSession:
@@ -68,11 +74,11 @@ def _get_shared_session() -> aiohttp.ClientSession:
 
 @ray.remote(num_cpus=0.25)
 class RewardWorker:
-    """Stateless worker that executes synchronous reward functions in a
-    dedicated process.
+    """Worker that executes synchronous reward functions in a dedicated
+    process.
 
-    Each call receives the rm_type and the necessary arguments so the worker
-    does not need to hold any state.
+    Built-in rewards are dispatched by rm_type. Custom reward functions are
+    cached per worker process so repeated calls do not re-import user code.
     """
 
     def __init__(self):
@@ -221,6 +227,12 @@ class RewardExecutor:
         self._worker_index += 1
         return worker
 
+    async def _submit_worker_call(self, remote_method, *args):
+        # Ray serializes remote-call arguments before returning ObjectRef. Do
+        # that submission in a thread so larger custom args/Sample payloads do
+        # not stall the rollout event loop during serialization.
+        return await asyncio.to_thread(remote_method.remote, *args)
+
     def _load_custom_rm_function(self, custom_rm_path: str):
         rm_function = self._custom_rm_functions.get(custom_rm_path)
         if rm_function is None:
@@ -314,7 +326,7 @@ class RewardExecutor:
             if rm_type:
                 self._ensure_workers()
                 worker = self._next_worker()
-                ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
+                ref = await self._submit_worker_call(worker.compute, rm_type, response, label, metadata)
                 return await ref
 
             # --- no rm_type specified -----------------------------------------
@@ -333,7 +345,7 @@ class RewardExecutor:
 
         self._ensure_workers()
         worker = self._next_worker()
-        ref = worker.compute_custom.remote(custom_rm_path, args, sample, kwargs)
+        ref = await self._submit_worker_call(worker.compute_custom, custom_rm_path, args, sample, kwargs)
         return await ref
 
     async def execute_custom_batch(self, args, samples: list[Sample], **kwargs):
@@ -352,7 +364,7 @@ class RewardExecutor:
 
             self._ensure_workers()
             worker = self._next_worker()
-            ref = worker.compute_custom_batch.remote(custom_rm_path, args, samples, kwargs)
+            ref = await self._submit_worker_call(worker.compute_custom_batch, custom_rm_path, args, samples, kwargs)
             return await ref
 
 

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -127,6 +127,8 @@ class RewardWorker:
 
     def compute_custom(self, custom_rm_path: str, args, sample: Sample, kwargs: dict | None = None):
         rm_function = self._load_custom_rm_function(custom_rm_path)
+        # Worker actors only execute synchronous custom rewards; async rewards
+        # must stay on the rollout event loop where they can be awaited safely.
         if inspect.iscoroutinefunction(rm_function):
             raise TypeError(f"Custom reward {custom_rm_path!r} is async and cannot run in RewardWorker.")
 
@@ -145,6 +147,8 @@ class RewardWorker:
 
     def compute_custom_batch(self, custom_rm_path: str, args, samples: list[Sample], kwargs: dict | None = None):
         rm_function = self._load_custom_rm_function(custom_rm_path)
+        # Keep group reward semantics intact by passing the whole sample group
+        # to a synchronous custom scorer inside one worker process.
         if inspect.iscoroutinefunction(rm_function):
             raise TypeError(f"Custom reward {custom_rm_path!r} is async and cannot run in RewardWorker.")
 
@@ -223,6 +227,8 @@ class RewardExecutor:
         return rm_function
 
     def _clear_custom_rm_cache(self, custom_rm_path: str | None = None):
+        # Explicit hot reload refreshes sys.modules in the rollout process; drop
+        # cached function objects here and in already-created worker actors.
         if custom_rm_path is None:
             self._custom_rm_functions.clear()
         else:
@@ -315,6 +321,8 @@ class RewardExecutor:
     async def _execute_custom(self, args, sample: Sample, kwargs: dict):
         custom_rm_path = args.custom_rm_path
         rm_function = self._load_custom_rm_function(custom_rm_path)
+        # Classify before calling the function. Calling first and checking the
+        # return value would already block the event loop for sync scorers.
         if inspect.iscoroutinefunction(rm_function):
             try:
                 return await rm_function(args, sample, **kwargs)
@@ -405,6 +413,8 @@ async def batched_async_rm(
 ) -> list[int | float]:
     if not samples:
         return []
+    # group_rm custom rewards are documented as whole-group scorers, so keep
+    # their batch input shape and offload sync implementations as one worker job.
     if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False) and getattr(args, "group_rm", False):
         max_concurrency = getattr(args, "reward_max_concurrency", 64)
         num_workers = getattr(args, "reward_num_workers", 16)

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
 import asyncio
+import inspect
 import random
 
 import aiohttp
@@ -23,6 +24,20 @@ from .openr1mm import get_openr1mm_rule_based_reward
 
 logger = get_logger(__name__)
 _shared_session: aiohttp.ClientSession | None = None
+
+
+def _sample_context(sample: Sample) -> str:
+    metadata = sample.metadata if isinstance(getattr(sample, "metadata", None), dict) else {}
+    metadata_keys = sorted(str(key) for key in metadata.keys())
+    return (
+        f"index={getattr(sample, 'index', None)!r}, "
+        f"group_index={getattr(sample, 'group_index', None)!r}, "
+        f"metadata_keys={metadata_keys!r}"
+    )
+
+
+def _sample_group_context(samples: list[Sample]) -> str:
+    return "[" + ", ".join(_sample_context(sample) for sample in samples) + "]"
 
 
 def _get_shared_session() -> aiohttp.ClientSession:
@@ -57,6 +72,22 @@ class RewardWorker:
     Each call receives the rm_type and the necessary arguments so the worker
     does not need to hold any state.
     """
+
+    def __init__(self):
+        self._custom_rm_functions: dict[str, object] = {}
+
+    def _load_custom_rm_function(self, custom_rm_path: str):
+        rm_function = self._custom_rm_functions.get(custom_rm_path)
+        if rm_function is None:
+            rm_function = load_function(custom_rm_path)
+            self._custom_rm_functions[custom_rm_path] = rm_function
+        return rm_function
+
+    def clear_custom_rm_cache(self, custom_rm_path: str | None = None):
+        if custom_rm_path is None:
+            self._custom_rm_functions.clear()
+            return
+        self._custom_rm_functions.pop(custom_rm_path, None)
 
     def compute(self, rm_type: str, response: str, label, metadata: dict | None = None):
         """Dispatch to the appropriate synchronous reward function.
@@ -94,6 +125,42 @@ class RewardWorker:
         else:
             raise NotImplementedError(f"RewardWorker: unknown rm_type={rm_type!r}")
 
+    def compute_custom(self, custom_rm_path: str, args, sample: Sample, kwargs: dict | None = None):
+        rm_function = self._load_custom_rm_function(custom_rm_path)
+        if inspect.iscoroutinefunction(rm_function):
+            raise TypeError(f"Custom reward {custom_rm_path!r} is async and cannot run in RewardWorker.")
+
+        kwargs = kwargs or {}
+        try:
+            result = rm_function(args, sample, **kwargs)
+        except Exception as exc:
+            raise RuntimeError(f"Custom reward failed for sample ({_sample_context(sample)}).") from exc
+
+        if inspect.isawaitable(result):
+            raise TypeError(
+                f"Custom reward {custom_rm_path!r} returned an awaitable from a synchronous function. "
+                "Define it with 'async def' to run it in the event loop."
+            )
+        return result
+
+    def compute_custom_batch(self, custom_rm_path: str, args, samples: list[Sample], kwargs: dict | None = None):
+        rm_function = self._load_custom_rm_function(custom_rm_path)
+        if inspect.iscoroutinefunction(rm_function):
+            raise TypeError(f"Custom reward {custom_rm_path!r} is async and cannot run in RewardWorker.")
+
+        kwargs = kwargs or {}
+        try:
+            result = rm_function(args, samples, **kwargs)
+        except Exception as exc:
+            raise RuntimeError(f"Custom reward failed for sample group {_sample_group_context(samples)}.") from exc
+
+        if inspect.isawaitable(result):
+            raise TypeError(
+                f"Custom reward {custom_rm_path!r} returned an awaitable from a synchronous function. "
+                "Define it with 'async def' to run it in the event loop."
+            )
+        return result
+
 
 # ---------------------------------------------------------------------------
 # RewardExecutor: manages the worker pool and global concurrency
@@ -112,6 +179,7 @@ class RewardExecutor:
         self._semaphore: asyncio.Semaphore | None = None
         self._workers: list = []
         self._worker_index = 0
+        self._custom_rm_functions: dict[str, object] = {}
 
     # -- singleton access -----------------------------------------------------
 
@@ -147,6 +215,36 @@ class RewardExecutor:
         self._worker_index += 1
         return worker
 
+    def _load_custom_rm_function(self, custom_rm_path: str):
+        rm_function = self._custom_rm_functions.get(custom_rm_path)
+        if rm_function is None:
+            rm_function = load_function(custom_rm_path)
+            self._custom_rm_functions[custom_rm_path] = rm_function
+        return rm_function
+
+    def _clear_custom_rm_cache(self, custom_rm_path: str | None = None):
+        if custom_rm_path is None:
+            self._custom_rm_functions.clear()
+        else:
+            self._custom_rm_functions.pop(custom_rm_path, None)
+
+        refs = []
+        for worker in self._workers:
+            try:
+                refs.append(worker.clear_custom_rm_cache.remote(custom_rm_path))
+            except Exception as exc:
+                logger.warning("RewardExecutor: failed to clear custom reward cache on worker: %s", exc)
+        if refs:
+            try:
+                ray.get(refs)
+            except Exception as exc:
+                logger.warning("RewardExecutor: failed to wait for custom reward cache clear: %s", exc)
+
+    @classmethod
+    def clear_custom_rm_cache(cls, custom_rm_path: str | None = None):
+        if cls._instance is not None:
+            cls._instance._clear_custom_rm_cache(custom_rm_path)
+
     # -- public API -----------------------------------------------------------
 
     # Async rm_types run in the event loop (not dispatched to worker pool).
@@ -181,16 +279,14 @@ class RewardExecutor:
 
         - Async rm_types (remote_rm, dapo-genrm) run in the event loop.
         - Sync rm_types are dispatched to the Ray worker pool.
-        - Custom rm paths are called directly (user is responsible for
-          async safety).
+        - Async custom rm paths run in the event loop.
+        - Sync custom rm paths are dispatched to the Ray worker pool.
         """
         self._ensure_semaphore()
 
         async with self._semaphore:
-            # --- custom rm path: delegate to user function directly ---
             if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False):
-                rm_function = load_function(args.custom_rm_path)
-                return await rm_function(args, sample, **kwargs)
+                return await self._execute_custom(args, sample, kwargs)
 
             metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
             rm_type = (metadata.get("rm_type") or args.rm_type or "").strip()
@@ -215,6 +311,39 @@ class RewardExecutor:
 
             # --- no rm_type specified -----------------------------------------
             raise NotImplementedError("Rule-based RM type is not specified.")
+
+    async def _execute_custom(self, args, sample: Sample, kwargs: dict):
+        custom_rm_path = args.custom_rm_path
+        rm_function = self._load_custom_rm_function(custom_rm_path)
+        if inspect.iscoroutinefunction(rm_function):
+            try:
+                return await rm_function(args, sample, **kwargs)
+            except Exception as exc:
+                raise RuntimeError(f"Custom reward failed for sample ({_sample_context(sample)}).") from exc
+
+        self._ensure_workers()
+        worker = self._next_worker()
+        ref = worker.compute_custom.remote(custom_rm_path, args, sample, kwargs)
+        return await ref
+
+    async def execute_custom_batch(self, args, samples: list[Sample], **kwargs):
+        self._ensure_semaphore()
+
+        async with self._semaphore:
+            custom_rm_path = args.custom_rm_path
+            rm_function = self._load_custom_rm_function(custom_rm_path)
+            if inspect.iscoroutinefunction(rm_function):
+                try:
+                    return await rm_function(args, samples, **kwargs)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Custom reward failed for sample group {_sample_group_context(samples)}."
+                    ) from exc
+
+            self._ensure_workers()
+            worker = self._next_worker()
+            ref = worker.compute_custom_batch.remote(custom_rm_path, args, samples, kwargs)
+            return await ref
 
 
 # ---------------------------------------------------------------------------
@@ -274,10 +403,16 @@ async def batched_async_rm(
     samples: list[Sample],
     **kwargs,
 ) -> list[int | float]:
-    if args.custom_rm_path is not None:
-        # Ensure the custom reward function is implemented in batch mode
-        rm_function = load_function(args.custom_rm_path)
-        return await rm_function(args, samples, **kwargs)
+    if not samples:
+        return []
+    if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False) and getattr(args, "group_rm", False):
+        max_concurrency = getattr(args, "reward_max_concurrency", 64)
+        num_workers = getattr(args, "reward_num_workers", 16)
+        executor = RewardExecutor.get_or_create(
+            max_concurrency=max_concurrency,
+            num_workers=num_workers,
+        )
+        return await executor.execute_custom_batch(args, samples, **kwargs)
     tasks = [async_rm(args, sample, **kwargs) for sample in samples]
     rewards = await asyncio.gather(*tasks)
     return rewards

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import random
+from typing import Any
 
 import aiohttp
 import ray
@@ -24,6 +25,7 @@ from .openr1mm import get_openr1mm_rule_based_reward
 
 logger = get_logger(__name__)
 _shared_session: aiohttp.ClientSession | None = None
+RewardValue = int | float | dict[str, Any]
 
 
 def _sample_context(sample: Sample) -> str:
@@ -410,7 +412,7 @@ async def batched_async_rm(
     args,
     samples: list[Sample],
     **kwargs,
-) -> list[int | float]:
+) -> list[RewardValue]:
     if not samples:
         return []
     # group_rm custom rewards are documented as whole-group scorers, so keep

--- a/relax/utils/reload_utils.py
+++ b/relax/utils/reload_utils.py
@@ -174,7 +174,7 @@ RELOADABLE_FUNCTIONS: List[ReloadableFunction] = [
         config_attr="custom_rm_path",
         scope=ReloadScope.IMMEDIATE,
         required=False,
-        description="Custom reward model function (auto-reloaded on each call)",
+        description="Custom reward model function (cached between explicit reloads)",
     ),
     ReloadableFunction(
         name="rollout_sample_filter",
@@ -382,6 +382,14 @@ class ReloadableMixin:
             # IMMEDIATE scope: Only refresh sys.modules, next load_function will get the new version
             logger.info(f"Refreshed sys.modules cache for {module_path}")
             message = f"Module '{module_name}' reloaded - will take effect on next call"
+
+        if func_def.name == "custom_rm":
+            try:
+                from relax.engine.rewards import RewardExecutor
+
+                RewardExecutor.clear_custom_rm_cache(module_path)
+            except Exception as exc:
+                logger.warning("Failed to clear custom reward cache after reload: %s", exc)
 
         return {
             "success": True,

--- a/relax/utils/reload_utils.py
+++ b/relax/utils/reload_utils.py
@@ -387,6 +387,8 @@ class ReloadableMixin:
             try:
                 from relax.engine.rewards import RewardExecutor
 
+                # custom_rm is cached by RewardExecutor and RewardWorker; clear
+                # both layers so explicit reload takes effect on the next call.
                 RewardExecutor.clear_custom_rm_cache(module_path)
             except Exception as exc:
                 logger.warning("Failed to clear custom reward cache after reload: %s", exc)

--- a/tests/engine/rewards/custom_reward_helpers.py
+++ b/tests/engine/rewards/custom_reward_helpers.py
@@ -44,6 +44,11 @@ def failing_sync_reward(args, sample, **kwargs):
     raise ValueError(f"boom for sample {sample.index}")
 
 
+def failing_batch_reward(args, samples, **kwargs):
+    del args, kwargs
+    raise ValueError(f"boom for group size {len(samples)}")
+
+
 def _update_counter(path: str, delta: int) -> None:
     import fcntl
 

--- a/tests/engine/rewards/custom_reward_helpers.py
+++ b/tests/engine/rewards/custom_reward_helpers.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+
+def sync_reward(args, sample, **kwargs):
+    return {
+        "score": 1.0 if sample.response == sample.label else 0.0,
+        "pid": os.getpid(),
+        "index": sample.index,
+        "tag": kwargs.get("tag"),
+    }
+
+
+async def async_reward(args, sample, **kwargs):
+    await asyncio.sleep(0)
+    return {
+        "score": 2.0,
+        "pid": os.getpid(),
+        "index": sample.index,
+        "tag": kwargs.get("tag"),
+    }
+
+
+def sync_batch_reward(args, samples, **kwargs):
+    pid = os.getpid()
+    return [
+        {
+            "score": 1.0 if sample.response == sample.label else 0.0,
+            "pid": pid,
+            "index": sample.index,
+            "tag": kwargs.get("tag"),
+        }
+        for sample in samples
+    ]
+
+
+def failing_sync_reward(args, sample, **kwargs):
+    del args, kwargs
+    raise ValueError(f"boom for sample {sample.index}")
+
+
+def _update_counter(path: str, delta: int) -> None:
+    import fcntl
+
+    counter_path = Path(path)
+    counter_path.parent.mkdir(parents=True, exist_ok=True)
+    with counter_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        handle.seek(0)
+        raw = handle.read()
+        state = json.loads(raw) if raw else {"active": 0, "max_active": 0}
+        state["active"] += delta
+        state["max_active"] = max(state["max_active"], state["active"])
+        handle.seek(0)
+        handle.truncate()
+        json.dump(state, handle)
+        handle.flush()
+        fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def metered_sync_reward(args, sample, **kwargs):
+    del kwargs
+    _update_counter(args.reward_counter_path, 1)
+    try:
+        time.sleep(args.reward_sleep_s)
+        return {
+            "score": 1.0,
+            "pid": os.getpid(),
+            "index": sample.index,
+        }
+    finally:
+        _update_counter(args.reward_counter_path, -1)

--- a/tests/engine/rewards/test_custom_reward_worker.py
+++ b/tests/engine/rewards/test_custom_reward_worker.py
@@ -178,6 +178,19 @@ async def test_sync_custom_reward_exception_includes_sample_context():
 
 
 @pytest.mark.asyncio
+async def test_group_custom_reward_exception_context_is_bounded():
+    args = _make_args(
+        custom_rm_path=f"{HELPERS}.failing_batch_reward",
+        group_rm=True,
+        reward_num_workers=1,
+    )
+    samples = [_make_sample(index=idx) for idx in range(8)]
+
+    with pytest.raises(Exception, match="omitted 3 samples"):
+        await batched_async_rm(args, samples)
+
+
+@pytest.mark.asyncio
 async def test_custom_reward_function_is_loaded_once_per_executor(monkeypatch):
     import relax.engine.rewards as reward_module
 

--- a/tests/engine/rewards/test_custom_reward_worker.py
+++ b/tests/engine/rewards/test_custom_reward_worker.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+
+_HAS_FULL_PIPELINE = False
+
+try:
+    import ray
+
+    if not ray.is_initialized():
+        try:
+            ray.init(num_cpus=8, ignore_reinit_error=True)
+        except ValueError as exc:
+            if "When connecting to an existing cluster" in str(exc):
+                ray.init(ignore_reinit_error=True)
+            else:
+                raise
+
+    from relax.engine.rewards import RewardExecutor, async_rm, batched_async_rm
+    from relax.utils.types import Sample
+
+    _HAS_FULL_PIPELINE = True
+except ImportError:
+    ray = None
+    RewardExecutor = None
+    Sample = None
+    async_rm = None
+    batched_async_rm = None
+
+
+pytestmark = pytest.mark.skipif(not _HAS_FULL_PIPELINE, reason="Full reward pipeline dependencies are not installed")
+
+HELPERS = "tests.engine.rewards.custom_reward_helpers"
+
+
+def _make_args(**overrides):
+    defaults = {
+        "rm_type": "openr1mm",
+        "custom_rm_path": None,
+        "group_rm": False,
+        "reward_max_concurrency": 64,
+        "reward_num_workers": 4,
+        "rm_url": None,
+        "reward_key": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_sample(index: int, response: str = "ok", label: str = "ok", metadata: dict | None = None):
+    return Sample(
+        index=index,
+        group_index=index // 10,
+        response=response,
+        label=label,
+        metadata=metadata or {},
+    )
+
+
+def _kill_named_reward_workers(max_workers: int = 16):
+    for idx in range(max_workers):
+        try:
+            worker = ray.get_actor(f"reward_worker_{idx}")
+        except ValueError:
+            continue
+        ray.kill(worker)
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor():
+    _kill_named_reward_workers()
+    RewardExecutor._instance = None
+    yield
+    inst = RewardExecutor._instance
+    if inst is not None:
+        for worker in inst._workers:
+            try:
+                ray.kill(worker)
+            except Exception:
+                pass
+        inst._workers = []
+    RewardExecutor._instance = None
+    _kill_named_reward_workers()
+
+
+@pytest.mark.asyncio
+async def test_sync_custom_reward_runs_in_worker_process():
+    args = _make_args(custom_rm_path=f"{HELPERS}.sync_reward", reward_num_workers=1)
+    sample = _make_sample(index=3)
+
+    result = await async_rm(args, sample, tag="single")
+
+    assert result["score"] == 1.0
+    assert result["index"] == 3
+    assert result["tag"] == "single"
+    assert result["pid"] != os.getpid()
+
+
+@pytest.mark.asyncio
+async def test_async_custom_reward_is_awaited_without_workers():
+    args = _make_args(custom_rm_path=f"{HELPERS}.async_reward", reward_num_workers=2)
+    samples = [_make_sample(index=idx) for idx in range(3)]
+
+    rewards = await batched_async_rm(args, samples, tag="async")
+
+    assert [reward["index"] for reward in rewards] == [0, 1, 2]
+    assert all(reward["score"] == 2.0 for reward in rewards)
+    assert {reward["pid"] for reward in rewards} == {os.getpid()}
+    assert RewardExecutor._instance._workers == []
+
+
+@pytest.mark.asyncio
+async def test_batched_sync_custom_reward_uses_worker_pool_and_preserves_order():
+    args = _make_args(
+        custom_rm_path=f"{HELPERS}.sync_reward",
+        reward_max_concurrency=4,
+        reward_num_workers=2,
+    )
+    samples = [_make_sample(index=idx) for idx in range(6)]
+
+    rewards = await batched_async_rm(args, samples)
+
+    assert [reward["index"] for reward in rewards] == list(range(6))
+    worker_pids = {reward["pid"] for reward in rewards}
+    assert len(worker_pids) == 2
+    assert os.getpid() not in worker_pids
+
+
+@pytest.mark.asyncio
+async def test_group_sync_custom_reward_keeps_batch_semantics_in_worker():
+    args = _make_args(
+        custom_rm_path=f"{HELPERS}.sync_batch_reward",
+        group_rm=True,
+        reward_num_workers=2,
+    )
+    samples = [_make_sample(index=idx) for idx in range(4)]
+
+    rewards = await batched_async_rm(args, samples, tag="group")
+
+    assert [reward["index"] for reward in rewards] == list(range(4))
+    assert all(reward["tag"] == "group" for reward in rewards)
+    worker_pids = {reward["pid"] for reward in rewards}
+    assert len(worker_pids) == 1
+    assert os.getpid() not in worker_pids
+
+
+@pytest.mark.asyncio
+async def test_reward_max_concurrency_limits_sync_custom_reward(tmp_path):
+    counter_path = tmp_path / "counter.json"
+    args = _make_args(
+        custom_rm_path=f"{HELPERS}.metered_sync_reward",
+        reward_max_concurrency=1,
+        reward_num_workers=3,
+        reward_counter_path=str(counter_path),
+        reward_sleep_s=0.05,
+    )
+    samples = [_make_sample(index=idx) for idx in range(5)]
+
+    rewards = await batched_async_rm(args, samples)
+
+    assert [reward["index"] for reward in rewards] == list(range(5))
+    state = json.loads(counter_path.read_text(encoding="utf-8"))
+    assert state["max_active"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_custom_reward_exception_includes_sample_context():
+    args = _make_args(custom_rm_path=f"{HELPERS}.failing_sync_reward", reward_num_workers=1)
+    sample = _make_sample(index=7, metadata={"source": "unit"})
+
+    with pytest.raises(Exception, match="index=7"):
+        await async_rm(args, sample)
+
+
+@pytest.mark.asyncio
+async def test_custom_reward_function_is_loaded_once_per_executor(monkeypatch):
+    import relax.engine.rewards as reward_module
+
+    calls = []
+    original_load_function = reward_module.load_function
+
+    def counting_load_function(path):
+        calls.append(path)
+        return original_load_function(path)
+
+    monkeypatch.setattr(reward_module, "load_function", counting_load_function)
+    custom_path = f"{HELPERS}.async_reward"
+    args = _make_args(custom_rm_path=custom_path)
+    samples = [_make_sample(index=idx) for idx in range(4)]
+
+    await batched_async_rm(args, samples)
+
+    assert calls == [custom_path]


### PR DESCRIPTION
Closes #115

## What

- Route synchronous custom reward functions through the existing `RewardWorker` Ray actor pool.
- Keep async custom reward functions directly awaited in the rollout event loop.
- Preserve `group_rm=True` custom reward semantics by offloading full-group synchronous scoring to a worker.
- Reuse the unified reward executor in agentic reward paths.
- Add explicit custom reward cache invalidation after hot reload.
- Document sync/async custom reward execution behavior in English and Chinese docs.

## Why

Synchronous custom reward functions can block the rollout event loop and previously did not reuse the existing process isolation and concurrency limits provided by `RewardWorker`.

## How

- Cache custom reward functions per executor/worker process.
- Detect async custom reward functions before invocation with `inspect.iscoroutinefunction()`.
- Dispatch sync custom reward calls to worker actors under the existing reward semaphore.
- Include bounded sample or group context in custom reward exceptions.
- Submit worker calls from a helper that avoids blocking the rollout event loop during heavier Ray argument serialization.
- Add targeted Ray-based tests for process isolation, concurrency, group semantics, async compatibility, ordering, bounded error context, and cache behavior.

## Testing

```bash
python -m pytest -q tests/engine/rewards/test_custom_reward_worker.py
# 8 passed

python -m pytest -q tests/engine/rewards/test_reward_worker.py
# 40 passed

python -m pytest -q tests/engine/rewards/test_custom_reward_worker.py tests/engine/rewards/test_reward_worker.py
# 48 passed

python -m ruff check relax/engine/rewards/__init__.py relax/agentic/pipeline/reward.py relax/utils/reload_utils.py tests/engine/rewards/custom_reward_helpers.py tests/engine/rewards/test_custom_reward_worker.py
# All checks passed

git diff --check
# passed

python -m pre_commit run --all-files
# passed
```

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Targeted reward tests pass
- [x] New tests added
- [x] Documentation updated

## Type of Change

New feature; documentation update.

