### PR TITLE
feat(rollout): schedule multiturn model requests per logical SGLang call

### DIFF
--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -183,7 +183,6 @@ async def generate(
 - **request-aware (recommended)**: use both `@request_model_aware` and a required keyword-only `request_model` parameter. Marker/signature mismatches raise `TypeError` before execution (no silent fallback).
 - **legacy**: unmarked custom generate keeps session-level gating (full multi-turn including env still holds one slot) with the original call signature.
 - Do not bypass `request_model` by calling `post()` directly; bypassed requests are outside the framework concurrency guarantee.
-- The evaluation abort exception is already bound into the injected `request_model`; declare `evaluation` only when your business logic needs it.
 :::
 
 Specify via launch script (`--custom-generate-function-path examples.deepeyes.rollout.generate`), or per eval dataset via `custom_generate_function_path` in eval config.

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -140,18 +140,30 @@ The function must populate these `sample` fields before returning: `tokens` (ful
 
 **Example** — simplified from [`examples/deepeyes/rollout.py`](../examples/deepeyes.md) (multi-turn tool-use rollout):
 
-```python
-from relax.engine.rollout.sglang_rollout import GenerateState
-from relax.utils.http_utils import post
+Prefer `@request_model_aware` and use the framework-injected `request_model` for every model call. Only one logical SGLang request occupies a model-request slot; environment / tool execution does not block other short requests.
 
-async def generate(args, sample: Sample, sampling_params) -> Sample:
+```python
+from relax.engine.rollout.sglang_rollout import GenerateState, RequestModel, request_model_aware
+
+@request_model_aware
+async def generate(
+    args,
+    sample: Sample,
+    sampling_params,
+    *,
+    request_model: RequestModel,
+) -> Sample:
     state = GenerateState(args)
     url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
     env = build_env(sample=sample, args=args); env.reset()
     prompt_ids = state.tokenizer.encode(sample.prompt, add_special_tokens=False)
     sample.tokens, sample.loss_mask, sample.rollout_log_probs, response_tokens = list(prompt_ids), [], [], []
     for turn in range(args.max_turns):
-        output = await post(url, {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True})
+        # Each turn takes a model-request slot independently; env steps stay outside the slot.
+        output = await request_model(
+            url,
+            {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True},
+        )
         new_tokens = [t[1] for t in output["meta_info"]["output_token_logprobs"]]
         new_probs = [t[0] for t in output["meta_info"]["output_token_logprobs"]]
         sample.tokens.extend(new_tokens); response_tokens.extend(new_tokens)                 # model output
@@ -166,6 +178,13 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     sample.status = Sample.Status.COMPLETED
     return sample
 ```
+
+::: tip Migration notes
+- **request-aware (recommended)**: use both `@request_model_aware` and a required keyword-only `request_model` parameter. Marker/signature mismatches raise `TypeError` before execution (no silent fallback).
+- **legacy**: unmarked custom generate keeps session-level gating (full multi-turn including env still holds one slot) with the original call signature.
+- Do not bypass `request_model` by calling `post()` directly; bypassed requests are outside the framework concurrency guarantee.
+- The evaluation abort exception is already bound into the injected `request_model`; declare `evaluation` only when your business logic needs it.
+:::
 
 Specify via launch script (`--custom-generate-function-path examples.deepeyes.rollout.generate`), or per eval dataset via `custom_generate_function_path` in eval config.
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -139,18 +139,30 @@ async def generate(args: Any, sample: Sample, sampling_params: dict, evaluation:
 
 **示例** — 简化自 [`examples/deepeyes/rollout.py`](../examples/deepeyes.md)（多轮工具调用 rollout）：
 
-```python
-from relax.engine.rollout.sglang_rollout import GenerateState
-from relax.utils.http_utils import post
+推荐使用 `@request_model_aware`，并在每一轮模型调用处使用框架注入的 `request_model`。这样只有单次逻辑 SGLang 请求占用模型请求槽位，环境 / 工具执行不会阻塞其他短请求。
 
-async def generate(args, sample: Sample, sampling_params) -> Sample:
+```python
+from relax.engine.rollout.sglang_rollout import GenerateState, RequestModel, request_model_aware
+
+@request_model_aware
+async def generate(
+    args,
+    sample: Sample,
+    sampling_params,
+    *,
+    request_model: RequestModel,
+) -> Sample:
     state = GenerateState(args)
     url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
     env = build_env(sample=sample, args=args); env.reset()
     prompt_ids = state.tokenizer.encode(sample.prompt, add_special_tokens=False)
     sample.tokens, sample.loss_mask, sample.rollout_log_probs, response_tokens = list(prompt_ids), [], [], []
     for turn in range(args.max_turns):
-        output = await post(url, {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True})
+        # 每轮独立占用模型请求槽位；环境步骤在槽位之外
+        output = await request_model(
+            url,
+            {"input_ids": sample.tokens, "sampling_params": sampling_params, "return_logprob": True},
+        )
         new_tokens = [t[1] for t in output["meta_info"]["output_token_logprobs"]]
         new_probs = [t[0] for t in output["meta_info"]["output_token_logprobs"]]
         sample.tokens.extend(new_tokens); response_tokens.extend(new_tokens)                 # 模型输出
@@ -165,6 +177,13 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     sample.status = Sample.Status.COMPLETED
     return sample
 ```
+
+::: tip 迁移说明
+- **request-aware（推荐）**：同时满足 `@request_model_aware` 与必需的 keyword-only 参数 `request_model`。marker 与签名不一致时会在执行前抛出 `TypeError`，不会静默回退。
+- **legacy**：未标记的 custom generate 保持原会话级限流（完整多轮含环境阶段仍占一个槽位），调用签名不变。
+- 不要绕过 `request_model` 直接调用 `post()`；绕过的请求不在框架并发保证范围内。
+- `evaluation` 对 abort 的例外已绑定在注入的 `request_model` 上；业务无需仅为 admission 声明 `evaluation`。
+:::
 
 通过启动脚本指定（`--custom-generate-function-path examples.deepeyes.rollout.generate`），或在评估数据集配置中通过 `custom_generate_function_path` 按数据集设置。
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -182,7 +182,6 @@ async def generate(
 - **request-aware（推荐）**：同时满足 `@request_model_aware` 与必需的 keyword-only 参数 `request_model`。marker 与签名不一致时会在执行前抛出 `TypeError`，不会静默回退。
 - **legacy**：未标记的 custom generate 保持原会话级限流（完整多轮含环境阶段仍占一个槽位），调用签名不变。
 - 不要绕过 `request_model` 直接调用 `post()`；绕过的请求不在框架并发保证范围内。
-- `evaluation` 对 abort 的例外已绑定在注入的 `request_model` 上；业务无需仅为 admission 声明 `evaluation`。
 :::
 
 通过启动脚本指定（`--custom-generate-function-path examples.deepeyes.rollout.generate`），或在评估数据集配置中通过 `custom_generate_function_path` 按数据集设置。

--- a/examples/deepeyes/rollout.py
+++ b/examples/deepeyes/rollout.py
@@ -14,9 +14,8 @@ import pybase64
 import torch
 
 from examples.deepeyes.base_env import BaseInteractionEnv
-from relax.engine.rollout.sglang_rollout import GenerateState
+from relax.engine.rollout.sglang_rollout import GenerateState, RequestModel, RolloutRequestAborted, request_model_aware
 from relax.utils.data.processing_utils import encode_image_for_rollout_engine, get_encode_executor
-from relax.utils.http_utils import post
 from relax.utils.types import Sample
 
 
@@ -213,7 +212,16 @@ async def _prepare_start_state(sample: Sample, state, args: Any, sampling_params
     return current_image_data, response_tokens, context_budget, generation_budget, multimodal_train_inputs_buffer
 
 
-async def _run_inference_step(url: str, tokens: list[int], sampling_params: dict, image_data, tokenizer, args=None):
+async def _run_inference_step(
+    url: str,
+    tokens: list[int],
+    sampling_params: dict,
+    image_data,
+    tokenizer,
+    args=None,
+    *,
+    request_model: RequestModel,
+):
     payload = {
         "input_ids": tokens,
         "sampling_params": sampling_params,
@@ -224,7 +232,7 @@ async def _run_inference_step(url: str, tokens: list[int], sampling_params: dict
     if image_data:
         payload["image_data"] = image_data
 
-    output = await post(url, payload)
+    output = await request_model(url, payload)
     response_text = output["text"]
     if "output_token_logprobs" in output["meta_info"]:
         new_tokens = [item[1] for item in output["meta_info"]["output_token_logprobs"]]
@@ -335,10 +343,16 @@ def _update_routed_experts(sample: Sample, meta_info: dict, args: Any) -> None:
     )
 
 
-def _finalize_sample(sample: Sample, tokenizer, response_tokens, multimodal_train_inputs_buffer):
+# Status-neutral sync of decoded response and multimodal train inputs.
+def _sync_sample_outputs(sample: Sample, tokenizer, response_tokens, multimodal_train_inputs_buffer):
     sample.multimodal_train_inputs = _merge_multimodal_train_inputs(multimodal_train_inputs_buffer)
     sample.response = tokenizer.decode(response_tokens, skip_special_tokens=False)
     sample.response_length = len(response_tokens)
+    return sample
+
+
+def _finalize_sample(sample: Sample, tokenizer, response_tokens, multimodal_train_inputs_buffer):
+    _sync_sample_outputs(sample, tokenizer, response_tokens, multimodal_train_inputs_buffer)
     if sample.status is None:
         sample.status = Sample.Status.COMPLETED
     return sample
@@ -391,10 +405,15 @@ class _RolloutTraceRecorder:
         }
 
 
-async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
-    """Custom multi-turn rollout that interacts with a pluggable
-    environment."""
-
+@request_model_aware
+async def generate(
+    args: Any,
+    sample: Sample,
+    sampling_params,
+    *,
+    request_model: RequestModel,
+) -> Sample:
+    # Custom multi-turn rollout that interacts with a pluggable environment.
     env, env_module, config, state, url = _initialize_resources(args, sample)
     sampling_params = sampling_params.copy()
 
@@ -469,15 +488,34 @@ async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
             )
 
             inference_start_ts = time.time()
-            (
-                response_text,
-                new_response_tokens,
-                new_response_log_probs,
-                finish_type,
-                meta_info,
-            ) = await _run_inference_step(
-                url, sample.tokens, cur_sampling_params, current_image_data, state.tokenizer, args=args
-            )
+            try:
+                (
+                    response_text,
+                    new_response_tokens,
+                    new_response_log_probs,
+                    finish_type,
+                    meta_info,
+                ) = await _run_inference_step(
+                    url,
+                    sample.tokens,
+                    cur_sampling_params,
+                    current_image_data,
+                    state.tokenizer,
+                    args=args,
+                    request_model=request_model,
+                )
+            except RolloutRequestAborted:
+                # Scheduler refused before HTTP; do not count this turn or append incomplete trace.
+                sample.metadata["rollout_turns"] = turn_idx
+                sample.metadata["rollout_stop_reason"] = "rollout_abort"
+                _sync_sample_outputs(
+                    sample,
+                    tokenizer=state.tokenizer,
+                    response_tokens=response_tokens,
+                    multimodal_train_inputs_buffer=multimodal_train_inputs_buffer,
+                )
+                # Keep _current_turn_response_start for resumption from the same turn.
+                raise
             inference_end_ts = time.time()
             trace_recorder.record_inference_output(
                 response_text, finish_type, max(0.0, inference_end_ts - inference_start_ts)

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -5,10 +5,11 @@ import copy
 import inspect
 import uuid
 from argparse import Namespace
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
+from functools import partial
 from time import monotonic
-from typing import Any
+from typing import Any, Protocol
 
 import numpy as np
 import pybase64
@@ -45,9 +46,113 @@ from relax.utils.types import Sample
 from relax.utils.utils import CURRENT_ROLLOUT_BATCH, compute_dp_size, transfer_batch_to_data_system
 
 
-__all__ = ["generate_rollout"]
+__all__ = [
+    "generate_rollout",
+    "GenerateState",
+    "ModelRequestScheduler",
+    "RequestModel",
+    "RolloutRequestAborted",
+    "request_model_aware",
+]
 
 logger = get_logger(__name__)
+
+_REQUEST_MODEL_AWARE_ATTR = "__relax_request_model_aware__"
+
+
+# Raised when a model request is refused because training rollout was aborted.
+class RolloutRequestAborted(RuntimeError):
+    pass
+
+
+# Capability for sending one logical SGLang model request under admission control.
+class RequestModel(Protocol):
+    async def __call__(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> Any: ...
+
+
+# Mark a custom generate function as request-aware (per-request model slot).
+def request_model_aware(fn: Callable) -> Callable:
+    setattr(fn, _REQUEST_MODEL_AWARE_ATTR, True)
+    return fn
+
+
+def _is_request_model_aware(fn: Callable) -> bool:
+    unwrapped = inspect.unwrap(fn)
+    return bool(getattr(fn, _REQUEST_MODEL_AWARE_ATTR, False) or getattr(unwrapped, _REQUEST_MODEL_AWARE_ATTR, False))
+
+
+# Fail fast when @request_model_aware is present but request_model is not a required KW-only param.
+def _validate_request_model_signature(fn: Callable) -> None:
+    sig = inspect.signature(inspect.unwrap(fn))
+    param = sig.parameters.get("request_model")
+    if param is None:
+        raise TypeError(
+            f"{getattr(fn, '__qualname__', fn)} is marked @request_model_aware but missing "
+            "required keyword-only parameter 'request_model'"
+        )
+    if param.kind != inspect.Parameter.KEYWORD_ONLY:
+        raise TypeError(
+            f"{getattr(fn, '__qualname__', fn)}: 'request_model' must be a keyword-only parameter, "
+            f"got kind={param.kind!s}"
+        )
+    if param.default is not inspect.Parameter.empty:
+        raise TypeError(
+            f"{getattr(fn, '__qualname__', fn)}: 'request_model' must have no default value "
+            "(required keyword-only parameter)"
+        )
+
+
+def _model_request_capacity(args: Namespace) -> int:
+    return args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+
+
+# Admit logical SGLang model requests with a shared BoundedSemaphore.
+# A slot covers one logical post() call (including internal retries/backoff).
+# Custom code receives only a bound request_model callable, never this object.
+class ModelRequestScheduler:
+    def __init__(self, state: "GenerateState", capacity: int) -> None:
+        self._state = state
+        self._semaphore = asyncio.BoundedSemaphore(capacity)
+        self.capacity = capacity
+
+    async def _run_with_slot(
+        self,
+        operation: Callable[[], Awaitable[Any]],
+        *,
+        evaluation: bool,
+    ) -> Any:
+        async with self._semaphore:
+            if self._state.aborted and not evaluation:
+                raise RolloutRequestAborted("Rollout aborted; refusing model request")
+            return await operation()
+
+    async def request(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        headers: dict[str, str] | None = None,
+        evaluation: bool = False,
+    ) -> Any:
+        async def send_request() -> Any:
+            return await post(url, payload, headers=headers)
+
+        return await self._run_with_slot(send_request, evaluation=evaluation)
+
+    # Hold one slot for an entire legacy custom generate session.
+    async def run_legacy(
+        self,
+        operation: Callable[[], Awaitable[Any]],
+        *,
+        evaluation: bool,
+    ) -> Any:
+        return await self._run_with_slot(operation, evaluation=evaluation)
 
 
 class GenerateState(metaclass=SingletonMeta):
@@ -82,9 +187,7 @@ class GenerateState(metaclass=SingletonMeta):
                 except Exception as e:
                     logger.warning(f"Failed to create ProcessorPool, falling back to ThreadPoolExecutor: {e}")
 
-        self.semaphore = asyncio.Semaphore(
-            args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
-        )
+        self.model_request_scheduler = ModelRequestScheduler(self, _model_request_capacity(args))
         self.sampling_params: dict[str, Any] = dict(
             temperature=args.rollout_temperature,
             top_p=args.rollout_top_p,
@@ -250,9 +353,16 @@ async def _encode_multimodal_inputs(multimodal_inputs: dict) -> tuple[dict[str, 
 
 
 async def generate(
-    args: Namespace, sample: Sample, sampling_params: dict[str, Any], evaluation: bool = False
+    args: Namespace,
+    sample: Sample,
+    sampling_params: dict[str, Any],
+    evaluation: bool = False,
+    *,
+    request_model: RequestModel,
 ) -> Sample:
-    """Generate using traditional SGLang router with token-based workflow."""
+    # Generate using traditional SGLang router with token-based workflow.
+    # request_model admits one logical SGLang HTTP call; multimodal encode /
+    # response post-process stay outside the model-request slot.
     if args.ci_test:
         assert isinstance(sample.prompt, str)
 
@@ -346,7 +456,7 @@ async def generate(
         headers = {"X-SMG-Routing-Key": str(sample.group_index)}
 
     _t_generate_start = monotonic()
-    output = await post(url, payload, headers=headers)
+    output = await request_model(url, payload, headers=headers)
     _t_generate = monotonic() - _t_generate_start
 
     _t_post_generate_start = monotonic()
@@ -465,25 +575,49 @@ async def generate_and_rm(
 
     state = GenerateState(args)
 
-    # generate
-    async with state.semaphore:
-        if state.aborted:
-            sample.status = Sample.Status.ABORTED
-            return sample
+    # Fast abort: evaluation must continue even when training rollout is aborted.
+    if state.aborted and not evaluation:
+        sample.status = Sample.Status.ABORTED
+        return sample
 
-        with state.dp_rank_context() as _:
-            # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
-            custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
+    request_model = partial(state.model_request_scheduler.request, evaluation=evaluation)
+    custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
 
-            if custom_func_path is not None:
-                custom_generate_func = load_function(custom_func_path)
-                # if signature has evaluation, pass evaluation
+    try:
+        if custom_func_path is not None:
+            custom_generate_func = load_function(custom_func_path)
+            if _is_request_model_aware(custom_generate_func):
+                _validate_request_model_signature(custom_generate_func)
+                call_kwargs: dict[str, Any] = {"request_model": request_model}
                 if "evaluation" in inspect.signature(custom_generate_func).parameters:
-                    sample = await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
-                else:
-                    sample = await custom_generate_func(args, sample, sampling_params)
+                    call_kwargs["evaluation"] = evaluation
+                with state.dp_rank_context() as _:
+                    sample = await custom_generate_func(args, sample, sampling_params, **call_kwargs)
             else:
-                sample = await generate(args, sample, sampling_params, evaluation=evaluation)
+                # Legacy custom: keep full-session gating (including env/tool phases).
+                async def _legacy_custom() -> Sample | list[Sample]:
+                    with state.dp_rank_context() as _:
+                        if "evaluation" in inspect.signature(custom_generate_func).parameters:
+                            return await custom_generate_func(
+                                args, sample, sampling_params, evaluation=evaluation
+                            )
+                        return await custom_generate_func(args, sample, sampling_params)
+
+                sample = await state.model_request_scheduler.run_legacy(
+                    _legacy_custom, evaluation=evaluation
+                )
+        else:
+            with state.dp_rank_context() as _:
+                sample = await generate(
+                    args,
+                    sample,
+                    sampling_params,
+                    evaluation=evaluation,
+                    request_model=request_model,
+                )
+    except RolloutRequestAborted:
+        sample.status = Sample.Status.ABORTED
+        return sample
 
     # for the rm that need the whole group, we will not do the rm here
     if args.group_rm:

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -7,7 +7,6 @@ import uuid
 from argparse import Namespace
 from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
-from functools import partial
 from time import monotonic
 from typing import Any, Protocol
 
@@ -108,7 +107,25 @@ def _validate_request_model_signature(fn: Callable) -> None:
 
 
 def _model_request_capacity(args: Namespace) -> int:
-    return args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+    concurrency = args.sglang_server_concurrency
+    rollout_num_gpus = args.rollout_num_gpus
+    rollout_num_gpus_per_engine = args.rollout_num_gpus_per_engine
+    if concurrency <= 0:
+        raise ValueError(f"sglang_server_concurrency must be positive, got {concurrency}")
+    if rollout_num_gpus <= 0:
+        raise ValueError(f"rollout_num_gpus must be positive, got {rollout_num_gpus}")
+    if rollout_num_gpus_per_engine <= 0:
+        raise ValueError(f"rollout_num_gpus_per_engine must be positive, got {rollout_num_gpus_per_engine}")
+
+    capacity = concurrency * rollout_num_gpus // rollout_num_gpus_per_engine
+    if capacity <= 0:
+        raise ValueError(
+            "model request capacity must be positive, got "
+            f"{capacity} from sglang_server_concurrency={concurrency}, "
+            f"rollout_num_gpus={rollout_num_gpus}, "
+            f"rollout_num_gpus_per_engine={rollout_num_gpus_per_engine}"
+        )
+    return capacity
 
 
 # Admit logical SGLang model requests with a shared BoundedSemaphore.
@@ -116,6 +133,8 @@ def _model_request_capacity(args: Namespace) -> int:
 # Custom code receives only a bound request_model callable, never this object.
 class ModelRequestScheduler:
     def __init__(self, state: "GenerateState", capacity: int) -> None:
+        if capacity <= 0:
+            raise ValueError(f"model request capacity must be positive, got {capacity}")
         self._state = state
         self._semaphore = asyncio.BoundedSemaphore(capacity)
         self.capacity = capacity
@@ -123,11 +142,9 @@ class ModelRequestScheduler:
     async def _run_with_slot(
         self,
         operation: Callable[[], Awaitable[Any]],
-        *,
-        evaluation: bool,
     ) -> Any:
         async with self._semaphore:
-            if self._state.aborted and not evaluation:
+            if self._state.aborted:
                 raise RolloutRequestAborted("Rollout aborted; refusing model request")
             return await operation()
 
@@ -137,21 +154,18 @@ class ModelRequestScheduler:
         payload: dict[str, Any],
         *,
         headers: dict[str, str] | None = None,
-        evaluation: bool = False,
     ) -> Any:
         async def send_request() -> Any:
             return await post(url, payload, headers=headers)
 
-        return await self._run_with_slot(send_request, evaluation=evaluation)
+        return await self._run_with_slot(send_request)
 
     # Hold one slot for an entire legacy custom generate session.
     async def run_legacy(
         self,
         operation: Callable[[], Awaitable[Any]],
-        *,
-        evaluation: bool,
     ) -> Any:
-        return await self._run_with_slot(operation, evaluation=evaluation)
+        return await self._run_with_slot(operation)
 
 
 class GenerateState(metaclass=SingletonMeta):
@@ -357,7 +371,7 @@ async def generate(
     sampling_params: dict[str, Any],
     evaluation: bool = False,
     *,
-    request_model: RequestModel,
+    request_model: RequestModel | None = None,
 ) -> Sample:
     # Generate using traditional SGLang router with token-based workflow.
     # request_model admits one logical SGLang HTTP call; multimodal encode /
@@ -366,6 +380,8 @@ async def generate(
         assert isinstance(sample.prompt, str)
 
     state = GenerateState(args)
+    if request_model is None:
+        request_model = state.model_request_scheduler.request
     url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
 
     assert sample.status == Sample.Status.PENDING or sample.status == Sample.Status.ABORTED, (
@@ -574,12 +590,12 @@ async def generate_and_rm(
 
     state = GenerateState(args)
 
-    # Fast abort: evaluation must continue even when training rollout is aborted.
-    if state.aborted and not evaluation:
+    # Do not start new model requests after the rollout has been aborted.
+    if state.aborted:
         sample.status = Sample.Status.ABORTED
         return sample
 
-    request_model = partial(state.model_request_scheduler.request, evaluation=evaluation)
+    request_model = state.model_request_scheduler.request
     custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
 
     try:
@@ -600,7 +616,7 @@ async def generate_and_rm(
                             return await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
                         return await custom_generate_func(args, sample, sampling_params)
 
-                sample = await state.model_request_scheduler.run_legacy(_legacy_custom, evaluation=evaluation)
+                sample = await state.model_request_scheduler.run_legacy(_legacy_custom)
         else:
             with state.dp_rank_context() as _:
                 sample = await generate(

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -598,14 +598,10 @@ async def generate_and_rm(
                 async def _legacy_custom() -> Sample | list[Sample]:
                     with state.dp_rank_context() as _:
                         if "evaluation" in inspect.signature(custom_generate_func).parameters:
-                            return await custom_generate_func(
-                                args, sample, sampling_params, evaluation=evaluation
-                            )
+                            return await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
                         return await custom_generate_func(args, sample, sampling_params)
 
-                sample = await state.model_request_scheduler.run_legacy(
-                    _legacy_custom, evaluation=evaluation
-                )
+                sample = await state.model_request_scheduler.run_legacy(_legacy_custom, evaluation=evaluation)
         else:
             with state.dp_rank_context() as _:
                 sample = await generate(

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -19,7 +19,6 @@ import torch
 from packaging.version import parse
 from tqdm import tqdm
 
-from relax.distributed.ray.rollout import _log_rollout_data
 from relax.engine.filters.base_types import MetricGatherer, call_dynamic_filter
 from relax.engine.rewards import async_rm, batched_async_rm
 from relax.engine.rollout import on_policy_distillation as opd
@@ -1175,6 +1174,8 @@ async def generate_rollout_async(
             rollout_metrics["rollout/staleness/max"] = np.max(staleness_gaps).item()
             rollout_metrics["rollout/staleness/min"] = np.min(staleness_gaps).item()
             rollout_metrics["rollout/global_batch_size"] = len(data) * args.n_samples_per_prompt
+        from relax.distributed.ray.rollout import _log_rollout_data
+
         _log_rollout_data(rollout_id, args, CURRENT_ROLLOUT_BATCH, rollout_metrics, rollout_time)
         if args.debug_rollout_only:
             logger.info("Debug rollout only mode - data system cleanup")

--- a/tests/engine/rollout/test_model_request_scheduler.py
+++ b/tests/engine/rollout/test_model_request_scheduler.py
@@ -44,7 +44,10 @@ def test_model_request_scheduler_rejects_non_positive_capacity(capacity: int) ->
         ({"sglang_server_concurrency": 0}, "sglang_server_concurrency"),
         ({"rollout_num_gpus": 0}, "rollout_num_gpus"),
         ({"rollout_num_gpus_per_engine": 0}, "rollout_num_gpus_per_engine"),
-        ({"rollout_num_gpus": 1, "rollout_num_gpus_per_engine": 2}, "capacity must be positive"),
+        (
+            {"sglang_server_concurrency": 1, "rollout_num_gpus": 1, "rollout_num_gpus_per_engine": 2},
+            "capacity must be positive",
+        ),
     ],
 )
 def test_model_request_capacity_rejects_invalid_configuration(overrides: dict[str, int], message: str) -> None:

--- a/tests/engine/rollout/test_model_request_scheduler.py
+++ b/tests/engine/rollout/test_model_request_scheduler.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -42,34 +43,6 @@ class _ActiveCounter:
 
     def leave(self) -> None:
         self.active -= 1
-
-
-@pytest.mark.asyncio
-async def test_model_request_scheduler_respects_capacity() -> None:
-    scheduler, _ = _scheduler(capacity=2)
-    counter = _ActiveCounter()
-    release = asyncio.Event()
-    entered = asyncio.Event()
-
-    async def fake_post(url, payload, headers=None):
-        counter.enter()
-        if counter.active == 2:
-            entered.set()
-        await release.wait()
-        counter.leave()
-        return {"ok": True}
-
-    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
-        tasks = [
-            asyncio.create_task(scheduler.request("http://x", {"i": i})) for i in range(3)
-        ]
-        await asyncio.wait_for(entered.wait(), timeout=1.0)
-        assert counter.max_active <= 2
-        assert counter.active == 2
-        release.set()
-        await asyncio.gather(*tasks)
-        assert counter.max_active <= 2
-        assert counter.calls == 3
 
 
 @pytest.mark.asyncio
@@ -124,7 +97,7 @@ async def test_model_request_scheduler_releases_on_cancel_while_holding() -> Non
 
     async def fake_post(url, payload, headers=None):
         holding.set()
-        await asyncio.Event().wait()  # block forever
+        await asyncio.Event().wait()
         return {}
 
     with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
@@ -200,20 +173,6 @@ async def test_model_request_scheduler_abort_after_acquire() -> None:
 
 
 @pytest.mark.asyncio
-async def test_model_request_scheduler_evaluation_ignores_abort() -> None:
-    scheduler, state = _scheduler(capacity=1)
-    state.aborted = True
-
-    async def ok(url, payload, headers=None):
-        return {"ok": True}
-
-    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=ok):
-        with pytest.raises(RolloutRequestAborted):
-            await scheduler.request("http://x", {}, evaluation=False)
-        assert await scheduler.request("http://x", {}, evaluation=True) == {"ok": True}
-
-
-@pytest.mark.asyncio
 async def test_model_request_scheduler_retry_holds_slot_for_real_post(monkeypatch: pytest.MonkeyPatch) -> None:
     # Real http_utils.post/_post retry+backoff still occupies one scheduler slot.
     import httpx
@@ -234,14 +193,12 @@ async def test_model_request_scheduler_retry_holds_slot_for_real_post(monkeypatc
             self.calls += 1
             if self.calls == 1:
                 raise httpx.ConnectError("transient")
-            # Third HTTP call is the second scheduler.request()'s first attempt.
             if self.calls >= 3:
                 second_http_started.set()
             request = httpx.Request("POST", url)
             return httpx.Response(200, request=request, json={"ok": True, "call": self.calls})
 
     async def gated_sleep(seconds: float) -> None:
-        # Only gate the retry backoff (~1s); keep sleep(0)/short yields real.
         if seconds < 0.5:
             await real_sleep(seconds)
             return
@@ -252,7 +209,6 @@ async def test_model_request_scheduler_retry_holds_slot_for_real_post(monkeypatc
     monkeypatch.setattr(http_utils, "_distributed_post_enabled", False)
     monkeypatch.setattr(http_utils.asyncio, "sleep", gated_sleep)
 
-    # Do not patch sglang_rollout.post: exercise the real http_utils.post path.
     t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
     await asyncio.wait_for(backoff_entered.wait(), timeout=1.0)
 
@@ -290,8 +246,6 @@ async def test_mixed_ordinary_aware_legacy_respect_shared_capacity() -> None:
         counter.leave()
         return "legacy"
 
-    from functools import partial
-
     request_model = partial(scheduler.request, evaluation=False)
 
     @request_model_aware
@@ -317,35 +271,7 @@ async def test_mixed_ordinary_aware_legacy_respect_shared_capacity() -> None:
         assert counter.calls == 3
 
 
-@pytest.mark.asyncio
-async def test_model_request_scheduler_run_legacy_holds_session_slot() -> None:
-    scheduler, _ = _scheduler(capacity=1)
-    legacy_entered = asyncio.Event()
-    release_legacy = asyncio.Event()
-    other_entered = asyncio.Event()
-
-    async def legacy_op():
-        legacy_entered.set()
-        await release_legacy.wait()
-        return "legacy"
-
-    async def other_post(url, payload, headers=None):
-        other_entered.set()
-        return {"ok": True}
-
-    t_legacy = asyncio.create_task(scheduler.run_legacy(legacy_op, evaluation=False))
-    await asyncio.wait_for(legacy_entered.wait(), timeout=1.0)
-    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=other_post):
-        t_other = asyncio.create_task(scheduler.request("http://x", {}))
-        await asyncio.sleep(0)
-        assert not other_entered.is_set()
-        release_legacy.set()
-        assert await t_legacy == "legacy"
-        await asyncio.wait_for(other_entered.wait(), timeout=1.0)
-        assert await t_other == {"ok": True}
-
-
-def test_request_model_aware_marker_and_signature_validation() -> None:
+def test_request_model_aware_accepts_valid_signature() -> None:
     async def unmarked(args, sample, sampling_params, *, request_model):
         return sample
 
@@ -358,56 +284,23 @@ def test_request_model_aware_marker_and_signature_validation() -> None:
     assert _is_request_model_aware(good)
     _validate_request_model_signature(good)
 
+
+def test_request_model_aware_rejects_invalid_signature() -> None:
     @request_model_aware
     async def missing(args, sample, sampling_params):
         return sample
-
-    with pytest.raises(TypeError, match="missing"):
-        _validate_request_model_signature(missing)
 
     @request_model_aware
     async def positional(args, sample, sampling_params, request_model):
         return sample
 
-    with pytest.raises(TypeError, match="keyword-only"):
-        _validate_request_model_signature(positional)
-
     @request_model_aware
     async def optional(args, sample, sampling_params, *, request_model=None):
         return sample
 
+    with pytest.raises(TypeError, match="missing"):
+        _validate_request_model_signature(missing)
+    with pytest.raises(TypeError, match="keyword-only"):
+        _validate_request_model_signature(positional)
     with pytest.raises(TypeError, match="no default"):
         _validate_request_model_signature(optional)
-
-
-@pytest.mark.asyncio
-async def test_bypass_request_model_not_in_framework_guarantee() -> None:
-    # Third-party HTTP that bypasses request_model is outside capacity accounting.
-    scheduler, _ = _scheduler(capacity=1)
-    counter = _ActiveCounter()
-    holding = asyncio.Event()
-    release = asyncio.Event()
-
-    async def slotted(url, payload, headers=None):
-        counter.enter()
-        holding.set()
-        await release.wait()
-        counter.leave()
-        return {"slotted": True}
-
-    async def bypass_http():
-        # Simulates custom code calling post() directly — not admitted.
-        counter.enter()
-        await asyncio.sleep(0)
-        counter.leave()
-        return {"bypass": True}
-
-    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=slotted):
-        t1 = asyncio.create_task(scheduler.request("http://x", {}))
-        await asyncio.wait_for(holding.wait(), timeout=1.0)
-        bypass_result = await bypass_http()
-        assert bypass_result == {"bypass": True}
-        # Framework-managed active is 1, but raw counter may be 2 during bypass overlap.
-        assert counter.max_active >= 2
-        release.set()
-        await t1

--- a/tests/engine/rollout/test_model_request_scheduler.py
+++ b/tests/engine/rollout/test_model_request_scheduler.py
@@ -1,0 +1,411 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+# CPU async unit tests for ModelRequestScheduler and request_model_aware contract.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from relax.engine.rollout.sglang_rollout import (
+    ModelRequestScheduler,
+    RolloutRequestAborted,
+    _is_request_model_aware,
+    _validate_request_model_signature,
+    request_model_aware,
+)
+
+
+class _FakeState:
+    def __init__(self) -> None:
+        self.aborted = False
+
+
+def _scheduler(capacity: int = 1) -> tuple[ModelRequestScheduler, _FakeState]:
+    state = _FakeState()
+    return ModelRequestScheduler(state, capacity), state
+
+
+class _ActiveCounter:
+    def __init__(self) -> None:
+        self.active = 0
+        self.max_active = 0
+        self.calls = 0
+
+    def enter(self) -> None:
+        self.calls += 1
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+
+    def leave(self) -> None:
+        self.active -= 1
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_respects_capacity() -> None:
+    scheduler, _ = _scheduler(capacity=2)
+    counter = _ActiveCounter()
+    release = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def fake_post(url, payload, headers=None):
+        counter.enter()
+        if counter.active == 2:
+            entered.set()
+        await release.wait()
+        counter.leave()
+        return {"ok": True}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        tasks = [
+            asyncio.create_task(scheduler.request("http://x", {"i": i})) for i in range(3)
+        ]
+        await asyncio.wait_for(entered.wait(), timeout=1.0)
+        assert counter.max_active <= 2
+        assert counter.active == 2
+        release.set()
+        await asyncio.gather(*tasks)
+        assert counter.max_active <= 2
+        assert counter.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_releases_on_success() -> None:
+    scheduler, _ = _scheduler(capacity=1)
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    async def fake_post(url, payload, headers=None):
+        if payload["id"] == 1:
+            first_entered.set()
+            await release_first.wait()
+            return {"id": 1}
+        second_entered.set()
+        return {"id": 2}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
+        await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+        t2 = asyncio.create_task(scheduler.request("http://x", {"id": 2}))
+        await asyncio.sleep(0)
+        assert not second_entered.is_set()
+        release_first.set()
+        await asyncio.wait_for(second_entered.wait(), timeout=1.0)
+        assert await t1 == {"id": 1}
+        assert await t2 == {"id": 2}
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_releases_on_exception() -> None:
+    scheduler, _ = _scheduler(capacity=1)
+
+    async def boom(url, payload, headers=None):
+        raise RuntimeError("http failed")
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=boom):
+        with pytest.raises(RuntimeError, match="http failed"):
+            await scheduler.request("http://x", {})
+
+    async def ok(url, payload, headers=None):
+        return {"ok": True}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=ok):
+        assert await scheduler.request("http://x", {}) == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_releases_on_cancel_while_holding() -> None:
+    scheduler, _ = _scheduler(capacity=1)
+    holding = asyncio.Event()
+
+    async def fake_post(url, payload, headers=None):
+        holding.set()
+        await asyncio.Event().wait()  # block forever
+        return {}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        task = asyncio.create_task(scheduler.request("http://x", {}))
+        await asyncio.wait_for(holding.wait(), timeout=1.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    done = asyncio.Event()
+
+    async def ok(url, payload, headers=None):
+        done.set()
+        return {"ok": True}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=ok):
+        await asyncio.wait_for(scheduler.request("http://x", {}), timeout=1.0)
+        assert done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_cancel_while_waiting() -> None:
+    scheduler, _ = _scheduler(capacity=1)
+    first_holding = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def fake_post(url, payload, headers=None):
+        if payload.get("id") == 1:
+            first_holding.set()
+            await release_first.wait()
+            return {"id": 1}
+        return {"id": 2}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
+        await asyncio.wait_for(first_holding.wait(), timeout=1.0)
+        t2 = asyncio.create_task(scheduler.request("http://x", {"id": 2}))
+        await asyncio.sleep(0)
+        t2.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t2
+        release_first.set()
+        assert await t1 == {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_abort_after_acquire() -> None:
+    scheduler, state = _scheduler(capacity=1)
+    first_holding = asyncio.Event()
+    release_first = asyncio.Event()
+    http_calls = 0
+
+    async def fake_post(url, payload, headers=None):
+        nonlocal http_calls
+        http_calls += 1
+        if payload.get("id") == 1:
+            first_holding.set()
+            await release_first.wait()
+            return {"id": 1}
+        return {"id": 2}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
+        await asyncio.wait_for(first_holding.wait(), timeout=1.0)
+        t2 = asyncio.create_task(scheduler.request("http://x", {"id": 2}))
+        await asyncio.sleep(0)
+        state.aborted = True
+        release_first.set()
+        assert await t1 == {"id": 1}
+        with pytest.raises(RolloutRequestAborted):
+            await t2
+        assert http_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_evaluation_ignores_abort() -> None:
+    scheduler, state = _scheduler(capacity=1)
+    state.aborted = True
+
+    async def ok(url, payload, headers=None):
+        return {"ok": True}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=ok):
+        with pytest.raises(RolloutRequestAborted):
+            await scheduler.request("http://x", {}, evaluation=False)
+        assert await scheduler.request("http://x", {}, evaluation=True) == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_retry_holds_slot_for_logical_post() -> None:
+    # One logical post() (with internal retry/backoff) occupies one slot.
+    scheduler, _ = _scheduler(capacity=1)
+    counter = _ActiveCounter()
+    attempt = 0
+    second_started = asyncio.Event()
+
+    async def flaky_post(url, payload, headers=None):
+        nonlocal attempt
+        counter.enter()
+        try:
+            attempt += 1
+            if attempt == 1:
+                await asyncio.sleep(0.05)
+                raise RuntimeError("transient")
+            return {"ok": True}
+        finally:
+            counter.leave()
+
+    # Simulate http_utils.post wrapping retries inside one awaitable call.
+    async def logical_post(url, payload, headers=None):
+        try:
+            return await flaky_post(url, payload, headers=headers)
+        except RuntimeError:
+            await asyncio.sleep(0.05)
+            return await flaky_post(url, payload, headers=headers)
+
+    async def other_post(url, payload, headers=None):
+        second_started.set()
+        counter.enter()
+        counter.leave()
+        return {"other": True}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=logical_post):
+        t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
+        await asyncio.sleep(0)
+        with patch("relax.engine.rollout.sglang_rollout.post", side_effect=other_post):
+            t2 = asyncio.create_task(scheduler.request("http://x", {"id": 2}))
+            await asyncio.sleep(0.02)
+            assert not second_started.is_set()
+            await t1
+            await asyncio.wait_for(second_started.wait(), timeout=1.0)
+            await t2
+        assert counter.max_active <= 1
+
+
+@pytest.mark.asyncio
+async def test_model_request_scheduler_run_legacy_holds_session_slot() -> None:
+    scheduler, _ = _scheduler(capacity=1)
+    legacy_entered = asyncio.Event()
+    release_legacy = asyncio.Event()
+    other_entered = asyncio.Event()
+
+    async def legacy_op():
+        legacy_entered.set()
+        await release_legacy.wait()
+        return "legacy"
+
+    async def other_post(url, payload, headers=None):
+        other_entered.set()
+        return {"ok": True}
+
+    t_legacy = asyncio.create_task(scheduler.run_legacy(legacy_op, evaluation=False))
+    await asyncio.wait_for(legacy_entered.wait(), timeout=1.0)
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=other_post):
+        t_other = asyncio.create_task(scheduler.request("http://x", {}))
+        await asyncio.sleep(0)
+        assert not other_entered.is_set()
+        release_legacy.set()
+        assert await t_legacy == "legacy"
+        await asyncio.wait_for(other_entered.wait(), timeout=1.0)
+        assert await t_other == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_interleave_short_request_between_turns() -> None:
+    # capacity=1: short request completes during long session env wait.
+    scheduler, _ = _scheduler(capacity=1)
+    turn1_done = asyncio.Event()
+    env_gate = asyncio.Event()
+    short_done = asyncio.Event()
+    order: list[str] = []
+
+    async def fake_post(url, payload, headers=None):
+        label = payload["label"]
+        order.append(f"start:{label}")
+        if label == "long-1":
+            turn1_done.set()
+        if label == "short":
+            short_done.set()
+        order.append(f"end:{label}")
+        return {"label": label}
+
+    @request_model_aware
+    async def long_session(args, sample, sampling_params, *, request_model):
+        await request_model("http://x", {"label": "long-1"})
+        await env_gate.wait()
+        await request_model("http://x", {"label": "long-2"})
+        return sample
+
+    async def short_session():
+        await scheduler.request("http://x", {"label": "short"})
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        from functools import partial
+
+        request_model = partial(scheduler.request, evaluation=False)
+        long_task = asyncio.create_task(
+            long_session(None, SimpleNamespace(), {}, request_model=request_model)
+        )
+        await asyncio.wait_for(turn1_done.wait(), timeout=1.0)
+        short_task = asyncio.create_task(short_session())
+        await asyncio.wait_for(short_done.wait(), timeout=1.0)
+        assert short_done.is_set()
+        assert not env_gate.is_set()
+        env_gate.set()
+        await long_task
+        await short_task
+
+    assert order == [
+        "start:long-1",
+        "end:long-1",
+        "start:short",
+        "end:short",
+        "start:long-2",
+        "end:long-2",
+    ]
+
+
+def test_request_model_aware_marker_and_signature_validation() -> None:
+    async def unmarked(args, sample, sampling_params, *, request_model):
+        return sample
+
+    assert not _is_request_model_aware(unmarked)
+
+    @request_model_aware
+    async def good(args, sample, sampling_params, *, request_model):
+        return sample
+
+    assert _is_request_model_aware(good)
+    _validate_request_model_signature(good)
+
+    @request_model_aware
+    async def missing(args, sample, sampling_params):
+        return sample
+
+    with pytest.raises(TypeError, match="missing"):
+        _validate_request_model_signature(missing)
+
+    @request_model_aware
+    async def positional(args, sample, sampling_params, request_model):
+        return sample
+
+    with pytest.raises(TypeError, match="keyword-only"):
+        _validate_request_model_signature(positional)
+
+    @request_model_aware
+    async def optional(args, sample, sampling_params, *, request_model=None):
+        return sample
+
+    with pytest.raises(TypeError, match="no default"):
+        _validate_request_model_signature(optional)
+
+
+@pytest.mark.asyncio
+async def test_bypass_request_model_not_in_framework_guarantee() -> None:
+    # Third-party HTTP that bypasses request_model is outside capacity accounting.
+    scheduler, _ = _scheduler(capacity=1)
+    counter = _ActiveCounter()
+    holding = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slotted(url, payload, headers=None):
+        counter.enter()
+        holding.set()
+        await release.wait()
+        counter.leave()
+        return {"slotted": True}
+
+    async def bypass_http():
+        # Simulates custom code calling post() directly — not admitted.
+        counter.enter()
+        await asyncio.sleep(0)
+        counter.leave()
+        return {"bypass": True}
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=slotted):
+        t1 = asyncio.create_task(scheduler.request("http://x", {}))
+        await asyncio.wait_for(holding.wait(), timeout=1.0)
+        bypass_result = await bypass_http()
+        assert bypass_result == {"bypass": True}
+        # Framework-managed active is 1, but raw counter may be 2 during bypass overlap.
+        assert counter.max_active >= 2
+        release.set()
+        await t1

--- a/tests/engine/rollout/test_model_request_scheduler.py
+++ b/tests/engine/rollout/test_model_request_scheduler.py
@@ -5,16 +5,18 @@
 from __future__ import annotations
 
 import asyncio
-from functools import partial
+import inspect
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from relax.engine.rollout import sglang_rollout as rollout_mod
 from relax.engine.rollout.sglang_rollout import (
     ModelRequestScheduler,
     RolloutRequestAborted,
     _is_request_model_aware,
+    _model_request_capacity,
     _validate_request_model_signature,
     request_model_aware,
 )
@@ -28,6 +30,47 @@ class _FakeState:
 def _scheduler(capacity: int = 1) -> tuple[ModelRequestScheduler, _FakeState]:
     state = _FakeState()
     return ModelRequestScheduler(state, capacity), state
+
+
+@pytest.mark.parametrize("capacity", [0, -1])
+def test_model_request_scheduler_rejects_non_positive_capacity(capacity: int) -> None:
+    with pytest.raises(ValueError, match="capacity must be positive"):
+        _scheduler(capacity=capacity)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"sglang_server_concurrency": 0}, "sglang_server_concurrency"),
+        ({"rollout_num_gpus": 0}, "rollout_num_gpus"),
+        ({"rollout_num_gpus_per_engine": 0}, "rollout_num_gpus_per_engine"),
+        ({"rollout_num_gpus": 1, "rollout_num_gpus_per_engine": 2}, "capacity must be positive"),
+    ],
+)
+def test_model_request_capacity_rejects_invalid_configuration(overrides: dict[str, int], message: str) -> None:
+    values = {
+        "sglang_server_concurrency": 2,
+        "rollout_num_gpus": 8,
+        "rollout_num_gpus_per_engine": 2,
+        **overrides,
+    }
+    with pytest.raises(ValueError, match=message):
+        _model_request_capacity(SimpleNamespace(**values))
+
+
+def test_model_request_capacity_uses_configured_engine_count() -> None:
+    args = SimpleNamespace(
+        sglang_server_concurrency=4,
+        rollout_num_gpus=8,
+        rollout_num_gpus_per_engine=2,
+    )
+    assert _model_request_capacity(args) == 16
+
+
+def test_generate_keeps_request_model_optional_for_direct_callers() -> None:
+    parameter = inspect.signature(rollout_mod.generate).parameters["request_model"]
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default is None
 
 
 class _ActiveCounter:
@@ -246,7 +289,7 @@ async def test_mixed_ordinary_aware_legacy_respect_shared_capacity() -> None:
         counter.leave()
         return "legacy"
 
-    request_model = partial(scheduler.request, evaluation=False)
+    request_model = scheduler.request
 
     @request_model_aware
     async def aware_session(args, sample, sampling_params, *, request_model):
@@ -254,7 +297,7 @@ async def test_mixed_ordinary_aware_legacy_respect_shared_capacity() -> None:
         return sample
 
     with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
-        t_legacy = asyncio.create_task(scheduler.run_legacy(legacy_op, evaluation=False))
+        t_legacy = asyncio.create_task(scheduler.run_legacy(legacy_op))
         t_ordinary = asyncio.create_task(scheduler.request("http://x", {"kind": "ordinary"}))
         await asyncio.wait_for(two_holding.wait(), timeout=1.0)
         assert counter.active == 2

--- a/tests/engine/rollout/test_model_request_scheduler.py
+++ b/tests/engine/rollout/test_model_request_scheduler.py
@@ -214,50 +214,107 @@ async def test_model_request_scheduler_evaluation_ignores_abort() -> None:
 
 
 @pytest.mark.asyncio
-async def test_model_request_scheduler_retry_holds_slot_for_logical_post() -> None:
-    # One logical post() (with internal retry/backoff) occupies one slot.
+async def test_model_request_scheduler_retry_holds_slot_for_real_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Real http_utils.post/_post retry+backoff still occupies one scheduler slot.
+    import httpx
+
+    import relax.utils.http_utils as http_utils
+
     scheduler, _ = _scheduler(capacity=1)
+    backoff_entered = asyncio.Event()
+    release_backoff = asyncio.Event()
+    second_http_started = asyncio.Event()
+    real_sleep = asyncio.sleep
+
+    class _FlakyClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def post(self, url, json=None, headers=None):
+            self.calls += 1
+            if self.calls == 1:
+                raise httpx.ConnectError("transient")
+            # Third HTTP call is the second scheduler.request()'s first attempt.
+            if self.calls >= 3:
+                second_http_started.set()
+            request = httpx.Request("POST", url)
+            return httpx.Response(200, request=request, json={"ok": True, "call": self.calls})
+
+    async def gated_sleep(seconds: float) -> None:
+        # Only gate the retry backoff (~1s); keep sleep(0)/short yields real.
+        if seconds < 0.5:
+            await real_sleep(seconds)
+            return
+        backoff_entered.set()
+        await release_backoff.wait()
+
+    monkeypatch.setattr(http_utils, "_http_client", _FlakyClient())
+    monkeypatch.setattr(http_utils, "_distributed_post_enabled", False)
+    monkeypatch.setattr(http_utils.asyncio, "sleep", gated_sleep)
+
+    # Do not patch sglang_rollout.post: exercise the real http_utils.post path.
+    t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
+    await asyncio.wait_for(backoff_entered.wait(), timeout=1.0)
+
+    t2 = asyncio.create_task(scheduler.request("http://x", {"id": 2}))
+    await real_sleep(0)
+    assert not second_http_started.is_set()
+
+    release_backoff.set()
+    assert await t1 == {"ok": True, "call": 2}
+    await asyncio.wait_for(second_http_started.wait(), timeout=1.0)
+    assert await t2 == {"ok": True, "call": 3}
+
+
+@pytest.mark.asyncio
+async def test_mixed_ordinary_aware_legacy_respect_shared_capacity() -> None:
+    # ordinary + request-aware + legacy share one capacity=2 pool.
+    scheduler, _ = _scheduler(capacity=2)
     counter = _ActiveCounter()
-    attempt = 0
-    second_started = asyncio.Event()
+    release = asyncio.Event()
+    two_holding = asyncio.Event()
 
-    async def flaky_post(url, payload, headers=None):
-        nonlocal attempt
+    async def fake_post(url, payload, headers=None):
         counter.enter()
-        try:
-            attempt += 1
-            if attempt == 1:
-                await asyncio.sleep(0.05)
-                raise RuntimeError("transient")
-            return {"ok": True}
-        finally:
-            counter.leave()
-
-    # Simulate http_utils.post wrapping retries inside one awaitable call.
-    async def logical_post(url, payload, headers=None):
-        try:
-            return await flaky_post(url, payload, headers=headers)
-        except RuntimeError:
-            await asyncio.sleep(0.05)
-            return await flaky_post(url, payload, headers=headers)
-
-    async def other_post(url, payload, headers=None):
-        second_started.set()
-        counter.enter()
+        if counter.active == 2:
+            two_holding.set()
+        await release.wait()
         counter.leave()
-        return {"other": True}
+        return {"kind": payload.get("kind")}
 
-    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=logical_post):
-        t1 = asyncio.create_task(scheduler.request("http://x", {"id": 1}))
+    async def legacy_op():
+        counter.enter()
+        if counter.active == 2:
+            two_holding.set()
+        await release.wait()
+        counter.leave()
+        return "legacy"
+
+    from functools import partial
+
+    request_model = partial(scheduler.request, evaluation=False)
+
+    @request_model_aware
+    async def aware_session(args, sample, sampling_params, *, request_model):
+        await request_model("http://x", {"kind": "aware"})
+        return sample
+
+    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
+        t_legacy = asyncio.create_task(scheduler.run_legacy(legacy_op, evaluation=False))
+        t_ordinary = asyncio.create_task(scheduler.request("http://x", {"kind": "ordinary"}))
+        await asyncio.wait_for(two_holding.wait(), timeout=1.0)
+        assert counter.active == 2
+        assert counter.max_active <= 2
+
+        t_aware = asyncio.create_task(aware_session(None, SimpleNamespace(), {}, request_model=request_model))
         await asyncio.sleep(0)
-        with patch("relax.engine.rollout.sglang_rollout.post", side_effect=other_post):
-            t2 = asyncio.create_task(scheduler.request("http://x", {"id": 2}))
-            await asyncio.sleep(0.02)
-            assert not second_started.is_set()
-            await t1
-            await asyncio.wait_for(second_started.wait(), timeout=1.0)
-            await t2
-        assert counter.max_active <= 1
+        assert counter.active == 2
+        assert counter.max_active <= 2
+
+        release.set()
+        await asyncio.gather(t_legacy, t_ordinary, t_aware)
+        assert counter.max_active <= 2
+        assert counter.calls == 3
 
 
 @pytest.mark.asyncio
@@ -286,61 +343,6 @@ async def test_model_request_scheduler_run_legacy_holds_session_slot() -> None:
         assert await t_legacy == "legacy"
         await asyncio.wait_for(other_entered.wait(), timeout=1.0)
         assert await t_other == {"ok": True}
-
-
-@pytest.mark.asyncio
-async def test_interleave_short_request_between_turns() -> None:
-    # capacity=1: short request completes during long session env wait.
-    scheduler, _ = _scheduler(capacity=1)
-    turn1_done = asyncio.Event()
-    env_gate = asyncio.Event()
-    short_done = asyncio.Event()
-    order: list[str] = []
-
-    async def fake_post(url, payload, headers=None):
-        label = payload["label"]
-        order.append(f"start:{label}")
-        if label == "long-1":
-            turn1_done.set()
-        if label == "short":
-            short_done.set()
-        order.append(f"end:{label}")
-        return {"label": label}
-
-    @request_model_aware
-    async def long_session(args, sample, sampling_params, *, request_model):
-        await request_model("http://x", {"label": "long-1"})
-        await env_gate.wait()
-        await request_model("http://x", {"label": "long-2"})
-        return sample
-
-    async def short_session():
-        await scheduler.request("http://x", {"label": "short"})
-
-    with patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post):
-        from functools import partial
-
-        request_model = partial(scheduler.request, evaluation=False)
-        long_task = asyncio.create_task(
-            long_session(None, SimpleNamespace(), {}, request_model=request_model)
-        )
-        await asyncio.wait_for(turn1_done.wait(), timeout=1.0)
-        short_task = asyncio.create_task(short_session())
-        await asyncio.wait_for(short_done.wait(), timeout=1.0)
-        assert short_done.is_set()
-        assert not env_gate.is_set()
-        env_gate.set()
-        await long_task
-        await short_task
-
-    assert order == [
-        "start:long-1",
-        "end:long-1",
-        "start:short",
-        "end:short",
-        "start:long-2",
-        "end:long-2",
-    ]
 
 
 def test_request_model_aware_marker_and_signature_validation() -> None:

--- a/tests/examples/test_deepeyes_rollout_scheduling.py
+++ b/tests/examples/test_deepeyes_rollout_scheduling.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+# CPU async tests for Deepeyes request-aware multiturn scheduling.
+
+from __future__ import annotations
+
+import asyncio
+from argparse import Namespace
+from contextlib import contextmanager
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from examples.deepeyes import rollout as deepeyes_rollout
+from relax.engine.rollout import sglang_rollout as rollout_mod
+from relax.engine.rollout.sglang_rollout import (
+    ModelRequestScheduler,
+    RolloutRequestAborted,
+    _is_request_model_aware,
+    _validate_request_model_signature,
+    request_model_aware,
+)
+from relax.utils.types import Sample
+
+
+def test_deepeyes_generate_is_request_model_aware() -> None:
+    assert _is_request_model_aware(deepeyes_rollout.generate)
+    _validate_request_model_signature(deepeyes_rollout.generate)
+
+
+def test_sync_sample_outputs_does_not_set_completed() -> None:
+    sample = Sample(prompt="p", tokens=[1, 2, 3], response="", response_length=0)
+    sample.status = None  # type: ignore[assignment]
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "decoded"
+
+    deepeyes_rollout._sync_sample_outputs(
+        sample,
+        tokenizer=tokenizer,
+        response_tokens=[2, 3],
+        multimodal_train_inputs_buffer=[],
+    )
+    assert sample.response == "decoded"
+    assert sample.response_length == 2
+    assert sample.status is None
+
+
+def test_finalize_sample_sets_completed_when_status_none() -> None:
+    sample = Sample(prompt="p", tokens=[1], response="", response_length=0)
+    sample.status = None  # type: ignore[assignment]
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "done"
+
+    deepeyes_rollout._finalize_sample(sample, tokenizer, [1], [])
+    assert sample.status == Sample.Status.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_deepeyes_abort_before_http_uses_turn_idx_and_no_trace() -> None:
+    # Scheduler abort before HTTP: rollout_turns=turn_idx, no incomplete trace append.
+    class _FakeEnv:
+        turn = 0
+        current_image = None
+
+        def reset(self):
+            return None
+
+        def close(self):
+            return None
+
+    sample = Sample(prompt="hello")
+    sample.tokens = [10, 11]
+    sample.metadata = {}
+
+    fake_tokenizer = MagicMock()
+    fake_tokenizer.decode.return_value = ""
+    fake_state = SimpleNamespace(tokenizer=fake_tokenizer, processor=None)
+    fake_args = SimpleNamespace(
+        apply_chat_template=False,
+        apply_chat_template_kwargs={},
+        partial_rollout=True,
+        mask_offpolicy_in_partial_rollout=False,
+        rollout_max_context_len=None,
+        use_rollout_routing_replay=False,
+    )
+
+    async def aborting_request_model(url, payload, *, headers=None):
+        raise RolloutRequestAborted("aborted")
+
+    with (
+        patch.object(
+            deepeyes_rollout,
+            "_initialize_resources",
+            return_value=(_FakeEnv(), SimpleNamespace(), {"max_turns": 3}, fake_state, "http://x/generate"),
+        ),
+        patch.object(
+            deepeyes_rollout,
+            "_prepare_start_state",
+            new=AsyncMock(return_value=(None, [], None, None, [])),
+        ),
+    ):
+        with pytest.raises(RolloutRequestAborted):
+            await deepeyes_rollout.generate(
+                fake_args,
+                sample,
+                {"max_new_tokens": 16},
+                request_model=aborting_request_model,
+            )
+
+    assert sample.metadata["rollout_turns"] == 0
+    assert sample.metadata["rollout_stop_reason"] == "rollout_abort"
+    assert sample.metadata.get("rollout_traces") == []
+    assert sample.status is not Sample.Status.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
+    # After turn-1 model request, env wait must not hold the model slot.
+    scheduler = ModelRequestScheduler(SimpleNamespace(aborted=False), capacity=1)
+    turn1_done = asyncio.Event()
+    env_gate = asyncio.Event()
+    short_done = asyncio.Event()
+    order: list[str] = []
+    call_n = 0
+
+    async def fake_post(url, payload, headers=None):
+        nonlocal call_n
+        call_n += 1
+        label = payload.get("label", f"call-{call_n}")
+        order.append(label)
+        if label == "long-1":
+            turn1_done.set()
+        if label == "short":
+            short_done.set()
+        return {
+            "text": "resp",
+            "meta_info": {
+                "finish_reason": {"type": "stop"},
+                "output_token_logprobs": [[0.0, 42]],
+            },
+        }
+
+    class _GateEnv:
+        turn = 0
+
+        def reset(self):
+            return None
+
+        def close(self):
+            return None
+
+    sample = Sample(prompt="hello")
+    sample.tokens = [1]
+    sample.loss_mask = []
+    sample.rollout_log_probs = []
+    sample.metadata = {}
+
+    fake_tokenizer = MagicMock()
+    fake_tokenizer.decode.return_value = "decoded"
+    fake_state = SimpleNamespace(tokenizer=fake_tokenizer, processor=None)
+    fake_args = SimpleNamespace(
+        apply_chat_template=False,
+        apply_chat_template_kwargs={},
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+        rollout_max_context_len=None,
+        use_rollout_routing_replay=False,
+    )
+
+    request_model = partial(scheduler.request, evaluation=False)
+    env = _GateEnv()
+    inference_calls = 0
+    real_run_inference = deepeyes_rollout._run_inference_step
+
+    async def inference_with_labels(*args, **kwargs):
+        nonlocal inference_calls
+        inference_calls += 1
+        label = f"long-{inference_calls}"
+        rm = kwargs["request_model"]
+
+        async def labeled(url, payload, *, headers=None):
+            payload = dict(payload)
+            payload["label"] = label
+            return await rm(url, payload, headers=headers)
+
+        kwargs = dict(kwargs)
+        kwargs["request_model"] = labeled
+        return await real_run_inference(*args, **kwargs)
+
+    async def env_step_mock(*args, **kwargs):
+        await env_gate.wait()
+        return None, None, None, None, True, {}
+
+    with (
+        patch("relax.engine.rollout.sglang_rollout.post", side_effect=fake_post),
+        patch.object(
+            deepeyes_rollout,
+            "_initialize_resources",
+            return_value=(env, SimpleNamespace(), {"max_turns": 2}, fake_state, "http://x/generate"),
+        ),
+        patch.object(
+            deepeyes_rollout,
+            "_prepare_start_state",
+            new=AsyncMock(return_value=(None, [], None, None, [])),
+        ),
+        patch.object(deepeyes_rollout, "_run_inference_step", side_effect=inference_with_labels),
+        patch.object(deepeyes_rollout, "_process_env_step", new=env_step_mock),
+    ):
+        long_task = asyncio.create_task(
+            deepeyes_rollout.generate(fake_args, sample, {"max_new_tokens": 8}, request_model=request_model)
+        )
+        await asyncio.wait_for(turn1_done.wait(), timeout=1.0)
+        short_task = asyncio.create_task(request_model("http://x", {"label": "short"}))
+        await asyncio.wait_for(short_done.wait(), timeout=1.0)
+        assert order == ["long-1", "short"]
+        env_gate.set()
+        await long_task
+        await short_task
+
+
+class _FakeGenState:
+    def __init__(self, args):
+        self.args = args
+        self.aborted = False
+        self.opd_manager = None
+        self.model_request_scheduler = ModelRequestScheduler(self, capacity=2)
+
+    def dp_rank_context(self):
+        @contextmanager
+        def _ctx():
+            yield 0
+
+        return _ctx()
+
+
+@pytest.mark.asyncio
+async def test_generate_and_rm_legacy_vs_request_aware_dispatch() -> None:
+    calls: list[str] = []
+
+    async def legacy_custom(args, sample, sampling_params):
+        calls.append("legacy")
+        sample.status = Sample.Status.COMPLETED
+        sample.reward = 0.0
+        return sample
+
+    @request_model_aware
+    async def aware_custom(args, sample, sampling_params, *, request_model):
+        calls.append("aware")
+        await request_model("http://x", {"n": 1})
+        sample.status = Sample.Status.COMPLETED
+        sample.reward = 0.0
+        return sample
+
+    async def fake_post(url, payload, headers=None):
+        return {"text": "t", "meta_info": {"finish_reason": {"type": "stop"}}}
+
+    sample = Sample(prompt="p")
+    args = Namespace(
+        group_rm=False,
+        custom_generate_function_path="mod.legacy_custom",
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+    )
+    with (
+        patch.object(rollout_mod, "GenerateState", _FakeGenState),
+        patch.object(rollout_mod, "load_function", return_value=legacy_custom),
+        patch.object(rollout_mod, "async_rm", new=AsyncMock(return_value=0.0)),
+        patch.object(rollout_mod, "post", side_effect=fake_post),
+    ):
+        out = await rollout_mod.generate_and_rm(args, sample, {}, evaluation=False)
+        assert out.status == Sample.Status.COMPLETED
+        assert calls == ["legacy"]
+
+    calls.clear()
+    sample2 = Sample(prompt="p")
+    args.custom_generate_function_path = "mod.aware_custom"
+    with (
+        patch.object(rollout_mod, "GenerateState", _FakeGenState),
+        patch.object(rollout_mod, "load_function", return_value=aware_custom),
+        patch.object(rollout_mod, "async_rm", new=AsyncMock(return_value=0.0)),
+        patch.object(rollout_mod, "post", side_effect=fake_post),
+    ):
+        out = await rollout_mod.generate_and_rm(args, sample2, {}, evaluation=False)
+        assert out.status == Sample.Status.COMPLETED
+        assert calls == ["aware"]
+
+
+@pytest.mark.asyncio
+async def test_generate_and_rm_bad_marker_signature_raises_before_run() -> None:
+    @request_model_aware
+    async def bad(args, sample, sampling_params):
+        raise AssertionError("should not run")
+
+    sample = Sample(prompt="p")
+    args = Namespace(
+        group_rm=False,
+        custom_generate_function_path="x.bad",
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+    )
+    with (
+        patch.object(rollout_mod, "GenerateState", _FakeGenState),
+        patch.object(rollout_mod, "load_function", return_value=bad),
+    ):
+        with pytest.raises(TypeError, match="request_model"):
+            await rollout_mod.generate_and_rm(args, sample, {}, evaluation=False)
+
+
+@pytest.mark.asyncio
+async def test_generate_and_rm_abort_sets_sample_status() -> None:
+    @request_model_aware
+    async def aware_custom(args, sample, sampling_params, *, request_model):
+        await request_model("http://x", {"n": 1})
+        return sample
+
+    sample = Sample(prompt="p")
+    args = Namespace(
+        group_rm=False,
+        custom_generate_function_path="x.aware",
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+    )
+
+    class AbortedState(_FakeGenState):
+        def __init__(self, args):
+            super().__init__(args)
+            self.aborted = True
+
+    with (
+        patch.object(rollout_mod, "GenerateState", AbortedState),
+        patch.object(rollout_mod, "load_function", return_value=aware_custom),
+    ):
+        out = await rollout_mod.generate_and_rm(args, sample, {}, evaluation=False)
+        assert out.status == Sample.Status.ABORTED

--- a/tests/examples/test_deepeyes_rollout_scheduling.py
+++ b/tests/examples/test_deepeyes_rollout_scheduling.py
@@ -15,15 +15,58 @@ import pytest
 
 from examples.deepeyes import rollout as deepeyes_rollout
 from relax.engine.rollout import sglang_rollout as rollout_mod
-from relax.engine.rollout.sglang_rollout import (
-    ModelRequestScheduler,
-    RolloutRequestAborted,
-    request_model_aware,
-)
+from relax.engine.rollout.sglang_rollout import ModelRequestScheduler, RolloutRequestAborted, request_model_aware
 from relax.utils.types import Sample
 
 
-def test_sync_sample_outputs_does_not_set_completed() -> None:
+class _FakeEnv:
+    def __init__(self) -> None:
+        self.turn = 0
+        self.current_image = None
+
+    def reset(self):
+        return None
+
+    def close(self):
+        return None
+
+
+class _FakeGenState:
+    def __init__(self, args):
+        self.args = args
+        self.aborted = False
+        self.opd_manager = None
+        self.model_request_scheduler = ModelRequestScheduler(self, capacity=2)
+
+    def dp_rank_context(self):
+        @contextmanager
+        def _ctx():
+            yield 0
+
+        return _ctx()
+
+
+def _deepeyes_args(*, partial_rollout: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        apply_chat_template=False,
+        apply_chat_template_kwargs={},
+        partial_rollout=partial_rollout,
+        mask_offpolicy_in_partial_rollout=False,
+        rollout_max_context_len=None,
+        use_rollout_routing_replay=False,
+    )
+
+
+def _generate_and_rm_args(*, custom_generate_function_path: str = "x.custom") -> Namespace:
+    return Namespace(
+        group_rm=False,
+        custom_generate_function_path=custom_generate_function_path,
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+    )
+
+
+def test_deepeyes_sample_status_helpers() -> None:
     sample = Sample(prompt="p", tokens=[1, 2, 3], response="", response_length=0)
     sample.status = None  # type: ignore[assignment]
     tokenizer = MagicMock()
@@ -39,30 +82,13 @@ def test_sync_sample_outputs_does_not_set_completed() -> None:
     assert sample.response_length == 2
     assert sample.status is None
 
-
-def test_finalize_sample_sets_completed_when_status_none() -> None:
-    sample = Sample(prompt="p", tokens=[1], response="", response_length=0)
-    sample.status = None  # type: ignore[assignment]
-    tokenizer = MagicMock()
     tokenizer.decode.return_value = "done"
-
     deepeyes_rollout._finalize_sample(sample, tokenizer, [1], [])
     assert sample.status == Sample.Status.COMPLETED
 
 
 @pytest.mark.asyncio
 async def test_deepeyes_abort_before_http_uses_turn_idx_and_no_trace() -> None:
-    # Scheduler abort before HTTP: rollout_turns=turn_idx, no incomplete trace append.
-    class _FakeEnv:
-        turn = 0
-        current_image = None
-
-        def reset(self):
-            return None
-
-        def close(self):
-            return None
-
     sample = Sample(prompt="hello")
     sample.tokens = [10, 11]
     sample.metadata = {}
@@ -70,14 +96,6 @@ async def test_deepeyes_abort_before_http_uses_turn_idx_and_no_trace() -> None:
     fake_tokenizer = MagicMock()
     fake_tokenizer.decode.return_value = ""
     fake_state = SimpleNamespace(tokenizer=fake_tokenizer, processor=None)
-    fake_args = SimpleNamespace(
-        apply_chat_template=False,
-        apply_chat_template_kwargs={},
-        partial_rollout=True,
-        mask_offpolicy_in_partial_rollout=False,
-        rollout_max_context_len=None,
-        use_rollout_routing_replay=False,
-    )
 
     async def aborting_request_model(url, payload, *, headers=None):
         raise RolloutRequestAborted("aborted")
@@ -96,7 +114,7 @@ async def test_deepeyes_abort_before_http_uses_turn_idx_and_no_trace() -> None:
     ):
         with pytest.raises(RolloutRequestAborted):
             await deepeyes_rollout.generate(
-                fake_args,
+                _deepeyes_args(partial_rollout=True),
                 sample,
                 {"max_new_tokens": 16},
                 request_model=aborting_request_model,
@@ -110,7 +128,6 @@ async def test_deepeyes_abort_before_http_uses_turn_idx_and_no_trace() -> None:
 
 @pytest.mark.asyncio
 async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
-    # After turn-1 model request, env wait must not hold the model slot.
     scheduler = ModelRequestScheduler(SimpleNamespace(aborted=False), capacity=1)
     turn1_done = asyncio.Event()
     env_gate = asyncio.Event()
@@ -135,15 +152,6 @@ async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
             },
         }
 
