### PR TITLE
feat(rewards): add format-aware router

### DIFF
--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -11,14 +11,8 @@ from relax.utils.misc import load_function
 from relax.utils.types import Sample
 
 from .dapo_genrm import async_compute_score_genrm
-from .deepscaler import get_deepscaler_rule_based_reward
-from .f1 import f1_score
-from .gpqa import compute_gpqa_reward
-from .math_dapo_utils import compute_score as compute_score_dapo
 from .math_utils import extract_answer as extract_boxed_answer
-from .math_utils import grade_answer_verl
-from .multiple_choice import get_multiple_choice_reward
-from .openr1mm import get_openr1mm_rule_based_reward
+from .registry import REWARD_REGISTRY, resolve_reward_route
 
 
 logger = get_logger(__name__)
@@ -63,36 +57,10 @@ class RewardWorker:
 
         Returns the same value the original function would return.
         """
-        if rm_type == "deepscaler":
-            return get_deepscaler_rule_based_reward(response, label)
-        elif rm_type == "geo3k":
-            from .geo3k import get_geo3k_reward
-
-            return get_geo3k_reward(response, label)
-        elif rm_type == "openr1mm":
-            return get_openr1mm_rule_based_reward(response, label)
-        elif rm_type == "multiple_choice":
-            return get_multiple_choice_reward(response, label)
-        elif rm_type == "dapo":
-            return compute_score_dapo(response, label)
-        elif rm_type == "math":
-            return 1 if grade_answer_verl(response, label) else 0
-        elif rm_type == "mopd":
-            from .mopd import get_mopd_reward
-
-            return get_mopd_reward(response, label, metadata)
-        elif rm_type == "f1":
-            return f1_score(response, label)[0]
-        elif rm_type == "gpqa":
-            return compute_gpqa_reward(response, label, metadata=metadata)
-        elif rm_type == "ifbench":
-            from .ifbench import compute_ifbench_reward
-
-            return compute_ifbench_reward(response, label, metadata=metadata)
-        elif rm_type == "random":
-            return random.randint(0, 1)
-        else:
+        spec = REWARD_REGISTRY.get(rm_type)
+        if spec is None or spec.execution != "sync":
             raise NotImplementedError(f"RewardWorker: unknown rm_type={rm_type!r}")
+        return spec.handler(response, label, metadata or {})
 
 
 # ---------------------------------------------------------------------------
@@ -149,33 +117,6 @@ class RewardExecutor:
 
     # -- public API -----------------------------------------------------------
 
-    # Async rm_types run in the event loop (not dispatched to worker pool).
-    _ASYNC_RM_DISPATCH = {
-        "remote_rm": lambda args, sample: remote_rm(args, sample),
-        "dapo-genrm": lambda args, sample: async_compute_score_genrm(args, sample),
-        # `dummy` returns 0 without any computation. Use it when the real
-        # reward is produced elsewhere (e.g., --custom-reward-post-process-path
-        # does batched GenRM scoring after all rollout finishes).
-        "dummy": lambda args, sample: _dummy_reward(args),
-    }
-
-    # CPU-bound / thread-unsafe rm_types dispatched to the Ray worker pool.
-    _SYNC_RM_TYPES = frozenset(
-        {
-            "deepscaler",
-            "geo3k",
-            "openr1mm",
-            "multiple_choice",
-            "dapo",
-            "math",
-            "mopd",
-            "f1",
-            "gpqa",
-            "ifbench",
-            "random",
-        }
-    )
-
     async def execute(self, args, sample: Sample, **kwargs):
         """Execute a single reward computation with concurrency control.
 
@@ -193,28 +134,39 @@ class RewardExecutor:
                 return await rm_function(args, sample, **kwargs)
 
             metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
-            rm_type = (metadata.get("rm_type") or args.rm_type or "").strip()
+            route = resolve_reward_route(
+                metadata=metadata,
+                label=sample.label,
+                fallback_rm_type=getattr(args, "rm_type", None),
+                registry=REWARD_REGISTRY,
+            )
+            for warning in route.warnings:
+                logger.warning(warning)
+            if route.rm_type is None:
+                return await _dummy_reward(args, sample)
+
+            rm_type = route.rm_type
             response = sample.response
             label = sample.label
