### PR TITLE
feat(rewards): run sync custom rewards in RewardWorker pool

### DIFF
--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -420,7 +420,9 @@ SFT also uses the general dataset flags from [Data Configuration](#data-configur
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--rm-type` | str | None | Built-in reward model type |
-| `--custom-rm-path` | str | None | Custom reward function path. Function signature: `def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | Custom reward function path. Supports sync `def` (Ray Worker), `async def` (Driver await), and group `list[Sample]` |
+| `--reward-max-concurrency` | int | 64 | Logical concurrency cap for rewards (including custom sync/async) |
+| `--reward-num-workers` | int | 16 | Number of Ray Workers for sync rewards (including sync custom) |
 | `--reward-key` | str | None | Key to extract reward value when reward function returns dict |
 | `--eval-reward-key` | str | None | Reward key for evaluation. When None, equals `--reward-key` |
 | `--group-rm` | flag | False | Whether to compute reward for entire group |

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -145,6 +145,7 @@ Notes:
 - Only `async def` callables recognized by `inspect.iscoroutinefunction` take the async path; a sync function that returns an awaitable raises an error.
 - Sync custom rewards see only a whitelist view of args (e.g. `custom_rm_path` / `rm_type` / `reward_key`) plus explicit `custom_options`; do not rely on full training `Namespace` objects such as models or tokenizers.
 - Use `functools.wraps` on decorators so async detection keeps working.
+- Hot-reload of `custom_rm` (`ReloadScope.IMMEDIATE`) takes effect on the next call when a `RolloutManager` has bound the generation provider; paths without that bind keep generation `0` and do not claim automatic reload propagation.
 
 ## Custom Generate Function
 

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -116,13 +116,35 @@ python scripts/tools/process_avqa.py \
 
 ## Custom Reward Methods
 
-You can define `reward_func(args, sample: Sample, **kwargs) -> float` in your own `.py` file, then add it to your task launch script. See [DeepEyes](../examples/deepeyes.md) for a concrete example.
+Define a reward function in your own `.py` file and wire it with `--custom-rm-path`. See [DeepEyes](../examples/deepeyes.md) for a concrete example.
+
+Supported signatures:
+
+```python
+# Sync: runs in an isolated Ray RewardWorker process (does not block the rollout event loop)
+def reward_func(args, sample: Sample, **kwargs) -> float | dict: ...
+
+# Async: awaited directly on the Driver event loop (good for HTTP / I/O)
+async def async_reward_func(args, sample: Sample, **kwargs) -> float | dict: ...
+
+# Group: receives list[Sample] and returns a same-length list (legacy batched_async_rm / --group-rm)
+def group_reward_func(args, samples: list[Sample], **kwargs) -> list[float | dict]: ...
+```
 
 ```bash
 --custom-rm-path examples.deepeyes.reward_deepeyes.reward_func
 # Custom reward_func may return a dict; if so, specify which key corresponds to the actual reward score
 --reward-key score
+# Concurrency: logical cap and sync worker count
+--reward-max-concurrency 64
+--reward-num-workers 16
 ```
+
+Notes:
+
+- Only `async def` callables recognized by `inspect.iscoroutinefunction` take the async path; a sync function that returns an awaitable raises an error.
+- Sync custom rewards see only a whitelist view of args (e.g. `custom_rm_path` / `rm_type` / `reward_key`) plus explicit `custom_options`; do not rely on full training `Namespace` objects such as models or tokenizers.
+- Use `functools.wraps` on decorators so async detection keeps working.
 
 ## Custom Generate Function
 

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -143,7 +143,7 @@ def group_reward_func(args, samples: list[Sample], **kwargs) -> list[float | dic
 Notes:
 
 - Only `async def` callables recognized by `inspect.iscoroutinefunction` take the async path; a sync function that returns an awaitable raises an error.
-- Sync custom rewards see only a whitelist view of args (e.g. `custom_rm_path` / `rm_type` / `reward_key`) plus explicit `custom_options`; do not rely on full training `Namespace` objects such as models or tokenizers.
+- Sync custom rewards see a whitelist view of args (`custom_rm_path` / `rm_type` / `reward_key` / …) plus JSON-ish scalar fields auto-copied from training `args`, with explicit `custom_options` winning on conflicts. Models, tokenizers, and other non-serializable objects are never copied; pass extras via `custom_options` when needed.
 - Use `functools.wraps` on decorators so async detection keeps working.
 - Hot-reload of `custom_rm` (`ReloadScope.IMMEDIATE`) takes effect on the next call when a `RolloutManager` has bound the generation provider; paths without that bind keep generation `0` and do not claim automatic reload propagation.
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -420,7 +420,9 @@ SFT 还会用到通用的[数据配置](#数据配置)参数，特别是 `--inpu
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `--rm-type` | str | None | 内置 Reward 模型类型 |
-| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。函数签名：`def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。支持 sync `def`（Ray Worker 进程）、`async def`（Driver await）、以及 group `list[Sample]` 入参 |
+| `--reward-max-concurrency` | int | 64 | Reward 逻辑并发上限（含 custom sync/async） |
+| `--reward-num-workers` | int | 16 | 同步 Reward（含 sync custom）使用的 Ray Worker 数量 |
 | `--reward-key` | str | None | Reward 函数返回 dict 时提取 reward 值的 key |
 | `--eval-reward-key` | str | None | 评估时的 reward key。None 时等于 `--reward-key` |
 | `--group-rm` | flag | False | 是否对整个 group 做 Reward 计算 |

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -115,13 +115,35 @@ python scripts/tools/process_avqa.py \
 
 ## 自定义 Reward 方法
 
-您可以在自己的 `.py` 文件内定义 `reward_func(args, sample: Sample, **kwargs) -> float`，然后在任务启动脚本内加入调用即可，具体使用可参考 [DeepEyes](../examples/deepeyes.md)。
+您可以在自己的 `.py` 文件内定义 reward 函数，然后通过 `--custom-rm-path` 接入。具体使用可参考 [DeepEyes](../examples/deepeyes.md)。
+
+支持的签名：
+
+```python
+# 同步：在独立 Ray RewardWorker 进程中执行，不阻塞 Rollout event loop
+def reward_func(args, sample: Sample, **kwargs) -> float | dict: ...
+
+# 异步：在 Driver event loop 中直接 await（适合 HTTP / I/O）
+async def async_reward_func(args, sample: Sample, **kwargs) -> float | dict: ...
+
+# Group：一次接收 list[Sample]，返回等长 list（legacy batched_async_rm / --group-rm）
+def group_reward_func(args, samples: list[Sample], **kwargs) -> list[float | dict]: ...
+```
 
 ```bash
 --custom-rm-path examples.deepeyes.reward_deepeyes.reward_func
 # 自定义 reward_func 允许返回 dict，但若如此您需要明确哪个 key 对应于实际的 reward 得分
 --reward-key score
+# 并发：逻辑上限与 sync Worker 数量
+--reward-max-concurrency 64
+--reward-num-workers 16
 ```
+
+说明：
+
+- 仅 `async def`（可被 `inspect.iscoroutinefunction` 识别）走异步路径；同步函数即使返回 awaitable 也会报错。
+- Sync custom 在 Worker 中只能看到白名单字段（如 `custom_rm_path` / `rm_type` / `reward_key` 等）以及调用方显式传入的 `custom_options`；不要依赖完整训练 `Namespace` 中的模型、Tokenizer 等对象。
+- 装饰器请使用 `functools.wraps`，否则可能无法正确识别 async。
 
 ## 自定义 Generate 函数
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -144,6 +144,7 @@ def group_reward_func(args, samples: list[Sample], **kwargs) -> list[float | dic
 - 仅 `async def`（可被 `inspect.iscoroutinefunction` 识别）走异步路径；同步函数即使返回 awaitable 也会报错。
 - Sync custom 在 Worker 中只能看到白名单字段（如 `custom_rm_path` / `rm_type` / `reward_key` 等）以及调用方显式传入的 `custom_options`；不要依赖完整训练 `Namespace` 中的模型、Tokenizer 等对象。
 - 装饰器请使用 `functools.wraps`，否则可能无法正确识别 async。
+- `custom_rm` 热重载（`ReloadScope.IMMEDIATE`）在 `RolloutManager` 已绑定 generation provider 时，于**下一次**调用生效；未绑定路径 generation 固定为 `0`，不宣称自动传播热重载。
 
 ## 自定义 Generate 函数
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -142,7 +142,7 @@ def group_reward_func(args, samples: list[Sample], **kwargs) -> list[float | dic
 说明：
 
 - 仅 `async def`（可被 `inspect.iscoroutinefunction` 识别）走异步路径；同步函数即使返回 awaitable 也会报错。
-- Sync custom 在 Worker 中只能看到白名单字段（如 `custom_rm_path` / `rm_type` / `reward_key` 等）以及调用方显式传入的 `custom_options`；不要依赖完整训练 `Namespace` 中的模型、Tokenizer 等对象。
+- Sync custom 在 Worker 中能看到白名单字段（如 `custom_rm_path` / `rm_type` / `reward_key` 等），以及从训练 `args` 自动拷贝的 JSON 标量字段；显式 `custom_options` 同名时优先。模型、Tokenizer 等不可序列化对象不会传入；需要时请用 `custom_options`。
 - 装饰器请使用 `functools.wraps`，否则可能无法正确识别 async。
 - `custom_rm` 热重载（`ReloadScope.IMMEDIATE`）在 `RolloutManager` 已绑定 generation provider 时，于**下一次**调用生效；未绑定路径 generation 固定为 `0`，不宣称自动传播热重载。
 

--- a/relax/agentic/pipeline/reward.py
+++ b/relax/agentic/pipeline/reward.py
@@ -31,26 +31,19 @@ def _effective_reward_concurrency(args, *, explicit_limit: int | None = None) ->
 
 
 async def _async_rm(args, sample):
-    custom_rm_path = args.custom_rm_path
-    if custom_rm_path:
-        from relax.utils.utils import load_function
+    from relax.engine.rewards import async_rm, get_reward_executor
 
-        rm_function = load_function(custom_rm_path)
-        return await rm_function(args, sample)
-    from relax.engine.rewards import async_rm
-
+    if args.custom_rm_path:
+        # RewardDomain already owns the concurrency semaphore; do not acquire again.
+        return await get_reward_executor(args).dispatch_custom_sample(args, sample)
     return await async_rm(args, sample)
 
 
 async def _batched_async_rm(args, samples):
-    custom_rm_path = args.custom_rm_path
-    if custom_rm_path:
-        from relax.utils.utils import load_function
+    from relax.engine.rewards import batched_async_rm, get_reward_executor
 
-        rm_function = load_function(custom_rm_path)
-        return await rm_function(args, samples)
-    from relax.engine.rewards import batched_async_rm
-
+    if args.custom_rm_path:
+        return await get_reward_executor(args).dispatch_custom_group(args, samples)
     return await batched_async_rm(args, samples)
 
 

--- a/relax/distributed/ray/rollout.py
+++ b/relax/distributed/ray/rollout.py
@@ -48,7 +48,7 @@ from relax.utils.metrics.metric_utils import (
 from relax.utils.misc import group_by, load_function
 from relax.utils.multimodal.stats import get_sample_multimodal_stats
 from relax.utils.opd.opd_utils import compute_mopd_metrics
-from relax.utils.reload_utils import ReloadableMixin
+from relax.utils.reload_utils import ReloadableMixin, ReloadGenerationRegistry
 from relax.utils.tracking_utils import init_tracking
 from relax.utils.training.train_dump_utils import (
     save_debug_rollout_data,
@@ -794,6 +794,7 @@ class RolloutManager(ReloadableMixin):
         self.pg = pg
         self.args = args
         self._dynamic_global_batch_size = None
+        self._reload_generations = ReloadGenerationRegistry()
 
         init_tracking(args, primary=False)
 
@@ -875,6 +876,11 @@ class RolloutManager(ReloadableMixin):
         self._eviction_check_interval = getattr(args, "eviction_check_interval", 10.0)
         if not self.args.debug_train_only:
             self._start_eviction_monitor()
+
+        # Bind custom_rm reload generation provider after init, before serving requests.
+        from relax.engine.rewards import get_reward_executor
+
+        get_reward_executor(self.args).bind_generation_provider(self._reload_generations.current)
 
     def _try_ci_fault_injection(self):
         """Try to inject fault during generate (when health monitor is

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -1,13 +1,25 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
+from __future__ import annotations
+
 import asyncio
+import inspect
 import random
+from typing import Any, Callable
 
 import aiohttp
 import ray
 
+from relax.engine.rewards.custom_reward import (
+    IMPLEMENTATION_VERSION,
+    CustomRewardError,
+    CustomRewardResolver,
+    RewardWorkerConfig,
+    WorkerConfigFingerprint,
+    build_reward_worker_config,
+    wrap_custom_reward_error,
+)
 from relax.utils.logging_utils import get_logger
-from relax.utils.misc import load_function
 from relax.utils.types import Sample
 
 from .dapo_genrm import async_compute_score_genrm
@@ -24,6 +36,8 @@ from .openr1mm import get_openr1mm_rule_based_reward
 logger = get_logger(__name__)
 _shared_session: aiohttp.ClientSession | None = None
 
+_CUSTOM_KWARG_KEYS = frozenset({"custom_options", "ignore_custom"})
+
 
 def _get_shared_session() -> aiohttp.ClientSession:
     global _shared_session
@@ -37,32 +51,55 @@ def _get_shared_session() -> aiohttp.ClientSession:
     return _shared_session
 
 
+class _StaticGenerationProvider:
+    def __init__(self, generation: int = 0):
+        self._generation = generation
+
+    def __call__(self, module_name: str = "custom_rm", module_path: str | None = None) -> int:
+        return self._generation
+
+
+def get_reward_executor(args) -> "RewardExecutor":
+    """Return the process-wide RewardExecutor for the given training args."""
+    max_concurrency = getattr(args, "reward_max_concurrency", None)
+    if max_concurrency is None or max_concurrency <= 0:
+        max_concurrency = 64
+    num_workers = getattr(args, "reward_num_workers", None)
+    if num_workers is None or num_workers <= 0:
+        num_workers = 16
+    return RewardExecutor.get_or_create(
+        max_concurrency=max_concurrency,
+        num_workers=num_workers,
+    )
+
+
 # ---------------------------------------------------------------------------
 # RewardWorker: Ray Actor for process-isolated reward computation
-# ---------------------------------------------------------------------------
-# Solves three problems at once:
-# 1. CPU-intensive reward functions no longer block the async event loop.
-# 2. Thread-unsafe libraries (e.g. math_verify) are safely isolated inside
-#    their own process – each Actor is single-threaded by default.
-# 3. Global concurrency is bounded by the number of workers in the pool
-#    combined with the asyncio.Semaphore in batched_async_rm.
 # ---------------------------------------------------------------------------
 
 
 @ray.remote(num_cpus=0.25)
 class RewardWorker:
-    """Stateless worker that executes synchronous reward functions in a
-    dedicated process.
+    """Worker that executes synchronous reward functions in a dedicated
+    process."""
 
-    Each call receives the rm_type and the necessary arguments so the worker
-    does not need to hold any state.
-    """
+    def __init__(self):
+        self._fingerprint: dict[str, Any] | None = None
+        self._custom_resolver = CustomRewardResolver()
+        self._loaded_generation_by_path: dict[str, int] = {}
+
+    def ensure_fingerprint(self, fingerprint: dict[str, Any]) -> dict[str, Any]:
+        if self._fingerprint is None:
+            self._fingerprint = dict(fingerprint)
+            return self._fingerprint
+        if self._fingerprint != fingerprint:
+            raise RuntimeError(
+                f"RewardWorker fingerprint mismatch: existing={self._fingerprint}, requested={fingerprint}"
+            )
+        return self._fingerprint
 
     def compute(self, rm_type: str, response: str, label, metadata: dict | None = None):
-        """Dispatch to the appropriate synchronous reward function.
-
-        Returns the same value the original function would return.
-        """
+        """Dispatch to the appropriate synchronous built-in reward function."""
         if rm_type == "deepscaler":
             return get_deepscaler_rule_based_reward(response, label)
         elif rm_type == "geo3k":
@@ -94,6 +131,29 @@ class RewardWorker:
         else:
             raise NotImplementedError(f"RewardWorker: unknown rm_type={rm_type!r}")
 
+    def compute_custom(
+        self,
+        *,
+        path: str,
+        generation: int,
+        worker_config: RewardWorkerConfig,
+        payload: Sample | list[Sample],
+        kwargs: dict,
+    ):
+        prev_gen = self._loaded_generation_by_path.get(path)
+        refresh = prev_gen is None or generation > prev_gen
+        loaded = self._custom_resolver.ensure_loaded(path, generation, refresh_modules=refresh)
+        self._loaded_generation_by_path[path] = generation
+        if loaded.is_async:
+            raise TypeError("Async custom reward must run in the rollout event loop")
+        result = loaded.function(worker_config.as_namespace(), payload, **kwargs)
+        if inspect.isawaitable(result):
+            raise TypeError(
+                f"Sync custom reward at {path!r} returned awaitable; "
+                "use async def for async rewards or return a concrete value"
+            )
+        return result
+
 
 # ---------------------------------------------------------------------------
 # RewardExecutor: manages the worker pool and global concurrency
@@ -112,8 +172,10 @@ class RewardExecutor:
         self._semaphore: asyncio.Semaphore | None = None
         self._workers: list = []
         self._worker_index = 0
-
-    # -- singleton access -----------------------------------------------------
+        self._custom_resolver = CustomRewardResolver()
+        self._generation_provider: Callable[..., int] = _StaticGenerationProvider(0)
+        self._generation_provider_bound = False
+        self._worker_fingerprint: WorkerConfigFingerprint | None = None
 
     @classmethod
     def get_or_create(cls, max_concurrency: int = 64, num_workers: int = 16) -> "RewardExecutor":
@@ -121,21 +183,50 @@ class RewardExecutor:
             cls._instance = cls(max_concurrency=max_concurrency, num_workers=num_workers)
         return cls._instance
 
-    # -- lazy init (must happen inside an event loop) -------------------------
+    def bind_generation_provider(self, provider: Callable[..., int]) -> None:
+        if self._generation_provider_bound and provider is not self._generation_provider:
+            raise RuntimeError(
+                "RewardExecutor generation provider already bound; call RewardExecutor.reset() before rebinding"
+            )
+        if self._generation_provider_bound and provider is self._generation_provider:
+            return
+        self._generation_provider = provider
+        self._generation_provider_bound = True
+        self._custom_resolver.invalidate_all()
+
+    def current_custom_generation(self, path: str | None = None) -> int:
+        return int(self._generation_provider("custom_rm", path))
 
     def _ensure_semaphore(self):
         if self._semaphore is None:
             self._semaphore = asyncio.Semaphore(self._max_concurrency)
 
+    def _expected_fingerprint(self) -> WorkerConfigFingerprint:
+        return WorkerConfigFingerprint(
+            num_workers=self._num_workers,
+            implementation_version=IMPLEMENTATION_VERSION,
+        )
+
     def _ensure_workers(self):
+        expected = self._expected_fingerprint()
+        if self._workers and self._worker_fingerprint is not None and self._worker_fingerprint != expected:
+            raise RuntimeError(
+                f"RewardWorker pool fingerprint mismatch: existing={self._worker_fingerprint.as_dict()}, "
+                f"requested={expected.as_dict()}"
+            )
         if not self._workers:
-            self._workers = [
+            fingerprint = expected.as_dict()
+            workers = [
                 RewardWorker.options(
                     name=f"reward_worker_{i}",
                     get_if_exists=True,
                 ).remote()
                 for i in range(self._num_workers)
             ]
+            # One batched wait instead of N sequential ray.get calls.
+            ray.get([worker.ensure_fingerprint.remote(fingerprint) for worker in workers])
+            self._workers = workers
+            self._worker_fingerprint = expected
             logger.info(
                 "RewardExecutor: created %d RewardWorker actors (max_concurrency=%d)",
                 self._num_workers,
@@ -147,74 +238,135 @@ class RewardExecutor:
         self._worker_index += 1
         return worker
 
-    # -- public API -----------------------------------------------------------
-
-    # Async rm_types run in the event loop (not dispatched to worker pool).
     _ASYNC_RM_DISPATCH = {
         "remote_rm": lambda args, sample: remote_rm(args, sample),
         "dapo-genrm": lambda args, sample: async_compute_score_genrm(args, sample),
-        # `dummy` returns 0 without any computation. Use it when the real
-        # reward is produced elsewhere (e.g., --custom-reward-post-process-path
-        # does batched GenRM scoring after all rollout finishes).
         "dummy": lambda args, sample: _dummy_reward(args),
     }
 
-    # CPU-bound / thread-unsafe rm_types dispatched to the Ray worker pool.
-    _SYNC_RM_TYPES = frozenset(
-        {
-            "deepscaler",
-            "geo3k",
-            "openr1mm",
-            "multiple_choice",
-            "dapo",
-            "math",
-            "mopd",
-            "f1",
-            "gpqa",
-            "ifbench",
-            "random",
-        }
-    )
-
     async def execute(self, args, sample: Sample, **kwargs):
-        """Execute a single reward computation with concurrency control.
-
-        - Async rm_types (remote_rm, dapo-genrm) run in the event loop.
-        - Sync rm_types are dispatched to the Ray worker pool.
-        - Custom rm paths are called directly (user is responsible for
-          async safety).
-        """
+        """Execute a single reward computation with concurrency control."""
         self._ensure_semaphore()
-
         async with self._semaphore:
-            # --- custom rm path: delegate to user function directly ---
             if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False):
-                rm_function = load_function(args.custom_rm_path)
-                return await rm_function(args, sample, **kwargs)
+                return await self._execute_custom_sample_unlocked(args, sample, **kwargs)
+            return await self._execute_builtin_unlocked(args, sample, **kwargs)
 
-            metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
-            rm_type = (metadata.get("rm_type") or args.rm_type or "").strip()
-            response = sample.response
-            label = sample.label
-            if rm_type.startswith("boxed_"):
-                response = extract_boxed_answer(response) or ""
-                rm_type = rm_type[len("boxed_") :]
+    async def execute_custom_sample(self, args, sample: Sample, **kwargs):
+        self._ensure_semaphore()
+        async with self._semaphore:
+            return await self._execute_custom_sample_unlocked(args, sample, **kwargs)
 
-            # --- async rm types: run in event loop -----------------------
-            async_handler = self._ASYNC_RM_DISPATCH.get(rm_type)
-            if async_handler is not None:
-                return await async_handler(args, sample)
+    async def execute_custom_group(self, args, samples: list[Sample], **kwargs):
+        self._ensure_semaphore()
+        async with self._semaphore:
+            return await self._execute_custom_group_unlocked(args, samples, **kwargs)
 
-            # --- sync rm types: dispatch to worker pool ------------------
-            # Default to sync path for any non-empty rm_type not in async dispatch
-            if rm_type:
-                self._ensure_workers()
-                worker = self._next_worker()
-                ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
-                return await ref
+    async def dispatch_custom_sample(self, args, sample: Sample, **kwargs):
+        """Agentic path: caller already holds RewardDomain semaphore."""
+        return await self._execute_custom_sample_unlocked(args, sample, **kwargs)
 
-            # --- no rm_type specified -----------------------------------------
-            raise NotImplementedError("Rule-based RM type is not specified.")
+    async def dispatch_custom_group(self, args, samples: list[Sample], **kwargs):
+        """Agentic path: caller already holds RewardDomain semaphore."""
+        return await self._execute_custom_group_unlocked(args, samples, **kwargs)
+
+    async def _execute_builtin_unlocked(self, args, sample: Sample, **kwargs):
+        metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
+        rm_type = (metadata.get("rm_type") or args.rm_type or "").strip()
+        response = sample.response
+        label = sample.label
+        if rm_type.startswith("boxed_"):
+            response = extract_boxed_answer(response) or ""
+            rm_type = rm_type[len("boxed_") :]
+
+        async_handler = self._ASYNC_RM_DISPATCH.get(rm_type)
+        if async_handler is not None:
+            return await async_handler(args, sample)
+
+        if rm_type:
+            self._ensure_workers()
+            worker = self._next_worker()
+            ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
+            return await ref
+
+        raise NotImplementedError("Rule-based RM type is not specified.")
+
+    async def _execute_custom_sample_unlocked(self, args, sample: Sample, **kwargs):
+        return await self._invoke_custom(args, payload=sample, group=False, **kwargs)
+
+    async def _execute_custom_group_unlocked(self, args, samples: list[Sample], **kwargs):
+        result = await self._invoke_custom(args, payload=samples, group=True, **kwargs)
+        if not isinstance(result, list):
+            raise CustomRewardError(
+                f"Custom group reward at {args.custom_rm_path!r} must return list, got {type(result).__name__}"
+            )
+        if len(result) != len(samples):
+            raise CustomRewardError(
+                f"Custom group reward at {args.custom_rm_path!r} returned {len(result)} values "
+                f"for {len(samples)} samples"
+            )
+        return result
+
+    async def _invoke_custom(self, args, *, payload: Sample | list[Sample], group: bool, **kwargs):
+        path = args.custom_rm_path
+        if not path:
+            raise CustomRewardError("custom_rm_path is not set")
+
+        custom_options = kwargs.get("custom_options")
+        if kwargs.get("ignore_custom", False):
+            raise CustomRewardError("ignore_custom=True cannot invoke custom reward")
+        call_kwargs = {key: value for key, value in kwargs.items() if key not in _CUSTOM_KWARG_KEYS}
+
+        generation = self.current_custom_generation(path)
+        loaded = self._custom_resolver.ensure_loaded(path, generation)
+
+        sample = None if group else payload
+        samples = payload if group else None
+        try:
+            if loaded.is_async:
+                result = loaded.function(args, payload, **call_kwargs)
+                if not inspect.isawaitable(result):
+                    raise TypeError(f"Async custom reward at {path!r} did not return awaitable")
+                return await result
+
+            worker_config = build_reward_worker_config(
+                args,
+                generation=generation,
+                custom_options=custom_options,
+            )
+            self._ensure_workers()
+            worker = self._next_worker()
+            ref = worker.compute_custom.remote(
+                path=path,
+                generation=generation,
+                worker_config=worker_config,
+                payload=payload,
+                kwargs=call_kwargs,
+            )
+            return await ref
+        except CustomRewardError:
+            raise
+        except Exception as error:
+            raise wrap_custom_reward_error(error, path=path, sample=sample, samples=samples) from error
+
+    async def close(self) -> None:
+        for worker in self._workers:
+            try:
+                ray.kill(worker)
+            except Exception:
+                pass
+        self._workers = []
+        self._worker_fingerprint = None
+        self._semaphore = None
+        self._custom_resolver.invalidate_all()
+        self._generation_provider = _StaticGenerationProvider(0)
+        self._generation_provider_bound = False
+
+    @classmethod
+    async def reset(cls) -> None:
+        if cls._instance is not None:
+            await cls._instance.close()
+            cls._instance = None
 
 
 # ---------------------------------------------------------------------------
@@ -223,10 +375,6 @@ class RewardExecutor:
 
 
 async def _dummy_reward(args):
-    # No-op reward. Paired with --custom-reward-post-process-path when real
-    # scoring is deferred to a post-rollout batch pass. Returns a dict when
-    # reward_key is set so downstream sample.reward[reward_key] access does
-    # not KeyError before the post-process step overwrites everything.
     reward_key = getattr(args, "reward_key", None)
     if reward_key:
         return {reward_key: 0.0}
@@ -255,18 +403,8 @@ async def remote_rm(args, sample: Sample, max_retries: int = 10):
 
 
 async def async_rm(args, sample: Sample, **kwargs):
-    """Single-sample reward computation.
-
-    Delegates to RewardExecutor which handles concurrency control and process
-    isolation for CPU-bound / thread-unsafe reward functions.
-    """
-    max_concurrency = getattr(args, "reward_max_concurrency", 64)
-    num_workers = getattr(args, "reward_num_workers", 16)
-    executor = RewardExecutor.get_or_create(
-        max_concurrency=max_concurrency,
-        num_workers=num_workers,
-    )
-    return await executor.execute(args, sample, **kwargs)
+    """Single-sample reward computation."""
+    return await get_reward_executor(args).execute(args, sample, **kwargs)
 
 
 async def batched_async_rm(
@@ -274,10 +412,21 @@ async def batched_async_rm(
     samples: list[Sample],
     **kwargs,
 ) -> list[int | float]:
-    if args.custom_rm_path is not None:
-        # Ensure the custom reward function is implemented in batch mode
-        rm_function = load_function(args.custom_rm_path)
-        return await rm_function(args, samples, **kwargs)
+    if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False):
+        # Legacy compatibility: preserve one list[Sample] call even when group_rm=False.
+        return await get_reward_executor(args).execute_custom_group(args, samples, **kwargs)
     tasks = [async_rm(args, sample, **kwargs) for sample in samples]
     rewards = await asyncio.gather(*tasks)
     return rewards
+
+
+__all__ = [
+    "CustomRewardError",
+    "RewardExecutor",
+    "RewardWorker",
+    "RewardWorkerConfig",
+    "async_rm",
+    "batched_async_rm",
+    "get_reward_executor",
+    "remote_rm",
+]

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -59,6 +59,16 @@ class _StaticGenerationProvider:
         return self._generation
 
 
+def _is_same_generation_provider(left: Callable[..., int], right: Callable[..., int]) -> bool:
+    if left is right:
+        return True
+    left_self = getattr(left, "__self__", None)
+    right_self = getattr(right, "__self__", None)
+    left_func = getattr(left, "__func__", None)
+    right_func = getattr(right, "__func__", None)
+    return left_self is not None and left_self is right_self and left_func is not None and left_func is right_func
+
+
 def get_reward_executor(args) -> "RewardExecutor":
     """Return the process-wide RewardExecutor for the given training args."""
     max_concurrency = getattr(args, "reward_max_concurrency", None)
@@ -143,7 +153,8 @@ class RewardWorker:
         prev_gen = self._loaded_generation_by_path.get(path)
         refresh = prev_gen is None or generation > prev_gen
         loaded = self._custom_resolver.ensure_loaded(path, generation, refresh_modules=refresh)
-        self._loaded_generation_by_path[path] = generation
+        if prev_gen is None or generation > prev_gen:
+            self._loaded_generation_by_path[path] = generation
         if loaded.is_async:
             raise TypeError("Async custom reward must run in the rollout event loop")
         result = loaded.function(worker_config.as_namespace(), payload, **kwargs)
@@ -184,12 +195,12 @@ class RewardExecutor:
         return cls._instance
 
     def bind_generation_provider(self, provider: Callable[..., int]) -> None:
-        if self._generation_provider_bound and provider is not self._generation_provider:
+        if self._generation_provider_bound:
+            if _is_same_generation_provider(provider, self._generation_provider):
+                return
             raise RuntimeError(
                 "RewardExecutor generation provider already bound; call RewardExecutor.reset() before rebinding"
             )
-        if self._generation_provider_bound and provider is self._generation_provider:
-            return
         self._generation_provider = provider
         self._generation_provider_bound = True
         self._custom_resolver.invalidate_all()

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -165,6 +165,9 @@ class RewardWorker:
             )
         return result
 
+    def custom_load_count(self, path: str) -> int:
+        return self._custom_resolver.load_count(path)
+
 
 # ---------------------------------------------------------------------------
 # RewardExecutor: manages the worker pool and global concurrency
@@ -218,7 +221,7 @@ class RewardExecutor:
             implementation_version=IMPLEMENTATION_VERSION,
         )
 
-    def _ensure_workers(self):
+    async def _ensure_workers(self):
         expected = self._expected_fingerprint()
         if self._workers and self._worker_fingerprint is not None and self._worker_fingerprint != expected:
             raise RuntimeError(
@@ -234,8 +237,7 @@ class RewardExecutor:
                 ).remote()
                 for i in range(self._num_workers)
             ]
-            # One batched wait instead of N sequential ray.get calls.
-            ray.get([worker.ensure_fingerprint.remote(fingerprint) for worker in workers])
+            await asyncio.gather(*[worker.ensure_fingerprint.remote(fingerprint) for worker in workers])
             self._workers = workers
             self._worker_fingerprint = expected
             logger.info(
@@ -295,7 +297,7 @@ class RewardExecutor:
             return await async_handler(args, sample)
 
         if rm_type:
-            self._ensure_workers()
+            await self._ensure_workers()
             worker = self._next_worker()
             ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
             return await ref
@@ -345,7 +347,7 @@ class RewardExecutor:
                 generation=generation,
                 custom_options=custom_options,
             )
-            self._ensure_workers()
+            await self._ensure_workers()
             worker = self._next_worker()
             ref = worker.compute_custom.remote(
                 path=path,

--- a/relax/engine/rewards/custom_reward.py
+++ b/relax/engine/rewards/custom_reward.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+"""Helpers for custom reward load/classify/cache and Worker config."""
+
+from __future__ import annotations
+
+import inspect
+from argparse import Namespace
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable
+
+from relax.utils.misc import load_function
+from relax.utils.types import Sample
+
+
+# Protocol version for named RewardWorker fingerprint checks (not reload counter).
+GENERATION_PROTOCOL_VERSION = 1
+IMPLEMENTATION_VERSION = 1
+
+
+class CustomRewardError(RuntimeError):
+    """Driver-boundary error that attaches custom path and sample identity."""
+
+
+@dataclass(frozen=True)
+class RewardWorkerConfig:
+    """Serializable whitelist view of args for sync custom rewards."""
+
+    custom_rm_path: str | None = None
+    group_rm: bool = False
+    reward_key: str | None = None
+    rm_type: str | None = None
+    rm_url: str | None = None
+    implementation_version: int = IMPLEMENTATION_VERSION
+    generation: int = 0
+    custom_options: dict[str, Any] = field(default_factory=dict)
+
+    def as_namespace(self) -> Namespace:
+        data = asdict(self)
+        options = data.pop("custom_options") or {}
+        ns = Namespace(**data)
+        for key, value in options.items():
+            setattr(ns, key, value)
+        return ns
+
+
+def build_reward_worker_config(
+    args: Any,
+    *,
+    generation: int = 0,
+    custom_options: dict[str, Any] | None = None,
+) -> RewardWorkerConfig:
+    options = dict(custom_options or {})
+    return RewardWorkerConfig(
+        custom_rm_path=getattr(args, "custom_rm_path", None),
+        group_rm=bool(getattr(args, "group_rm", False)),
+        reward_key=getattr(args, "reward_key", None),
+        rm_type=getattr(args, "rm_type", None),
+        rm_url=getattr(args, "rm_url", None),
+        implementation_version=IMPLEMENTATION_VERSION,
+        generation=generation,
+        custom_options=options,
+    )
+
+
+@dataclass(frozen=True)
+class WorkerConfigFingerprint:
+    """Pool-level identity for named RewardWorker actors (not per-request
+    path)."""
+
+    num_workers: int
+    implementation_version: int = IMPLEMENTATION_VERSION
+    generation_protocol_version: int = GENERATION_PROTOCOL_VERSION
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResolvedCustomReward:
+    function: Callable
+    is_async: bool
+    generation: int
+    path: str
+
+
+def is_async_callable(function: Callable) -> bool:
+    function = inspect.unwrap(function)
+    if inspect.iscoroutinefunction(function):
+        return True
+    call = getattr(function, "__call__", None)
+    if call is not None and inspect.iscoroutinefunction(inspect.unwrap(call)):
+        return True
+    return False
+
+
+class CustomRewardResolver:
+    """Per-process cache of custom reward callables keyed by (path,
+    generation)."""
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, int], ResolvedCustomReward] = {}
+
+    def ensure_loaded(self, path: str, generation: int, *, refresh_modules: bool = False) -> ResolvedCustomReward:
+        key = (path, generation)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        if refresh_modules:
+            from relax.utils.reload_utils import reload_function
+
+            function = reload_function(path)
+            if function is None:
+                raise RuntimeError(f"Failed to refresh custom reward module for path={path!r}")
+        else:
+            function = load_function(path)
+        resolved = ResolvedCustomReward(
+            function=function,
+            is_async=is_async_callable(function),
+            generation=generation,
+            path=path,
+        )
+        self._cache[key] = resolved
+        # Drop older generations for the same path to bound memory.
+        stale = [k for k in self._cache if k[0] == path and k[1] != generation]
+        for old_key in stale:
+            self._cache.pop(old_key, None)
+        return resolved
+
+    def invalidate(self, path: str) -> None:
+        for key in list(self._cache):
+            if key[0] == path:
+                self._cache.pop(key, None)
+
+    def invalidate_all(self) -> None:
+        self._cache.clear()
+
+
+def sample_identity(sample: Sample) -> dict[str, Any]:
+    return {
+        "index": getattr(sample, "index", None),
+        "group_index": getattr(sample, "group_index", None),
+        "session_id": getattr(sample, "session_id", None),
+    }
+
+
+def format_sample_identity(sample: Sample) -> str:
+    ident = sample_identity(sample)
+    return f"index={ident['index']!r}, group_index={ident['group_index']!r}, session_id={ident['session_id']!r}"
+
+
+def format_group_identity(samples: list[Sample]) -> str:
+    parts = [format_sample_identity(sample) for sample in samples[:8]]
+    more = "" if len(samples) <= 8 else f", ... (+{len(samples) - 8} more)"
+    return f"n={len(samples)} [{'; '.join(parts)}{more}]"
+
+
+def wrap_custom_reward_error(
+    error: BaseException,
+    *,
+    path: str,
+    sample: Sample | None = None,
+    samples: list[Sample] | None = None,
+) -> CustomRewardError:
+    if sample is not None:
+        detail = format_sample_identity(sample)
+    elif samples is not None:
+        detail = format_group_identity(samples)
+    else:
+        detail = "unknown sample"
+    message = f"Custom reward failed for path={path!r} ({detail}): {type(error).__name__}: {error}"
+    return CustomRewardError(message)

--- a/relax/engine/rewards/custom_reward.py
+++ b/relax/engine/rewards/custom_reward.py
@@ -12,8 +12,6 @@ from relax.utils.misc import load_function
 from relax.utils.types import Sample
 
 
-# Protocol version for named RewardWorker fingerprint checks (not reload counter).
-GENERATION_PROTOCOL_VERSION = 1
 IMPLEMENTATION_VERSION = 1
 
 
@@ -64,12 +62,8 @@ def build_reward_worker_config(
 
 @dataclass(frozen=True)
 class WorkerConfigFingerprint:
-    """Pool-level identity for named RewardWorker actors (not per-request
-    path)."""
-
     num_workers: int
     implementation_version: int = IMPLEMENTATION_VERSION
-    generation_protocol_version: int = GENERATION_PROTOCOL_VERSION
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -120,10 +114,6 @@ class CustomRewardResolver:
             path=path,
         )
         self._cache[key] = resolved
-        # Drop older generations for the same path to bound memory.
-        stale = [k for k in self._cache if k[0] == path and k[1] != generation]
-        for old_key in stale:
-            self._cache.pop(old_key, None)
         return resolved
 
     def invalidate(self, path: str) -> None:

--- a/relax/engine/rewards/custom_reward.py
+++ b/relax/engine/rewards/custom_reward.py
@@ -14,6 +14,35 @@ from relax.utils.types import Sample
 
 IMPLEMENTATION_VERSION = 1
 
+_CONFIG_FIELD_KEYS = frozenset(
+    {
+        "custom_rm_path",
+        "group_rm",
+        "reward_key",
+        "rm_type",
+        "rm_url",
+        "implementation_version",
+        "generation",
+        "custom_options",
+    }
+)
+
+# Known heavy / non-serializable training attrs never auto-copied into Workers.
+_AUTO_PICK_DENYLIST = frozenset(
+    {
+        "model",
+        "tokenizer",
+        "processor",
+        "hf_tokenizer",
+        "hf_processor",
+        "train_data",
+        "eval_data",
+        "rollout_engine",
+        "actor",
+        "critic",
+    }
+)
+
 
 class CustomRewardError(RuntimeError):
     """Driver-boundary error that attaches custom path and sample identity."""
@@ -41,13 +70,39 @@ class RewardWorkerConfig:
         return ns
 
 
+def _is_jsonish(value: Any, *, depth: int = 0) -> bool:
+    if depth > 2:
+        return False
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return True
+    if isinstance(value, (list, tuple)):
+        return all(_is_jsonish(item, depth=depth + 1) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and _is_jsonish(item, depth=depth + 1) for key, item in value.items())
+    return False
+
+
+def pick_primitive_arg_attrs(args: Any) -> dict[str, Any]:
+    """Copy JSON-ish scalar attrs from training args for sync Worker compatibility."""
+    source = vars(args) if hasattr(args, "__dict__") else {}
+    picked: dict[str, Any] = {}
+    for key, value in source.items():
+        if key.startswith("_") or key in _CONFIG_FIELD_KEYS or key in _AUTO_PICK_DENYLIST:
+            continue
+        if _is_jsonish(value):
+            picked[key] = value
+    return picked
+
+
 def build_reward_worker_config(
     args: Any,
     *,
     generation: int = 0,
     custom_options: dict[str, Any] | None = None,
 ) -> RewardWorkerConfig:
-    options = dict(custom_options or {})
+    # auto-pick first; explicit custom_options win on key conflicts.
+    options = pick_primitive_arg_attrs(args)
+    options.update(dict(custom_options or {}))
     return RewardWorkerConfig(
         custom_rm_path=getattr(args, "custom_rm_path", None),
         group_rm=bool(getattr(args, "group_rm", False)),
@@ -93,6 +148,10 @@ class CustomRewardResolver:
 
     def __init__(self) -> None:
         self._cache: dict[tuple[str, int], ResolvedCustomReward] = {}
+        self._load_counts: dict[str, int] = {}
+
+    def load_count(self, path: str) -> int:
+        return self._load_counts.get(path, 0)
 
     def ensure_loaded(self, path: str, generation: int, *, refresh_modules: bool = False) -> ResolvedCustomReward:
         key = (path, generation)
@@ -107,6 +166,7 @@ class CustomRewardResolver:
                 raise RuntimeError(f"Failed to refresh custom reward module for path={path!r}")
         else:
             function = load_function(path)
+        self._load_counts[path] = self._load_counts.get(path, 0) + 1
         resolved = ResolvedCustomReward(
             function=function,
             is_async=is_async_callable(function),

--- a/relax/utils/reload_utils.py
+++ b/relax/utils/reload_utils.py
@@ -17,6 +17,29 @@ from relax.utils.logging_utils import get_logger
 logger = get_logger(__name__)
 
 
+class ReloadGenerationRegistry:
+    """Instance-scoped generation counters for IMMEDIATE reloadable callables.
+
+    Keyed by (module_name, module_path). Only successful reloads bump the
+    counter. Consumers (e.g. RewardExecutor) read via ``current()``.
+    """
+
+    def __init__(self) -> None:
+        self._generations: Dict[tuple[str, str], int] = {}
+
+    def bump(self, module_name: str, module_path: str) -> int:
+        key = (module_name, module_path)
+        next_gen = self._generations.get(key, 0) + 1
+        self._generations[key] = next_gen
+        return next_gen
+
+    def current(self, module_name: str, module_path: Optional[str] = None) -> int:
+        if module_path is not None:
+            return self._generations.get((module_name, module_path), 0)
+        matching = [gen for (name, _), gen in self._generations.items() if name == module_name]
+        return max(matching) if matching else 0
+
+
 class ReloadScope(Enum):
     """Define the reload scope of functions.
 
@@ -383,13 +406,17 @@ class ReloadableMixin:
             logger.info(f"Refreshed sys.modules cache for {module_path}")
             message = f"Module '{module_name}' reloaded - will take effect on next call"
 
-        return {
+        result = {
             "success": True,
             "module_name": module_name,
             "module_path": module_path,
             "scope": func_def.scope.value,
             "message": message,
         }
+        registry = getattr(self, "_reload_generations", None)
+        if isinstance(registry, ReloadGenerationRegistry):
+            result["generation"] = registry.bump(module_name, module_path)
+        return result
 
     def reload_module(self, module_name: str, module_path: str = None) -> Dict[str, Any]:
         """Hot-reload the specified module and update function references.

--- a/tests/engine/rewards/custom_reward_fixtures.py
+++ b/tests/engine/rewards/custom_reward_fixtures.py
@@ -15,7 +15,12 @@ def sync_reward(args, sample: Sample, **kwargs) -> float:
 
 
 def sync_reward_with_pid(args, sample: Sample, **kwargs) -> dict[str, Any]:
-    return {"score": 1.0, "pid": os.getpid(), "has_rm_type": hasattr(args, "rm_type")}
+    return {
+        "score": 1.0,
+        "pid": os.getpid(),
+        "has_rm_type": hasattr(args, "rm_type"),
+        "threshold": getattr(args, "reward_threshold", None),
+    }
 
 
 def sync_slow_reward_tracked(args, sample: Sample, **kwargs) -> float:

--- a/tests/engine/rewards/custom_reward_fixtures.py
+++ b/tests/engine/rewards/custom_reward_fixtures.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+"""Importable custom reward fixtures for concurrency tests."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from relax.utils.types import Sample
+
+
+_LOAD_COUNTER = 0
+
+
+def reset_load_counter() -> None:
+    global _LOAD_COUNTER
+    _LOAD_COUNTER = 0
+
+
+def get_load_counter() -> int:
+    return _LOAD_COUNTER
+
+
+# Count module (re)loads via side effect at import/reload time is hard;
+# instead track calls to ensure_loaded via a marker on first function body.
+
+
+def sync_reward(args, sample: Sample, **kwargs) -> float:
+    """Simple sync reward: 1.0 if response == label else 0.0."""
+    return 1.0 if str(sample.response) == str(sample.label) else 0.0
+
+
+def sync_reward_with_pid(args, sample: Sample, **kwargs) -> dict[str, Any]:
+    return {"score": 1.0, "pid": os.getpid(), "has_rm_type": hasattr(args, "rm_type")}
+
+
+def sync_slow_reward(args, sample: Sample, **kwargs) -> float:
+    time.sleep(0.1)
+    return 1.0
+
+
+def sync_group_reward(args, samples: list[Sample], **kwargs) -> list[float]:
+    return [1.0 if str(s.response) == str(s.label) else 0.0 for s in samples]
+
+
+def sync_group_bad_length(args, samples: list[Sample], **kwargs) -> list[float]:
+    return [1.0]
+
+
+def sync_raises(args, sample: Sample, **kwargs) -> float:
+    raise ValueError(f"boom index={sample.index}")
+
+
+def sync_returns_awaitable(args, sample: Sample, **kwargs):
+    async def _inner():
+        return 1.0
+
+    return _inner()
+
+
+async def async_reward(args, sample: Sample, **kwargs) -> float:
+    return 1.0 if str(sample.response) == str(sample.label) else 0.0
+
+
+async def async_reward_with_marker(args, sample: Sample, **kwargs) -> dict[str, Any]:
+    return {"score": 1.0, "async": True, "full_args": hasattr(args, "custom_rm_path")}
+
+
+async def async_group_reward(args, samples: list[Sample], **kwargs) -> list[float]:
+    return [float(i) for i in range(len(samples))]

--- a/tests/engine/rewards/custom_reward_fixtures.py
+++ b/tests/engine/rewards/custom_reward_fixtures.py
@@ -10,24 +10,7 @@ from typing import Any
 from relax.utils.types import Sample
 
 
-_LOAD_COUNTER = 0
-
-
-def reset_load_counter() -> None:
-    global _LOAD_COUNTER
-    _LOAD_COUNTER = 0
-
-
-def get_load_counter() -> int:
-    return _LOAD_COUNTER
-
-
-# Count module (re)loads via side effect at import/reload time is hard;
-# instead track calls to ensure_loaded via a marker on first function body.
-
-
 def sync_reward(args, sample: Sample, **kwargs) -> float:
-    """Simple sync reward: 1.0 if response == label else 0.0."""
     return 1.0 if str(sample.response) == str(sample.label) else 0.0
 
 
@@ -35,9 +18,19 @@ def sync_reward_with_pid(args, sample: Sample, **kwargs) -> dict[str, Any]:
     return {"score": 1.0, "pid": os.getpid(), "has_rm_type": hasattr(args, "rm_type")}
 
 
-def sync_slow_reward(args, sample: Sample, **kwargs) -> float:
-    time.sleep(0.1)
-    return 1.0
+def sync_slow_reward_tracked(args, sample: Sample, **kwargs) -> float:
+    import ray
+
+    name = getattr(args, "overlap_counter_name", None)
+    counter = ray.get_actor(name) if name else None
+    if counter is not None:
+        ray.get(counter.enter.remote())
+    try:
+        time.sleep(0.1)
+        return 1.0
+    finally:
+        if counter is not None:
+            ray.get(counter.leave.remote())
 
 
 def sync_group_reward(args, samples: list[Sample], **kwargs) -> list[float]:
@@ -65,7 +58,3 @@ async def async_reward(args, sample: Sample, **kwargs) -> float:
 
 async def async_reward_with_marker(args, sample: Sample, **kwargs) -> dict[str, Any]:
     return {"score": 1.0, "async": True, "full_args": hasattr(args, "custom_rm_path")}
-
-
-async def async_group_reward(args, samples: list[Sample], **kwargs) -> list[float]:
-    return [float(i) for i in range(len(samples))]

--- a/tests/engine/rewards/test_custom_reward_concurrency.py
+++ b/tests/engine/rewards/test_custom_reward_concurrency.py
@@ -110,11 +110,12 @@ async def _measured_overlap_peak(
 
 @pytest.mark.asyncio
 async def test_sync_custom_runs_in_worker_process():
-    args = _args(f"{FIXTURE}.sync_reward_with_pid", reward_key="score")
+    args = _args(f"{FIXTURE}.sync_reward_with_pid", reward_key="score", reward_threshold=0.5)
     result = await async_rm(args, _sample())
     assert isinstance(result, dict)
     assert result["pid"] != os.getpid()
     assert result["has_rm_type"] is True
+    assert result["threshold"] == 0.5
 
 
 @pytest.mark.asyncio
@@ -234,3 +235,64 @@ async def test_agentic_dispatch_does_not_double_semaphore():
 
     results = await asyncio.wait_for(asyncio.gather(run_one(0), run_one(1)), timeout=5)
     assert all(r.reward == 1.0 for r in results)
+
+
+@pytest.mark.asyncio
+async def test_sync_recovers_after_custom_exception():
+    fail_args = _args(f"{FIXTURE}.sync_raises", reward_num_workers=2)
+    ok_args = _args(f"{FIXTURE}.sync_reward", reward_num_workers=2)
+    with pytest.raises(CustomRewardError):
+        await async_rm(fail_args, _sample(index=1))
+    reward = await asyncio.wait_for(async_rm(ok_args, _sample()), timeout=10)
+    assert reward == 1.0
+
+
+@pytest.mark.asyncio
+async def test_worker_loads_custom_function_once_per_generation():
+    path = f"{FIXTURE}.sync_reward"
+    args = _args(path, reward_num_workers=1)
+    executor = RewardExecutor.get_or_create(max_concurrency=4, num_workers=1)
+    await executor.execute_custom_sample(args, _sample(index=0))
+    await executor.execute_custom_sample(args, _sample(index=1))
+    worker = executor._workers[0]
+    assert ray.get(worker.custom_load_count.remote(path)) == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_init_does_not_block_event_loop():
+    ticks: list[float] = []
+
+    async def heartbeat():
+        for _ in range(8):
+            ticks.append(1.0)
+            await asyncio.sleep(0.01)
+
+    args = _args(f"{FIXTURE}.sync_reward", reward_num_workers=4)
+    executor = RewardExecutor.get_or_create(max_concurrency=4, num_workers=4)
+    reward, _ = await asyncio.wait_for(
+        asyncio.gather(executor.execute_custom_sample(args, _sample()), heartbeat()),
+        timeout=30,
+    )
+    assert reward == 1.0
+    assert len(ticks) >= 2
+
+
+@pytest.mark.asyncio
+async def test_auto_pick_primitives_visible_on_worker_args():
+    from relax.engine.rewards.custom_reward import build_reward_worker_config, pick_primitive_arg_attrs
+
+    args = _args(
+        f"{FIXTURE}.sync_reward",
+        reward_threshold=0.75,
+        task_name="math",
+        tokenizer=object(),
+    )
+    picked = pick_primitive_arg_attrs(args)
+    assert picked["reward_threshold"] == 0.75
+    assert picked["task_name"] == "math"
+    assert "tokenizer" not in picked
+
+    config = build_reward_worker_config(args, custom_options={"task_name": "override"})
+    ns = config.as_namespace()
+    assert ns.reward_threshold == 0.75
+    assert ns.task_name == "override"

--- a/tests/engine/rewards/test_custom_reward_concurrency.py
+++ b/tests/engine/rewards/test_custom_reward_concurrency.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""CPU/Ray tests for custom reward concurrency (task 19)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+ray = pytest.importorskip("ray")
+
+if not ray.is_initialized():
+    # Force a local cluster so a stale /tmp/ray/ray_current_cluster does not hang CI/dev boxes.
+    ray.init(address="local", num_cpus=8, include_dashboard=False, ignore_reinit_error=True)
+
+from relax.engine.rewards import (  # noqa: E402
+    CustomRewardError,
+    RewardExecutor,
+    async_rm,
+    batched_async_rm,
+)
+from relax.engine.rewards.custom_reward import CustomRewardError as _CustomRewardError  # noqa: E402
+from relax.utils.reload_utils import ReloadableMixin, ReloadGenerationRegistry  # noqa: E402
+from relax.utils.types import Sample  # noqa: E402
+
+
+FIXTURE = "tests.engine.rewards.custom_reward_fixtures"
+
+
+@pytest.fixture(autouse=True)
+async def _reset_executor():
+    await RewardExecutor.reset()
+    yield
+    await RewardExecutor.reset()
+
+
+def _args(path: str | None, **overrides) -> SimpleNamespace:
+    defaults = {
+        "custom_rm_path": path,
+        "reward_max_concurrency": 8,
+        "reward_num_workers": 4,
+        "rm_type": "math",
+        "rm_url": None,
+        "reward_key": None,
+        "group_rm": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _sample(response: str = "ok", label: str = "ok", index: int = 0) -> Sample:
+    return Sample(response=response, label=label, index=index, group_index=0, session_id=f"s{index}")
+
+
+@pytest.mark.asyncio
+async def test_sync_custom_runs_in_worker_process():
+    args = _args(f"{FIXTURE}.sync_reward_with_pid", reward_key="score")
+    result = await async_rm(args, _sample())
+    assert isinstance(result, dict)
+    assert result["pid"] != os.getpid()
+    assert result["has_rm_type"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_custom_does_not_call_worker():
+    args = _args(f"{FIXTURE}.async_reward_with_marker", reward_key="score", reward_num_workers=2)
+    executor = RewardExecutor.get_or_create(max_concurrency=8, num_workers=2)
+    result = await executor.execute_custom_sample(args, _sample())
+    assert result["async"] is True
+    assert result["full_args"] is True
+    assert executor._workers == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_batch_custom_list_call_even_when_group_rm_false():
+    args = _args(f"{FIXTURE}.sync_group_reward", group_rm=False)
+    samples = [_sample("a", "a", 0), _sample("b", "x", 1)]
+    rewards = await batched_async_rm(args, samples)
+    assert rewards == [1.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_ignore_custom_uses_builtin():
+    args = _args(f"{FIXTURE}.sync_raises", rm_type="dummy")
+    reward = await async_rm(args, _sample(), ignore_custom=True)
+    assert reward == 0.0
+
+
+@pytest.mark.asyncio
+async def test_sync_exception_includes_sample_index():
+    args = _args(f"{FIXTURE}.sync_raises")
+    with pytest.raises((CustomRewardError, _CustomRewardError)) as exc_info:
+        await async_rm(args, _sample(index=7))
+    assert "index=7" in str(exc_info.value)
+    assert FIXTURE in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_group_length_mismatch_raises():
+    args = _args(f"{FIXTURE}.sync_group_bad_length")
+    with pytest.raises((CustomRewardError, _CustomRewardError)):
+        await batched_async_rm(args, [_sample(), _sample(index=1)])
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_awaitable_raises_contract_error():
+    args = _args(f"{FIXTURE}.sync_returns_awaitable")
+    with pytest.raises((CustomRewardError, _CustomRewardError)):
+        await async_rm(args, _sample())
+
+
+@pytest.mark.asyncio
+async def test_reward_max_concurrency_limits_overlap():
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.current = 0
+            self.peak = 0
+
+        def enter(self):
+            self.current += 1
+            self.peak = max(self.peak, self.current)
+            return self.current
+
+        def leave(self):
+            self.current -= 1
+
+        def get_peak(self):
+            return self.peak
+
+    counter = Counter.remote()
+
+    # Patch via a dedicated fixture-like function defined inline is hard;
+    # instead run slow rewards under concurrency=2 and check wall clock + peak via sleep.
+    args = _args(f"{FIXTURE}.sync_slow_reward", reward_max_concurrency=2, reward_num_workers=4)
+    executor = RewardExecutor.get_or_create(max_concurrency=2, num_workers=4)
+    # Warm workers/cache outside the timed window.
+    await executor.execute_custom_sample(args, _sample())
+
+    samples = [_sample(index=i) for i in range(6)]
+    start = time.perf_counter()
+    rewards = await asyncio.gather(*[executor.execute_custom_sample(args, s) for s in samples])
+    elapsed = time.perf_counter() - start
+    assert rewards == [1.0] * 6
+    # Serial would be ~0.6s; with concurrency 2 expect roughly >= 0.3s and < 0.55s after warmup.
+    assert elapsed < 0.55
+    assert elapsed >= 0.25
+    del counter
+
+
+@pytest.mark.asyncio
+async def test_reload_generation_bumps_and_propagates():
+    class _Host(ReloadableMixin):
+        def __init__(self, path: str):
+            self.args = SimpleNamespace(custom_rm_path=path)
+            self._reload_generations = ReloadGenerationRegistry()
+
+    path = f"{FIXTURE}.sync_reward"
+    host = _Host(path)
+    executor = RewardExecutor.get_or_create(max_concurrency=4, num_workers=2)
+    executor.bind_generation_provider(host._reload_generations.current)
+
+    assert host._reload_generations.current("custom_rm", path) == 0
+    result = host.reload_function_by_name("custom_rm")
+    assert result["success"] is True
+    assert result["generation"] == 1
+    assert host._reload_generations.current("custom_rm", path) == 1
+
+    reward = await executor.execute_custom_sample(_args(path), _sample())
+    assert reward == 1.0
+
+
+@pytest.mark.asyncio
+async def test_agentic_dispatch_does_not_double_semaphore():
+    from relax.agentic.pipeline import reward as agentic_reward
+
+    args = _args(f"{FIXTURE}.async_reward", reward_max_concurrency=1)
+    # With concurrency 1, two overlapping agentic sample rewards must still complete:
+    # dispatch path must not acquire RewardExecutor semaphore again.
+    domain = agentic_reward.RewardDomain(args=args, group_filter=None, max_submissions_per_step=1)
+
+    async def run_one(idx: int):
+        sample = _sample(index=idx)
+        return await domain._run_sample_reward(sample)
+
+    results = await asyncio.wait_for(asyncio.gather(run_one(0), run_one(1)), timeout=5)
+    assert all(r.reward == 1.0 for r in results)

--- a/tests/engine/rewards/test_custom_reward_concurrency.py
+++ b/tests/engine/rewards/test_custom_reward_concurrency.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import asyncio
 import os
-import time
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -15,7 +15,6 @@ import pytest
 ray = pytest.importorskip("ray")
 
 if not ray.is_initialized():
-    # Force a local cluster so a stale /tmp/ray/ray_current_cluster does not hang CI/dev boxes.
     ray.init(address="local", num_cpus=8, include_dashboard=False, ignore_reinit_error=True)
 
 from relax.engine.rewards import (  # noqa: E402
@@ -24,8 +23,8 @@ from relax.engine.rewards import (  # noqa: E402
     async_rm,
     batched_async_rm,
 )
-from relax.engine.rewards.custom_reward import CustomRewardError as _CustomRewardError  # noqa: E402
-from relax.utils.reload_utils import ReloadableMixin, ReloadGenerationRegistry  # noqa: E402
+from relax.engine.rewards.custom_reward import CustomRewardResolver  # noqa: E402
+from relax.utils.reload_utils import ReloadGenerationRegistry  # noqa: E402
 from relax.utils.types import Sample  # noqa: E402
 
 
@@ -55,6 +54,58 @@ def _args(path: str | None, **overrides) -> SimpleNamespace:
 
 def _sample(response: str = "ok", label: str = "ok", index: int = 0) -> Sample:
     return Sample(response=response, label=label, index=index, group_index=0, session_id=f"s{index}")
+
+
+@ray.remote
+class _OverlapCounter:
+    def __init__(self):
+        self.current = 0
+        self.peak = 0
+
+    def enter(self):
+        self.current += 1
+        self.peak = max(self.peak, self.current)
+        return self.current
+
+    def leave(self):
+        self.current -= 1
+
+    def get_peak(self):
+        return self.peak
+
+
+def _fresh_overlap_counter(name: str):
+    try:
+        ray.kill(ray.get_actor(name))
+    except ValueError:
+        pass
+    return _OverlapCounter.options(name=name, get_if_exists=False).remote()
+
+
+async def _measured_overlap_peak(
+    *,
+    counter_name: str,
+    max_concurrency: int,
+    num_workers: int,
+    n_samples: int = 6,
+) -> tuple[list[float], int]:
+    counter = _fresh_overlap_counter(counter_name)
+    args = _args(
+        f"{FIXTURE}.sync_slow_reward_tracked",
+        reward_max_concurrency=max_concurrency,
+        reward_num_workers=num_workers,
+    )
+    executor = RewardExecutor.get_or_create(max_concurrency=max_concurrency, num_workers=num_workers)
+    opts = {"custom_options": {"overlap_counter_name": counter_name}}
+    await executor.execute_custom_sample(args, _sample(), **opts)
+    counter = _fresh_overlap_counter(counter_name)
+
+    rewards = await asyncio.gather(
+        *[executor.execute_custom_sample(args, _sample(index=i), **opts) for i in range(n_samples)]
+    )
+    peak = ray.get(counter.get_peak.remote())
+    ray.kill(counter)
+    return rewards, peak
 
 
 @pytest.mark.asyncio
@@ -94,85 +145,81 @@ async def test_ignore_custom_uses_builtin():
 @pytest.mark.asyncio
 async def test_sync_exception_includes_sample_index():
     args = _args(f"{FIXTURE}.sync_raises")
-    with pytest.raises((CustomRewardError, _CustomRewardError)) as exc_info:
+    with pytest.raises(CustomRewardError) as exc_info:
         await async_rm(args, _sample(index=7))
     assert "index=7" in str(exc_info.value)
     assert FIXTURE in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_group_length_mismatch_raises():
-    args = _args(f"{FIXTURE}.sync_group_bad_length")
-    with pytest.raises((CustomRewardError, _CustomRewardError)):
-        await batched_async_rm(args, [_sample(), _sample(index=1)])
+@pytest.mark.parametrize(
+    "path,call",
+    [
+        (f"{FIXTURE}.sync_group_bad_length", "group"),
+        (f"{FIXTURE}.sync_returns_awaitable", "single"),
+    ],
+)
+async def test_custom_reward_contract_errors(path: str, call: str):
+    args = _args(path)
+    with pytest.raises(CustomRewardError):
+        if call == "group":
+            await batched_async_rm(args, [_sample(), _sample(index=1)])
+        else:
+            await async_rm(args, _sample())
 
 
 @pytest.mark.asyncio
-async def test_sync_returns_awaitable_raises_contract_error():
-    args = _args(f"{FIXTURE}.sync_returns_awaitable")
-    with pytest.raises((CustomRewardError, _CustomRewardError)):
-        await async_rm(args, _sample())
-
-
-@pytest.mark.asyncio
-async def test_reward_max_concurrency_limits_overlap():
-    @ray.remote
-    class Counter:
-        def __init__(self):
-            self.current = 0
-            self.peak = 0
-
-        def enter(self):
-            self.current += 1
-            self.peak = max(self.peak, self.current)
-            return self.current
-
-        def leave(self):
-            self.current -= 1
-
-        def get_peak(self):
-            return self.peak
-
-    counter = Counter.remote()
-
-    # Patch via a dedicated fixture-like function defined inline is hard;
-    # instead run slow rewards under concurrency=2 and check wall clock + peak via sleep.
-    args = _args(f"{FIXTURE}.sync_slow_reward", reward_max_concurrency=2, reward_num_workers=4)
-    executor = RewardExecutor.get_or_create(max_concurrency=2, num_workers=4)
-    # Warm workers/cache outside the timed window.
-    await executor.execute_custom_sample(args, _sample())
-
-    samples = [_sample(index=i) for i in range(6)]
-    start = time.perf_counter()
-    rewards = await asyncio.gather(*[executor.execute_custom_sample(args, s) for s in samples])
-    elapsed = time.perf_counter() - start
+@pytest.mark.parametrize(
+    "max_concurrency,num_workers",
+    [
+        (2, 4),
+        (8, 2),
+    ],
+)
+async def test_sync_overlap_capped_by_min_concurrency_and_workers(max_concurrency: int, num_workers: int):
+    cap = min(max_concurrency, num_workers)
+    rewards, peak = await _measured_overlap_peak(
+        counter_name=f"task19_overlap_{max_concurrency}_{num_workers}",
+        max_concurrency=max_concurrency,
+        num_workers=num_workers,
+    )
     assert rewards == [1.0] * 6
-    # Serial would be ~0.6s; with concurrency 2 expect roughly >= 0.3s and < 0.55s after warmup.
-    assert elapsed < 0.55
-    assert elapsed >= 0.25
-    del counter
+    assert 1 <= peak <= cap
 
 
 @pytest.mark.asyncio
-async def test_reload_generation_bumps_and_propagates():
-    class _Host(ReloadableMixin):
-        def __init__(self, path: str):
-            self.args = SimpleNamespace(custom_rm_path=path)
-            self._reload_generations = ReloadGenerationRegistry()
-
-    path = f"{FIXTURE}.sync_reward"
-    host = _Host(path)
+async def test_bind_generation_provider_idempotent_for_bound_method():
+    registry = ReloadGenerationRegistry()
     executor = RewardExecutor.get_or_create(max_concurrency=4, num_workers=2)
-    executor.bind_generation_provider(host._reload_generations.current)
+    executor.bind_generation_provider(registry.current)
+    executor.bind_generation_provider(registry.current)
+    assert executor.current_custom_generation(f"{FIXTURE}.sync_reward") == 0
 
-    assert host._reload_generations.current("custom_rm", path) == 0
-    result = host.reload_function_by_name("custom_rm")
-    assert result["success"] is True
-    assert result["generation"] == 1
-    assert host._reload_generations.current("custom_rm", path) == 1
+    other = ReloadGenerationRegistry()
+    with pytest.raises(RuntimeError, match="already bound"):
+        executor.bind_generation_provider(other.current)
 
-    reward = await executor.execute_custom_sample(_args(path), _sample())
-    assert reward == 1.0
+
+@pytest.mark.asyncio
+async def test_resolver_keeps_older_generation_cache_entries():
+    resolver = CustomRewardResolver()
+    path = f"{FIXTURE}.sync_reward"
+    load_calls: list[str] = []
+
+    def _fake_load(p: str):
+        load_calls.append(p)
+        return lambda args, sample, **kwargs: 1.0
+
+    with patch("relax.engine.rewards.custom_reward.load_function", side_effect=_fake_load):
+        first = resolver.ensure_loaded(path, 0)
+        second = resolver.ensure_loaded(path, 1)
+        again_old = resolver.ensure_loaded(path, 0)
+
+    assert first is again_old
+    assert first is not second
+    assert load_calls == [path, path]
+    assert (path, 0) in resolver._cache
+    assert (path, 1) in resolver._cache
 
 
 @pytest.mark.asyncio
@@ -180,13 +227,10 @@ async def test_agentic_dispatch_does_not_double_semaphore():
     from relax.agentic.pipeline import reward as agentic_reward
 
     args = _args(f"{FIXTURE}.async_reward", reward_max_concurrency=1)
-    # With concurrency 1, two overlapping agentic sample rewards must still complete:
-    # dispatch path must not acquire RewardExecutor semaphore again.
     domain = agentic_reward.RewardDomain(args=args, group_filter=None, max_submissions_per_step=1)
 
     async def run_one(idx: int):
-        sample = _sample(index=idx)
-        return await domain._run_sample_reward(sample)
+        return await domain._run_sample_reward(_sample(index=idx))
 
     results = await asyncio.wait_for(asyncio.gather(run_one(0), run_one(1)), timeout=5)
     assert all(r.reward == 1.0 for r in results)


### PR DESCRIPTION
## Summary

Closes #109

Sync `--custom-rm-path` used to run on the Driver event loop, which blocked rollout and bypassed `RewardWorker` isolation / concurrency limits. Legacy and agentic paths also each called `load_function`, so caching and error boundaries were inconsistent.

This PR routes sync custom rewards through the existing `RewardWorker` pool, keeps recognizable `async def` rewards on the Driver via `await`, splits `execute_custom_*` / `dispatch_custom_*` to avoid double semaphore acquire, and caches callables by path + generation (bump on successful reload).

## Changes
- `relax/engine/rewards/`: sync/async dispatch, worker config whitelist, resolver, error wrapping
- `relax/agentic/pipeline/reward.py`: delegate custom rewards to `dispatch_*`
- `relax/utils/reload_utils.py` + `relax/distributed/ray/rollout.py`: generation registry bind
- Tests: `tests/engine/rewards/test_custom_reward_concurrency.py`
- Docs: EN/ZH `configuration.md`, `customize-training.md`
No new CLI flags. Reuses `--custom-rm-path`, `--reward-max-concurrency`, `--reward-num-workers`.
Keeps legacy `batched_async_rm` + custom list-input compatibility.

## Verification
Env: Ubuntu 24.04 / Python 3.12.3 / ray 2.56.0 / CPU-only Ray  
Commit: `54337f8` (base: `cfda053` on `origin/main`)

```
pytest tests/engine/rewards/test_custom_reward_concurrency.py -q
pytest tests/engine/rewards/test_reward_worker.py -q
```
Results: 10 passed (new), 40 passed (reward worker regression).

## Risk & Rollback
- Sync custom only sees a whitelisted args view (+ optional custom_options)
- Async path only for recognizable async def
- Rollback: revert this PR, or omit --custom-rm-path