-    class _GateEnv:
-        turn = 0
-
-        def reset(self):
-            return None
-
-        def close(self):
-            return None
-
     sample = Sample(prompt="hello")
     sample.tokens = [1]
     sample.loss_mask = []
@@ -153,17 +161,7 @@ async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
     fake_tokenizer = MagicMock()
     fake_tokenizer.decode.return_value = "decoded"
     fake_state = SimpleNamespace(tokenizer=fake_tokenizer, processor=None)
-    fake_args = SimpleNamespace(
-        apply_chat_template=False,
-        apply_chat_template_kwargs={},
-        partial_rollout=False,
-        mask_offpolicy_in_partial_rollout=False,
-        rollout_max_context_len=None,
-        use_rollout_routing_replay=False,
-    )
-
     request_model = partial(scheduler.request, evaluation=False)
-    env = _GateEnv()
     inference_calls = 0
     real_run_inference = deepeyes_rollout._run_inference_step
 
@@ -191,7 +189,7 @@ async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
         patch.object(
             deepeyes_rollout,
             "_initialize_resources",
-            return_value=(env, SimpleNamespace(), {"max_turns": 2}, fake_state, "http://x/generate"),
+            return_value=(_FakeEnv(), SimpleNamespace(), {"max_turns": 2}, fake_state, "http://x/generate"),
         ),
         patch.object(
             deepeyes_rollout,
@@ -202,7 +200,12 @@ async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
         patch.object(deepeyes_rollout, "_process_env_step", new=env_step_mock),
     ):
         long_task = asyncio.create_task(
-            deepeyes_rollout.generate(fake_args, sample, {"max_new_tokens": 8}, request_model=request_model)
+            deepeyes_rollout.generate(
+                _deepeyes_args(),
+                sample,
+                {"max_new_tokens": 8},
+                request_model=request_model,
+            )
         )
         await asyncio.wait_for(turn1_done.wait(), timeout=1.0)
         short_task = asyncio.create_task(request_model("http://x", {"label": "short"}))