-            if rm_type.startswith("boxed_"):
+            if route.strip_boxed:
                 response = extract_boxed_answer(response) or ""
-                rm_type = rm_type[len("boxed_") :]
+
+            spec = REWARD_REGISTRY.get(rm_type)
+            if spec is None:
+                raise NotImplementedError(f"RewardExecutor: unknown rm_type={rm_type!r}")
 
             # --- async rm types: run in event loop -----------------------
-            async_handler = self._ASYNC_RM_DISPATCH.get(rm_type)
-            if async_handler is not None:
-                return await async_handler(args, sample)
+            if spec.execution == "async":
+                return await spec.handler(args, sample)
 
             # --- sync rm types: dispatch to worker pool ------------------
-            # Default to sync path for any non-empty rm_type not in async dispatch
-            if rm_type:
+            if spec.execution == "sync":
                 self._ensure_workers()
                 worker = self._next_worker()
                 ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
                 return await ref
 
-            # --- no rm_type specified -----------------------------------------
-            raise NotImplementedError("Rule-based RM type is not specified.")
+            raise NotImplementedError(f"RewardExecutor: unsupported execution mode for rm_type={rm_type!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +174,7 @@ class RewardExecutor:
 # ---------------------------------------------------------------------------
 
 
-async def _dummy_reward(args):
+async def _dummy_reward(args, sample: Sample | None = None):
     # No-op reward. Paired with --custom-reward-post-process-path when real
     # scoring is deferred to a post-rollout batch pass. Returns a dict when
     # reward_key is set so downstream sample.reward[reward_key] access does
@@ -252,6 +204,11 @@ async def remote_rm(args, sample: Sample, max_retries: int = 10):
             backoff = min(2**attempt, 30) + random.random()
             logger.info(f"remote_rm: {type(e).__name__}, retrying in {backoff:.1f}s ({attempt + 1}/{max_retries})")
             await asyncio.sleep(backoff)
+
+
+REWARD_REGISTRY.register("remote_rm", remote_rm, execution="async")
+REWARD_REGISTRY.register("dapo-genrm", async_compute_score_genrm, execution="async")
+REWARD_REGISTRY.register("dummy", _dummy_reward, execution="async")
 
 
 async def async_rm(args, sample: Sample, **kwargs):

--- a/relax/engine/rewards/registry.py
+++ b/relax/engine/rewards/registry.py
@@ -107,7 +107,10 @@ def resolve_reward_route(
         return RewardRoute(resolved_type, "metadata", strip_boxed=strip_boxed)
 
     raw_metadata_type = _normalize_rm_type(metadata_rm_type)
-    if "rm_type" in metadata_dict and metadata_rm_type not in (None, ""):
+    has_metadata_type = metadata_rm_type is not None and (
+        not isinstance(metadata_rm_type, str) or bool(raw_metadata_type)
+    )
+    if "rm_type" in metadata_dict and has_metadata_type:
         display_type = raw_metadata_type or metadata_rm_type
         warnings.append(f"Unknown metadata rm_type {display_type!r}; trying label routing and fallback.")
 

--- a/relax/engine/rewards/registry.py
+++ b/relax/engine/rewards/registry.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import random
+import re
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .deepscaler import get_deepscaler_rule_based_reward
+from .f1 import f1_score
+from .gpqa import compute_gpqa_reward
+from .math_dapo_utils import compute_score as compute_score_dapo
+from .math_utils import grade_answer_verl
+from .multiple_choice import get_multiple_choice_reward
+from .openr1mm import get_openr1mm_rule_based_reward
+
+
+LabelMatcher = Callable[[Any], bool]
+RouteSource = Literal["metadata", "label", "fallback", "unresolved"]
+ExecutionMode = Literal["sync", "async"]
+
+
+@dataclass(frozen=True)
+class RewardSpec:
+    handler: Callable[..., Any]
+    label_matcher: LabelMatcher | None = None
+    execution: ExecutionMode = "sync"
+
+
+@dataclass(frozen=True)
+class RewardRoute:
+    rm_type: str | None
+    source: RouteSource
+    strip_boxed: bool = False
+    warnings: tuple[str, ...] = ()
+
+
+class RewardRegistry:
+    """Registry for reward handlers and optional label matchers."""
+
+    def __init__(self):
+        self._specs: dict[str, RewardSpec] = {}
+
+    def register(
+        self,
+        rm_type: str,
+        handler: Callable[..., Any],
+        label_matcher: LabelMatcher | None = None,
+        execution: ExecutionMode = "sync",
+    ) -> None:
+        name = rm_type.strip()
+        if not name:
+            raise ValueError("Reward type must be a non-empty string.")
+        if name in self._specs:
+            raise ValueError(f"Reward type {name!r} is already registered.")
+        if execution not in ("sync", "async"):
+            raise ValueError(f"Unsupported reward execution mode: {execution!r}.")
+        self._specs[name] = RewardSpec(handler=handler, label_matcher=label_matcher, execution=execution)
+
+    def get(self, rm_type: str) -> RewardSpec | None:
+        return self._specs.get(rm_type)
+
+    def __contains__(self, rm_type: object) -> bool:
+        return rm_type in self._specs
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._specs)
+
+    def matching_types(self, label: Any) -> tuple[str, ...]:
+        return tuple(
+            rm_type
+            for rm_type, spec in self._specs.items()
+            if spec.label_matcher is not None and spec.label_matcher(label)
+        )
+
+
+def _normalize_rm_type(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _resolve_registered_type(
+    value: object,
+    registry: RewardRegistry,
+) -> tuple[str | None, bool]:
+    rm_type = _normalize_rm_type(value)
+    if not rm_type:
+        return None, False
+
+    strip_boxed = rm_type.startswith("boxed_")
+    base_type = rm_type[len("boxed_") :] if strip_boxed else rm_type
+    if base_type in registry:
+        return base_type, strip_boxed
+    return None, strip_boxed
+
+
+def resolve_reward_route(
+    metadata: object,
+    label: object,
+    fallback_rm_type: object,
+    registry: RewardRegistry,
+) -> RewardRoute:
+    warnings = []
+    metadata_dict = metadata if isinstance(metadata, dict) else {}
+    metadata_rm_type = metadata_dict.get("rm_type")
+    resolved_type, strip_boxed = _resolve_registered_type(metadata_rm_type, registry)
+    if resolved_type is not None:
+        return RewardRoute(resolved_type, "metadata", strip_boxed=strip_boxed)
+
+    raw_metadata_type = _normalize_rm_type(metadata_rm_type)
+    if "rm_type" in metadata_dict and metadata_rm_type not in (None, ""):
+        display_type = raw_metadata_type or metadata_rm_type
+        warnings.append(f"Unknown metadata rm_type {display_type!r}; trying label routing and fallback.")
+
+    matching_types = registry.matching_types(label)
+    if len(matching_types) > 1:
+        warnings.append(f"Conflicting reward types inferred from label: {', '.join(matching_types)}.")
+
+    fallback_type, fallback_strip_boxed = _resolve_registered_type(
+        fallback_rm_type,
+        registry,
+    )
+    if fallback_type is not None:
+        return RewardRoute(
+            fallback_type,
+            "fallback",
+            strip_boxed=fallback_strip_boxed,
+            warnings=tuple(warnings),
+        )
+
+    raw_fallback_type = _normalize_rm_type(fallback_rm_type)
+    if raw_fallback_type:
+        warnings.append(f"Unknown fallback rm_type {raw_fallback_type!r}.")
+    if len(matching_types) == 1:
+        return RewardRoute(matching_types[0], "label", warnings=tuple(warnings))
+
+    warnings.append("Unable to resolve a reward type; returning a zero reward.")
+    return RewardRoute(None, "unresolved", warnings=tuple(warnings))
+
+
+_MULTIPLE_CHOICE_LABEL = re.compile(r"<answer>\s*[A-Za-z]\s*</answer>", re.DOTALL)
+_NUMERIC_LABEL = re.compile(
+    r"""
+    [+-]?
+    (?:
+        (?:\d[\d,]*)(?:\.\d+)?
+        |
+        (?:\d[\d,]*)?\.\d+
+    )
+    (?:\s*/\s*[+-]?\d[\d,]*(?:\.\d+)?)?
+    """,
+    re.VERBOSE,
+)
+_LATEX_FRACTION_LABEL = re.compile(r"\\(?:d)?frac\{[+-]?\d+\}\{[+-]?\d+\}")
+
+
+def _is_multiple_choice_label(label: Any) -> bool:
+    return isinstance(label, str) and _MULTIPLE_CHOICE_LABEL.fullmatch(label.strip()) is not None
+
+
+def _is_math_label(label: Any) -> bool:
+    if not isinstance(label, (str, int, float)) or isinstance(label, bool):
+        return False
+    text = str(label).strip()
+    if text.startswith("\\boxed{") and text.endswith("}"):
+        text = text[len("\\boxed{") : -1].strip()
+    return _NUMERIC_LABEL.fullmatch(text) is not None or _LATEX_FRACTION_LABEL.fullmatch(text) is not None
+
+
+def _deepscaler_reward(response: str, label: Any, metadata: dict) -> Any:
+    return get_deepscaler_rule_based_reward(response, label)
+
+
+def _geo3k_reward(response: str, label: Any, metadata: dict) -> Any:
+    from .geo3k import get_geo3k_reward
+
+    return get_geo3k_reward(response, label)
+
+
+def _openr1mm_reward(response: str, label: Any, metadata: dict) -> Any:
+    return get_openr1mm_rule_based_reward(response, label)
+
+
+def _multiple_choice_reward(response: str, label: Any, metadata: dict) -> Any:
+    return get_multiple_choice_reward(response, label)
+
+
+def _dapo_reward(response: str, label: Any, metadata: dict) -> Any:
+    return compute_score_dapo(response, label)
+
+
+def _math_reward(response: str, label: Any, metadata: dict) -> Any:
+    return 1 if grade_answer_verl(response, label) else 0
+
+
+def _mopd_reward(response: str, label: Any, metadata: dict) -> Any:
+    from .mopd import get_mopd_reward
+
+    return get_mopd_reward(response, label, metadata)
+
+
+def _f1_reward(response: str, label: Any, metadata: dict) -> Any:
+    return f1_score(response, label)[0]
+
+
+def _gpqa_reward(response: str, label: Any, metadata: dict) -> Any:
+    return compute_gpqa_reward(response, label, metadata=metadata)
+
+
+def _ifbench_reward(response: str, label: Any, metadata: dict) -> Any:
+    from .ifbench import compute_ifbench_reward
+
+    return compute_ifbench_reward(response, label, metadata=metadata)
+
+
+def _random_reward(response: str, label: Any, metadata: dict) -> Any:
+    return random.randint(0, 1)
+
+
+REWARD_REGISTRY = RewardRegistry()
+REWARD_REGISTRY.register("deepscaler", _deepscaler_reward)
+REWARD_REGISTRY.register("geo3k", _geo3k_reward)
+REWARD_REGISTRY.register("openr1mm", _openr1mm_reward)
+REWARD_REGISTRY.register("multiple_choice", _multiple_choice_reward, _is_multiple_choice_label)
+REWARD_REGISTRY.register("dapo", _dapo_reward)
+REWARD_REGISTRY.register("math", _math_reward, _is_math_label)
+REWARD_REGISTRY.register("mopd", _mopd_reward)
+REWARD_REGISTRY.register("f1", _f1_reward)
+REWARD_REGISTRY.register("gpqa", _gpqa_reward)
+REWARD_REGISTRY.register("ifbench", _ifbench_reward)
+REWARD_REGISTRY.register("random", _random_reward)

--- a/tests/engine/rewards/test_reward_router.py
+++ b/tests/engine/rewards/test_reward_router.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import pytest
+
+from relax.engine.rewards.registry import (
+    REWARD_REGISTRY,
+    RewardRegistry,
+    resolve_reward_route,
+)
+
+
+def _constant_reward(response: str, label: object, metadata: dict) -> float:
+    return 1.0
+
+
+def test_registry_registers_reward_without_router_changes():
+    registry = RewardRegistry()
+
+    registry.register("custom", _constant_reward)
+
+    spec = registry.get("custom")
+    assert spec is not None
+    assert spec.handler("response", "label", {}) == 1.0
+    route = resolve_reward_route({}, None, "custom", registry)
+    assert route.rm_type == "custom"
+    assert route.source == "fallback"
+
+
+def test_registry_rejects_duplicate_reward_type():
+    registry = RewardRegistry()
+    registry.register("custom", _constant_reward)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("custom", _constant_reward)
+
+
+def test_registry_rejects_unknown_execution_mode():
+    registry = RewardRegistry()
+
+    with pytest.raises(ValueError, match="Unsupported reward execution mode"):
+        registry.register("custom", _constant_reward, execution="thread")
+
+
+def test_metadata_route_has_highest_priority():
+    route = resolve_reward_route(
+        metadata={"rm_type": "math"},
+        label="<answer>B</answer>",
+        fallback_rm_type="multiple_choice",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "math"
+    assert route.source == "metadata"
+    assert route.warnings == ()
+
+
+def test_unknown_metadata_type_uses_unique_label_match():
+    route = resolve_reward_route(
+        metadata={"rm_type": "unknown"},
+        label="<answer>B</answer>",
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "multiple_choice"
+    assert route.source == "label"
+    assert "Unknown metadata rm_type" in route.warnings[0]
+
+
+def test_unknown_metadata_type_uses_configured_fallback_and_warns():
+    route = resolve_reward_route(
+        metadata={"rm_type": 123},
+        label="free-form answer",
+        fallback_rm_type="math",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "math"
+    assert route.source == "fallback"
+    assert "Unknown metadata rm_type" in route.warnings[0]
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["42", "-3.5", "1 / 2", "\\frac{1}{2}", "\\boxed{7}", "\\boxed{\\frac{1}{2}}", 12, 0.5],
+)
+def test_math_label_matcher_routes_unambiguous_labels(label):
+    route = resolve_reward_route(
+        metadata={},
+        label=label,
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "math"
+    assert route.source == "label"
+
+
+def test_multiple_choice_label_matcher_requires_answer_tag():
+    tagged_route = resolve_reward_route(
+        metadata={},
+        label="<answer> B </answer>",
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+    bare_route = resolve_reward_route(
+        metadata={},
+        label="B",
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert tagged_route.rm_type == "multiple_choice"
+    assert tagged_route.source == "label"
+    assert bare_route.rm_type is None
+    assert bare_route.source == "unresolved"
+
+
+@pytest.mark.parametrize("label", ["\\boxed{B}", "\\boxed{Paris}", True])
+def test_math_label_matcher_rejects_non_math_boxed_and_boolean_labels(label):
+    route = resolve_reward_route(
+        metadata={},
+        label=label,
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type is None
+    assert route.source == "unresolved"
+
+
+def test_explicit_fallback_takes_priority_over_label_match():
+    route = resolve_reward_route(
+        metadata={},
+        label="<answer>C</answer>",
+        fallback_rm_type="math",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "math"
+    assert route.source == "fallback"
+
+
+@pytest.mark.parametrize("rm_type", ["dapo", "dapo-genrm", "dummy", "remote_rm", "openr1mm"])
+def test_explicit_reward_type_is_not_overridden_by_numeric_label(rm_type):
+    route = resolve_reward_route(
+        metadata={},
+        label="42",
+        fallback_rm_type=rm_type,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == rm_type
+    assert route.source == "fallback"
+
+
+def test_missing_label_match_uses_valid_fallback_without_warning():
+    route = resolve_reward_route(
+        metadata={},
+        label="free-form answer",
+        fallback_rm_type="openr1mm",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "openr1mm"
+    assert route.source == "fallback"
+    assert route.warnings == ()
+
+
+def test_conflicting_label_matches_use_fallback_and_warn():
+    registry = RewardRegistry()
+    registry.register("first", _constant_reward, lambda label: label == "conflict")
+    registry.register("second", _constant_reward, lambda label: label == "conflict")
+    registry.register("fallback", _constant_reward)
+
+    route = resolve_reward_route(
+        metadata={},
+        label="conflict",
+        fallback_rm_type="fallback",
+        registry=registry,
+    )
+
+    assert route.rm_type == "fallback"
+    assert route.source == "fallback"
+    assert "Conflicting reward types" in route.warnings[0]
+
+
+def test_conflicting_label_matches_without_fallback_are_unresolved():
+    registry = RewardRegistry()
+    registry.register("first", _constant_reward, lambda label: label == "conflict")
+    registry.register("second", _constant_reward, lambda label: label == "conflict")
+
+    route = resolve_reward_route(
+        metadata={},
+        label="conflict",
+        fallback_rm_type=None,
+        registry=registry,
+    )
+
+    assert route.rm_type is None
+    assert route.source == "unresolved"
+    assert "Conflicting reward types" in route.warnings[0]
+    assert "returning a zero reward" in route.warnings[-1]
+
+
+@pytest.mark.parametrize(
+    ("metadata", "label", "fallback"),
+    [
+        ({}, None, None),
+        (None, {}, None),
+        ({"rm_type": 123}, "free-form answer", None),
+        ({}, "free-form answer", "unknown"),
+    ],
+)
+def test_unresolved_route_returns_zero_target_and_warning(metadata, label, fallback):
+    route = resolve_reward_route(
+        metadata=metadata,
+        label=label,
+        fallback_rm_type=fallback,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type is None
+    assert route.source == "unresolved"
+    assert "returning a zero reward" in route.warnings[-1]
+
+
+def test_boxed_metadata_and_fallback_keep_compatibility():
+    metadata_route = resolve_reward_route(
+        metadata={"rm_type": "boxed_math"},
+        label="free-form answer",
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+    fallback_route = resolve_reward_route(
+        metadata={},
+        label="42",
+        fallback_rm_type="boxed_math",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert metadata_route.rm_type == "math"
+    assert metadata_route.strip_boxed is True
+    assert fallback_route.rm_type == "math"
+    assert fallback_route.strip_boxed is True
+
+
+def test_async_reward_type_is_registered_for_metadata_routing():
+    route = resolve_reward_route(
+        metadata={"rm_type": "remote_rm"},
+        label=None,
+        fallback_rm_type=None,
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "remote_rm"
+    assert route.source == "metadata"
+    spec = REWARD_REGISTRY.get("remote_rm")
+    assert spec is not None
+    assert spec.execution == "async"
+
+
+def test_async_reward_type_can_be_used_as_fallback():
+    route = resolve_reward_route(
+        metadata={},
+        label=None,
+        fallback_rm_type="remote_rm",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "remote_rm"
+    assert route.source == "fallback"
+
+
+def test_mixed_math_and_multiple_choice_batch_routes_per_sample():
+    samples = [
+        ({}, "42"),
+        ({}, "<answer>A</answer>"),
+        ({"rm_type": "math"}, "<answer>B</answer>"),
+        ({"rm_type": "multiple_choice"}, "not inferable"),
+    ]
+
+    routes = [
+        resolve_reward_route(
+            metadata=metadata,
+            label=label,
+            fallback_rm_type=None,
+            registry=REWARD_REGISTRY,
+        )
+        for metadata, label in samples
+    ]
+
+    assert [route.rm_type for route in routes] == [
+        "math",
+        "multiple_choice",
+        "math",
+        "multiple_choice",
+    ]

--- a/tests/engine/rewards/test_reward_router.py
+++ b/tests/engine/rewards/test_reward_router.py
@@ -80,6 +80,19 @@ def test_unknown_metadata_type_uses_configured_fallback_and_warns():
     assert "Unknown metadata rm_type" in route.warnings[0]
 
 
+def test_whitespace_metadata_type_is_treated_as_missing():
+    route = resolve_reward_route(
+        metadata={"rm_type": " \t\n "},
+        label="free-form answer",
+        fallback_rm_type="math",
+        registry=REWARD_REGISTRY,
+    )
+
+    assert route.rm_type == "math"
+    assert route.source == "fallback"
+    assert route.warnings == ()
+
+
 @pytest.mark.parametrize(
     "label",
     ["42", "-3.5", "1 / 2", "\\frac{1}{2}", "\\boxed{7}", "\\boxed{\\frac{1}{2}}", 12, 0.5],

--- a/tests/engine/rewards/test_reward_worker.py
+++ b/tests/engine/rewards/test_reward_worker.py
@@ -310,11 +310,45 @@ class TestRewardExecutorSingleSample:
         assert result == 1.0
 
     @pytest.mark.asyncio
-    async def test_execute_unknown_rm_type_raises(self):
+    async def test_execute_unknown_rm_type_returns_zero(self, caplog):
         args = _make_args(rm_type="totally_unknown_type")
         sample = _make_sample(response="foo", label="bar")
-        with pytest.raises(NotImplementedError, match="totally_unknown_type"):
-            await async_rm(args, sample)
+        result = await async_rm(args, sample)
+
+        assert result == 0.0
+        assert "Unknown fallback rm_type" in caplog.text
+        assert "returning a zero reward" in caplog.text
+        assert RewardExecutor._instance is not None
+        assert RewardExecutor._instance._workers == []
+
+    @pytest.mark.asyncio
+    async def test_unresolved_route_preserves_reward_key_shape(self, caplog):
+        args = _make_args(rm_type="totally_unknown_type", reward_key="score")
+        sample = _make_sample(response="foo", label="bar")
+
+        result = await async_rm(args, sample)
+
+        assert result == {"score": 0.0}
+        assert "returning a zero reward" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_explicit_dapo_type_is_not_overridden_by_numeric_label(self):
+        args = _make_args(rm_type="dapo")
+        sample = _make_sample(response="The final answer is \\boxed{42}", label="42")
+
+        result = await async_rm(args, sample)
+
+        assert isinstance(result, dict)
+        assert "score" in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_dummy_type_is_not_overridden_by_numeric_label(self):
+        args = _make_args(rm_type="dummy", reward_key="score")
+        sample = _make_sample(response="unused", label="42")
+
+        result = await async_rm(args, sample)
+
+        assert result == {"score": 0.0}
 
 
 @requires_full_pipeline
@@ -353,6 +387,32 @@ class TestBatchedAsyncRM:
         args = _make_args()
         rewards = await batched_async_rm(args, [])
         assert rewards == []
+
+
+@requires_full_pipeline
+class TestRewardRoutingIntegration:
+    @pytest.fixture(autouse=True)
+    def _reset_executor(self):
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+        yield
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+
+    @pytest.mark.asyncio
+    async def test_mixed_rm_types_inferred_from_labels(self):
+        args = _make_args(rm_type=None)
+        samples = [
+            _make_sample(response="\\boxed{42}", label="42"),
+            _make_sample(response="<answer>B</answer>", label="<answer>B</answer>"),
+        ]
+
+        rewards = await asyncio.wait_for(
+            batched_async_rm(args, samples),
+            timeout=60,
+        )
+
+        assert list(rewards) == [1, 1.0]
 
 
 # ===========================================================================
@@ -441,7 +501,11 @@ class TestHighConcurrency:
             _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
             _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
             _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
-            _make_sample(response="A", label="A", metadata={"rm_type": "multiple_choice"}),
+            _make_sample(
+                response="<answer>A</answer>",
+                label="<answer>A</answer>",
+                metadata={"rm_type": "multiple_choice"},
+            ),
         ]
         rewards = await asyncio.wait_for(
             batched_async_rm(args, samples),
@@ -449,7 +513,6 @@ class TestHighConcurrency:
         )
         rewards = list(rewards)
         assert len(rewards) == len(samples)
-        # All three should be correct (1.0)
         assert all(r == 1.0 for r in rewards), f"Got {rewards}"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

This PR implements Task 18: a format-aware reward router for mixed-task batches.
Relates to #97 (Task 18: Format-aware reward router).

- Add a unified registry for synchronous and asynchronous reward handlers.
- Support per-sample routing through `metadata["rm_type"]`.
- Infer math and multiple-choice reward types through strict label matchers when no explicit type is configured.
- Preserve the existing explicit `--rm-type` behavior.
- Support configured fallback, reward-key-aware zero rewards, and readable warnings.
- Replace the synchronous RewardWorker `if/elif` dispatch with registry lookup.
- Add unit and integration tests for routing, fallback, conflicts, registry extension, and mixed batches.

Routing precedence:

```text
valid metadata["rm_type"]
    → valid explicit --rm-type
    → exactly one matching label matcher
    → reward-key-aware zero + warning
```
## Why

A single global `--rm-type` cannot route samples from different task formats in the same batch. For example, a mixed batch may contain both numeric math answers and multiple-choice answers formatted as `<answer>B</answer>`.

The previous RewardWorker also used a hard-coded `if/elif` dispatch chain, so adding a built-in reward required modifying routing branches.

This change provides per-sample routing and a registry-based extension point while preserving existing training behavior.

Explicit `--rm-type` remains ahead of label inference for backward compatibility. Otherwise, numeric labels used by existing DAPO, GenRM, dummy, remote RM, or OpenR1MM jobs could be incorrectly routed to the scalar math reward and change the expected reward output schema.


## How

A `RewardRegistry` stores:

- the reward handler;
- its execution mode (`sync` or `async`);
- an optional label matcher.

`resolve_reward_route()` is a side-effect-free routing function. It returns a structured result containing:

- the selected reward type;
- the routing source;
- whether `boxed_` preprocessing is required;
- warning messages for unknown, missing, or conflicting types.

The RewardExecutor records returned warnings and then:

- executes asynchronous handlers in the event loop;
- dispatches synchronous handlers to the existing RewardWorker pool;
- returns a scalar zero or `{reward_key: 0.0}` if no valid route exists.

Only math and multiple-choice currently define label matchers:

- math: strict numeric, fractional, or supported LaTeX fraction formats;
- multiple-choice: tagged answers such as `<answer>B</answer>`.

Ambiguous labels such as bare `B` and non-math values such as `\boxed{Paris}` are not inferred automatically.

This PR does not change worker count, semaphore behavior, round-robin scheduling, batching, or other Task 19 concurrency behavior.

## Testing

Environment:

- Image: `ghcr.io/redai-infra/relaxrl:dev-20260715-8325919e`
- Python: 3.12.3
- CUDA: 12.9

Commands:

```
python -m pytest -q tests/engine/rewards/
pre-commit run --all-files --show-diff-on-failure
git diff --check
```

Results:

```
79 passed in 66.37s
All pre-commit hooks passed
git diff --check passed
```

Coverage includes:

- metadata routing;

- explicit `--rm-type` compatibility;

- strict math and multiple-choice label routing;

- mixed math and multiple-choice batches;

- unknown, missing, and conflicting types;

- configured fallback and zero-reward handling;

- `reward_key` output-shape compatibility;

- registry extension and duplicate validation;

- synchronous and asynchronous handlers;

- `boxed_` compatibility;

- DAPO, GenRM, dummy, remote RM, and OpenR1MM routing guards.

-   `pre-commit run --all-files` passes

-   Relevant tests pass (`python -m pytest -q tests/engine/rewards/`)

-   New tests added

## Type of Change

-   New feature (non-breaking change that adds functionality)