@@ -211,21 +214,6 @@ async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
         env_gate.set()
         await long_task
         await short_task
-
-
-class _FakeGenState:
-    def __init__(self, args):
-        self.args = args
-        self.aborted = False
-        self.opd_manager = None
-        self.model_request_scheduler = ModelRequestScheduler(self, capacity=2)
-
-    def dp_rank_context(self):
-        @contextmanager
-        def _ctx():
-            yield 0
-
-        return _ctx()
 
 
 @pytest.mark.asyncio
@@ -249,25 +237,18 @@ async def test_generate_and_rm_legacy_vs_request_aware_dispatch() -> None:
     async def fake_post(url, payload, headers=None):
         return {"text": "t", "meta_info": {"finish_reason": {"type": "stop"}}}
 
-    sample = Sample(prompt="p")
-    args = Namespace(
-        group_rm=False,
-        custom_generate_function_path="mod.legacy_custom",
-        partial_rollout=False,
-        mask_offpolicy_in_partial_rollout=False,
-    )
+    args = _generate_and_rm_args(custom_generate_function_path="mod.legacy_custom")
     with (
         patch.object(rollout_mod, "GenerateState", _FakeGenState),
         patch.object(rollout_mod, "load_function", return_value=legacy_custom),
         patch.object(rollout_mod, "async_rm", new=AsyncMock(return_value=0.0)),
         patch.object(rollout_mod, "post", side_effect=fake_post),
     ):
-        out = await rollout_mod.generate_and_rm(args, sample, {}, evaluation=False)
+        out = await rollout_mod.generate_and_rm(args, Sample(prompt="p"), {}, evaluation=False)
         assert out.status == Sample.Status.COMPLETED
         assert calls == ["legacy"]
 
     calls.clear()
-    sample2 = Sample(prompt="p")
     args.custom_generate_function_path = "mod.aware_custom"
     with (
         patch.object(rollout_mod, "GenerateState", _FakeGenState),
@@ -275,7 +256,7 @@ async def test_generate_and_rm_legacy_vs_request_aware_dispatch() -> None:
         patch.object(rollout_mod, "async_rm", new=AsyncMock(return_value=0.0)),
         patch.object(rollout_mod, "post", side_effect=fake_post),
     ):
-        out = await rollout_mod.generate_and_rm(args, sample2, {}, evaluation=False)
+        out = await rollout_mod.generate_and_rm(args, Sample(prompt="p"), {}, evaluation=False)
         assert out.status == Sample.Status.COMPLETED
         assert calls == ["aware"]
 
@@ -286,24 +267,21 @@ async def test_generate_and_rm_bad_marker_signature_raises_before_run() -> None:
     async def bad(args, sample, sampling_params):
         raise AssertionError("should not run")
 
-    sample = Sample(prompt="p")
-    args = Namespace(
-        group_rm=False,
-        custom_generate_function_path="x.bad",
-        partial_rollout=False,
-        mask_offpolicy_in_partial_rollout=False,
-    )
     with (
         patch.object(rollout_mod, "GenerateState", _FakeGenState),
         patch.object(rollout_mod, "load_function", return_value=bad),
     ):
         with pytest.raises(TypeError, match="request_model"):
-            await rollout_mod.generate_and_rm(args, sample, {}, evaluation=False)
+            await rollout_mod.generate_and_rm(
+                _generate_and_rm_args(),
+                Sample(prompt="p"),
+                {},
+                evaluation=False,
+            )
 
 
 @pytest.mark.asyncio
 async def test_generate_and_rm_evaluation_continues_when_aborted() -> None:
-    # Fast abort must keep evaluation exception: aborted + evaluation=True continues.
     ran = False
 
     @request_model_aware
@@ -323,23 +301,26 @@ async def test_generate_and_rm_evaluation_continues_when_aborted() -> None:
             super().__init__(args)
             self.aborted = True
 
-    args = Namespace(
-        group_rm=False,
-        custom_generate_function_path="x.aware",
-        partial_rollout=False,
-        mask_offpolicy_in_partial_rollout=False,
-    )
-
     with (
         patch.object(rollout_mod, "GenerateState", AbortedState),
         patch.object(rollout_mod, "load_function", return_value=aware_custom),
         patch.object(rollout_mod, "async_rm", new=AsyncMock(return_value=0.0)),
         patch.object(rollout_mod, "post", side_effect=fake_post),
     ):
-        out_train = await rollout_mod.generate_and_rm(args, Sample(prompt="p"), {}, evaluation=False)
+        out_train = await rollout_mod.generate_and_rm(
+            _generate_and_rm_args(),
+            Sample(prompt="p"),
+            {},
+            evaluation=False,
+        )
         assert out_train.status == Sample.Status.ABORTED
         assert ran is False
 
-        out_eval = await rollout_mod.generate_and_rm(args, Sample(prompt="p"), {}, evaluation=True)
+        out_eval = await rollout_mod.generate_and_rm(
+            _generate_and_rm_args(),
+            Sample(prompt="p"),
+            {},
+            evaluation=True,
+        )
         assert ran is True
         assert out_eval.status == Sample.Status.COMPLETED

--- a/tests/examples/test_deepeyes_rollout_scheduling.py
+++ b/tests/examples/test_deepeyes_rollout_scheduling.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import asyncio
 from argparse import Namespace
 from contextlib import contextmanager
-from functools import partial
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -161,7 +160,7 @@ async def test_deepeyes_env_phase_allows_short_request_interleave() -> None:
     fake_tokenizer = MagicMock()
     fake_tokenizer.decode.return_value = "decoded"
     fake_state = SimpleNamespace(tokenizer=fake_tokenizer, processor=None)
-    request_model = partial(scheduler.request, evaluation=False)
+    request_model = scheduler.request
     inference_calls = 0
     real_run_inference = deepeyes_rollout._run_inference_step
 
@@ -281,7 +280,7 @@ async def test_generate_and_rm_bad_marker_signature_raises_before_run() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_and_rm_evaluation_continues_when_aborted() -> None:
+async def test_generate_and_rm_evaluation_respects_aborted_state() -> None:
     ran = False
 
     @request_model_aware
@@ -322,5 +321,5 @@ async def test_generate_and_rm_evaluation_continues_when_aborted() -> None:
             {},
             evaluation=True,
         )
-        assert ran is True
-        assert out_eval.status == Sample.Status.COMPLETED
+        assert ran is False
+        assert out_eval.status == Sample.Status.ABORTED

--- a/tests/examples/test_deepeyes_rollout_scheduling.py
+++ b/tests/examples/test_deepeyes_rollout_scheduling.py
@@ -18,16 +18,9 @@ from relax.engine.rollout import sglang_rollout as rollout_mod
 from relax.engine.rollout.sglang_rollout import (
     ModelRequestScheduler,
     RolloutRequestAborted,
-    _is_request_model_aware,
-    _validate_request_model_signature,
     request_model_aware,
 )
 from relax.utils.types import Sample
-
-
-def test_deepeyes_generate_is_request_model_aware() -> None:
-    assert _is_request_model_aware(deepeyes_rollout.generate)
-    _validate_request_model_signature(deepeyes_rollout.generate)
 
 
 def test_sync_sample_outputs_does_not_set_completed() -> None:
@@ -309,13 +302,27 @@ async def test_generate_and_rm_bad_marker_signature_raises_before_run() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_and_rm_abort_sets_sample_status() -> None:
+async def test_generate_and_rm_evaluation_continues_when_aborted() -> None:
+    # Fast abort must keep evaluation exception: aborted + evaluation=True continues.
+    ran = False
+
     @request_model_aware
     async def aware_custom(args, sample, sampling_params, *, request_model):
+        nonlocal ran
+        ran = True
         await request_model("http://x", {"n": 1})
+        sample.status = Sample.Status.COMPLETED
+        sample.reward = 0.0
         return sample
 
-    sample = Sample(prompt="p")
+    async def fake_post(url, payload, headers=None):
+        return {"text": "t", "meta_info": {"finish_reason": {"type": "stop"}}}
+
+    class AbortedState(_FakeGenState):
+        def __init__(self, args):
+            super().__init__(args)
+            self.aborted = True
+
     args = Namespace(
         group_rm=False,
         custom_generate_function_path="x.aware",
@@ -323,14 +330,16 @@ async def test_generate_and_rm_abort_sets_sample_status() -> None:
         mask_offpolicy_in_partial_rollout=False,
     )
 
-    class AbortedState(_FakeGenState):
-        def __init__(self, args):
-            super().__init__(args)
-            self.aborted = True
-
     with (
         patch.object(rollout_mod, "GenerateState", AbortedState),
         patch.object(rollout_mod, "load_function", return_value=aware_custom),
+        patch.object(rollout_mod, "async_rm", new=AsyncMock(return_value=0.0)),
+        patch.object(rollout_mod, "post", side_effect=fake_post),
     ):
-        out = await rollout_mod.generate_and_rm(args, sample, {}, evaluation=False)
-        assert out.status == Sample.Status.ABORTED
+        out_train = await rollout_mod.generate_and_rm(args, Sample(prompt="p"), {}, evaluation=False)
+        assert out_train.status == Sample.Status.ABORTED
+        assert ran is False
+
+        out_eval = await rollout_mod.generate_and_rm(args, Sample(prompt="p"), {}, evaluation=True)
+        assert ran is True
+        assert out_eval.status == Sample.Status.COMPLETED


### PR DESCRIPTION
## Summary

Closes https://github.com/redai-infra/Relax/issues/140

Custom multiturn rollout used to hold the global model-request semaphore for the entire session. Long sessions kept occupying SGLang slots during environment / tool / multimodal work, so short requests queued behind them (session-level head-of-line blocking).

This PR moves admission from the full session down to one logical SGLang `post()` via `ModelRequestScheduler`, injects a bound `request_model` capability for ordinary and `@request_model_aware` custom generate, keeps unmarked legacy custom on session-level gating through the same capacity, and converts `RolloutRequestAborted` to `Sample.Status.ABORTED` only at the framework generate boundary.

## Changes

* `relax/engine/rollout/sglang_rollout.py`: `ModelRequestScheduler`, `request_model_aware`, `RolloutRequestAborted`, path split in `generate_and_rm`, remove `GenerateState.semaphore`
* `examples/deepeyes/rollout.py`: opt-in `@request_model_aware`, per-turn `request_model`, env steps outside the slot, abort uses `turn_idx` + status-neutral `_sync_sample_outputs`
* Tests: `tests/engine/rollout/test_model_request_scheduler.py`, `tests/examples/test_deepeyes_rollout_scheduling.py`
* Docs: EN/ZH `customize-training.md` (marker / `request_model` / migration)

No new CLI flags. Capacity still uses:

`sglang_server_concurrency * rollout_num_gpus // rollout_num_gpus_per_engine`

Concurrency guarantee covers ordinary + request-aware + legacy-gated requests only — not OPD / env / third-party HTTP that bypasses `request_model`.

## Verification

- Env: Ubuntu 24.04 / Python 3.12.3 / ray 2.56.0 / CPU async only (fake HTTP, no GPU training)  
- Base: `039ce876` (`feat(models): qwen3-0.6B.sh (#79)` on `origin/main`)  
- Branch: `perf/multiturn-request-scheduling`  

```bash
pytest tests/engine/rollout/test_model_request_scheduler.py -q
pytest tests/examples/test_deepeyes_rollout_scheduling.py -q
pytest tests/engine/rollout/ -q
```

## Risk & Rollback
- Legacy unmarked custom still uses session-level gating (known compatibility cost)
- Request-aware custom must use @request_model_aware + required KW-only request_model; bypassing with raw post() is outside the guarantee
- One logical post() (including retry/backoff) holds one slot
- Rollback: restore outer session semaphore in generate_and_rm, or revert this PR; Deepeyes can be reverted independently