### PR TITLE
feat(reward): add format-aware reward router

### DIFF
--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -10,14 +10,22 @@ from relax.utils.logging_utils import get_logger
 from relax.utils.misc import load_function
 from relax.utils.types import Sample
 
+# -- format-aware reward routing -------------------------------------------
+from .registry import get_reward, register_reward
+from .router import resolve_rm_type
+
+# -- reward function imports (decorator-based registration for math + mc) --
 from .dapo_genrm import async_compute_score_genrm
 from .deepscaler import get_deepscaler_rule_based_reward
 from .f1 import f1_score
+from .geo3k import get_geo3k_reward
 from .gpqa import compute_gpqa_reward
+from .ifbench import compute_ifbench_reward
 from .math_dapo_utils import compute_score as compute_score_dapo
 from .math_utils import extract_answer as extract_boxed_answer
-from .math_utils import grade_answer_verl
-from .multiple_choice import get_multiple_choice_reward
+from .math_utils import math_reward  # noqa: F401 – triggers @register_reward("math")
+from .mopd import get_mopd_reward
+from .multiple_choice import multiple_choice_reward  # noqa: F401 – triggers @register_reward("multiple_choice")
 from .openr1mm import get_openr1mm_rule_based_reward
 
 
@@ -35,6 +43,61 @@ def _get_shared_session() -> aiohttp.ClientSession:
         timeout = aiohttp.ClientTimeout(total=120)
         _shared_session = aiohttp.ClientSession(connector=connector, timeout=timeout)
     return _shared_session
+
+
+# ---------------------------------------------------------------------------
+# Register remaining built-in reward types
+# ---------------------------------------------------------------------------
+# math and multiple_choice are registered via @register_reward decorators
+# in their respective modules (imported above).  The remaining types are
+# registered here as thin wrappers so that *every* supported rm_type lives
+# in the registry and the if/elif chain can be retired.
+# ---------------------------------------------------------------------------
+
+
+@register_reward("deepscaler")
+def _deepscaler_reward(response, label, metadata=None):
+    return get_deepscaler_rule_based_reward(response, label)
+
+
+@register_reward("geo3k")
+def _geo3k_reward(response, label, metadata=None):
+    return get_geo3k_reward(response, label)
+
+
+@register_reward("openr1mm")
+def _openr1mm_reward(response, label, metadata=None):
+    return get_openr1mm_rule_based_reward(response, label)
+
+
+@register_reward("dapo")
+def _dapo_reward(response, label, metadata=None):
+    return compute_score_dapo(response, label)
+
+
+@register_reward("mopd")
+def _mopd_reward(response, label, metadata=None):
+    return get_mopd_reward(response, label, metadata)
+
+
+@register_reward("f1")
+def _f1_reward(response, label, metadata=None):
+    return f1_score(response, label)[0]
+
+
+@register_reward("gpqa")
+def _gpqa_reward(response, label, metadata=None):
+    return compute_gpqa_reward(response, label, metadata=metadata)
+
+
+@register_reward("ifbench")
+def _ifbench_reward(response, label, metadata=None):
+    return compute_ifbench_reward(response, label, metadata=metadata)
+
+
+@register_reward("random")
+def _random_reward(response, label, metadata=None):
+    return random.randint(0, 1)
 
 
 # ---------------------------------------------------------------------------
@@ -59,40 +122,15 @@ class RewardWorker:
     """
 
     def compute(self, rm_type: str, response: str, label, metadata: dict | None = None):
-        """Dispatch to the appropriate synchronous reward function.
+        """Dispatch to the appropriate reward function via the registry.
 
         Returns the same value the original function would return.
         """
-        if rm_type == "deepscaler":
-            return get_deepscaler_rule_based_reward(response, label)
-        elif rm_type == "geo3k":
-            from .geo3k import get_geo3k_reward
+        reward_fn = get_reward(rm_type)
+        if reward_fn is not None:
+            return reward_fn(response, label, metadata=metadata)
 
-            return get_geo3k_reward(response, label)
-        elif rm_type == "openr1mm":
-            return get_openr1mm_rule_based_reward(response, label)
-        elif rm_type == "multiple_choice":
-            return get_multiple_choice_reward(response, label)
-        elif rm_type == "dapo":
-            return compute_score_dapo(response, label)
-        elif rm_type == "math":
-            return 1 if grade_answer_verl(response, label) else 0
-        elif rm_type == "mopd":
-            from .mopd import get_mopd_reward
-
-            return get_mopd_reward(response, label, metadata)
-        elif rm_type == "f1":
-            return f1_score(response, label)[0]
-        elif rm_type == "gpqa":
-            return compute_gpqa_reward(response, label, metadata=metadata)
-        elif rm_type == "ifbench":
-            from .ifbench import compute_ifbench_reward
-
-            return compute_ifbench_reward(response, label, metadata=metadata)
-        elif rm_type == "random":
-            return random.randint(0, 1)
-        else:
-            raise NotImplementedError(f"RewardWorker: unknown rm_type={rm_type!r}")
+        raise NotImplementedError(f"RewardWorker: unknown rm_type={rm_type!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -159,28 +197,12 @@ class RewardExecutor:
         "dummy": lambda args, sample: _dummy_reward(args),
     }
 
-    # CPU-bound / thread-unsafe rm_types dispatched to the Ray worker pool.
-    _SYNC_RM_TYPES = frozenset(
-        {
-            "deepscaler",
-            "geo3k",
-            "openr1mm",
-            "multiple_choice",
-            "dapo",
-            "math",
-            "mopd",
-            "f1",
-            "gpqa",
-            "ifbench",
-            "random",
-        }
-    )
-
     async def execute(self, args, sample: Sample, **kwargs):
         """Execute a single reward computation with concurrency control.
 
         - Async rm_types (remote_rm, dapo-genrm) run in the event loop.
-        - Sync rm_types are dispatched to the Ray worker pool.
+        - Sync rm_types are dispatched to the Ray worker pool via the
+          format-aware registry.
         - Custom rm paths are called directly (user is responsible for
           async safety).
         """
@@ -192,29 +214,46 @@ class RewardExecutor:
                 rm_function = load_function(args.custom_rm_path)
                 return await rm_function(args, sample, **kwargs)
 
+            # --- resolve rm_type via the format-aware router -----------
             metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
-            rm_type = (metadata.get("rm_type") or args.rm_type or "").strip()
+            rm_type = resolve_rm_type(sample, default_rm_type=args.rm_type)
+
             response = sample.response
             label = sample.label
-            if rm_type.startswith("boxed_"):
+
+            if rm_type and rm_type.startswith("boxed_"):
                 response = extract_boxed_answer(response) or ""
                 rm_type = rm_type[len("boxed_") :]
 
             # --- async rm types: run in event loop -----------------------
-            async_handler = self._ASYNC_RM_DISPATCH.get(rm_type)
+            async_handler = self._ASYNC_RM_DISPATCH.get(rm_type) if rm_type else None
             if async_handler is not None:
                 return await async_handler(args, sample)
 
-            # --- sync rm types: dispatch to worker pool ------------------
-            # Default to sync path for any non-empty rm_type not in async dispatch
+            # --- sync rm types: dispatch to worker pool via registry -----
             if rm_type:
+                # Guard: only dispatch known types; unknown → fallback
+                if get_reward(rm_type) is None:
+                    logger.warning(
+                        "RewardExecutor: unknown rm_type=%r (not in registry). "
+                        "Falling back to zero reward.",
+                        rm_type,
+                    )
+                    return 0.0
+
                 self._ensure_workers()
                 worker = self._next_worker()
                 ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
                 return await ref
 
-            # --- no rm_type specified -----------------------------------------
-            raise NotImplementedError("Rule-based RM type is not specified.")
+            # --- no rm_type could be resolved: zero-reward fallback ------
+            logger.warning(
+                "RewardExecutor: could not resolve rm_type for sample (metadata=%s, "
+                "default_rm_type=%r). Falling back to zero reward.",
+                {k: metadata.get(k) for k in ("rm_type", "task_type", "label_type") if k in metadata},
+                args.rm_type,
+            )
+            return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/relax/engine/rewards/math_utils.py
+++ b/relax/engine/rewards/math_utils.py
@@ -488,3 +488,20 @@ def grade_answer_verl(solution_str, ground_truth):
     if given_answer is None:
         return False
     return grade_answer_mathd(given_answer, ground_truth) or grade_answer_sympy(given_answer, ground_truth)
+
+
+# ---------------------------------------------------------------------------
+# Format-aware reward registry wrapper
+# ---------------------------------------------------------------------------
+
+from relax.engine.rewards.registry import register_reward  # noqa: E402
+
+
+@register_reward("math")
+def math_reward(response, label, metadata=None):
+    """Reward function for the ``math`` type.
+
+    Registered via ``@register_reward("math")`` so it participates in the
+    format-aware reward routing system.
+    """
+    return 1 if grade_answer_verl(response, label) else 0

--- a/relax/engine/rewards/multiple_choice.py
+++ b/relax/engine/rewards/multiple_choice.py
@@ -2,6 +2,7 @@
 
 import re
 
+from relax.engine.rewards.registry import register_reward
 
 ANS_TAG = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.S)
 
@@ -16,3 +17,13 @@ def get_multiple_choice_reward(response, label):
     label = extract_answer(label)
     reward = 1.0 if response == label else 0.0
     return reward
+
+
+@register_reward("multiple_choice")
+def multiple_choice_reward(response, label, metadata=None):
+    """Reward function for the ``multiple_choice`` type.
+
+    Registered via ``@register_reward("multiple_choice")`` so it
+    participates in the format-aware reward routing system.
+    """
+    return get_multiple_choice_reward(response, label)

--- a/relax/engine/rewards/registry.py
+++ b/relax/engine/rewards/registry.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Format-aware reward function registry.
+
+Provides a decorator-based registration mechanism so that new reward
+functions can be added with a single line without modifying any routing
+branches.
+"""
+
+from typing import Callable
+
+REWARD_REGISTRY: dict[str, Callable] = {}
+
+
+def register_reward(name: str):
+    """Decorator that registers a reward function under *name*.
+
+    Usage::
+
+        @register_reward("biology")
+        def biology_reward(response, label, metadata=None):
+            ...
+    """
+
+    def wrapper(func: Callable):
+        REWARD_REGISTRY[name] = func
+        return func
+
+    return wrapper
+
+
+def get_reward(name: str) -> Callable | None:
+    """Look up a registered reward function by name.
+
+    Returns ``None`` when no function is registered for *name*.
+    """
+    return REWARD_REGISTRY.get(name)
+
+
+def list_registered() -> list[str]:
+    """Return the names of all registered reward types."""
+    return sorted(REWARD_REGISTRY.keys())

--- a/relax/engine/rewards/router.py
+++ b/relax/engine/rewards/router.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Format-aware reward router.
+
+Resolves the reward type for a single sample by inspecting its metadata
+and applying a configurable fallback chain.  Supports mixed-task batches
+where different samples may require different reward functions.
+"""
+
+from relax.utils.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Metadata keys inspected in priority order when resolving the reward type.
+_DEFAULT_METADATA_KEYS = ("rm_type", "task_type", "label_type")
+
+
+def resolve_rm_type(
+    sample,
+    default_rm_type: str | None = None,
+    metadata_keys: tuple[str, ...] = _DEFAULT_METADATA_KEYS,
+) -> str | None:
+    """Resolve the reward type for *sample*.
+
+    Resolution order (first non-empty value wins):
+
+    1. ``sample.metadata["rm_type"]``
+    2. ``sample.metadata["task_type"]``
+    3. ``sample.metadata["label_type"]``
+    4. *default_rm_type* (typically the CLI ``--rm-type`` value)
+
+    When multiple metadata keys disagree a warning is logged and the
+    highest-priority value is used.  When no type can be determined a
+    warning is logged and ``None`` is returned.
+    """
+    metadata = getattr(sample, "metadata", None) or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    for key in metadata_keys:
+        value = metadata.get(key)
+        if value and isinstance(value, str):
+            value = value.strip()
+            if value and value not in seen:
+                candidates.append(value)
+                seen.add(value)
+
+    # Append the CLI default (lowest priority).
+    if default_rm_type:
+        default_rm_type = default_rm_type.strip()
+        if default_rm_type and default_rm_type not in seen:
+            candidates.append(default_rm_type)
+
+    if not candidates:
+        logger.warning(
+            "RewardRouter: could not resolve reward type – "
+            "metadata=%s, default_rm_type=%r. Falling back to None (zero reward).",
+            {k: metadata.get(k) for k in metadata_keys if k in metadata},
+            default_rm_type,
+        )
+        return None
+
+    if len(candidates) > 1:
+        logger.warning(
+            "RewardRouter: conflicting reward type hints %s – "
+            "using highest-priority value %r.",
+            candidates,
+            candidates[0],
+        )
+
+    return candidates[0]

--- a/tests/engine/rewards/test_reward_router.py
+++ b/tests/engine/rewards/test_reward_router.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the format-aware reward router and registry.
+
+Covers:
+  - Registry: register, get, list, duplicate registration
+  - Router:  metadata priority, CLI fallback, conflict detection, empty path
+  - Integration: RewardWorker compute via registry, mixed-batch routing
+  - Fallback:  unknown type → None + warning, missing type → zero reward
+"""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import strategy
+# ---------------------------------------------------------------------------
+# The relax.engine.rewards package __init__.py requires Ray.  When Ray is
+# absent we load registry.py and router.py directly from their file paths.
+# ---------------------------------------------------------------------------
+
+_REWARDS_DIR = Path(__file__).resolve().parents[3] / "relax" / "engine" / "rewards"
+
+_HAS_FULL_PIPELINE = False
+
+# -- always-available: registry + router (loaded directly from files) ---------
+
+
+def _load_module_from_file(name: str, path: Path):
+    """Import a module directly from a file path, bypassing package init."""
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load registry module
+_registry_mod = _load_module_from_file(
+    "relax.engine.rewards.registry",
+    _REWARDS_DIR / "registry.py",
+)
+REWARD_REGISTRY = _registry_mod.REWARD_REGISTRY
+get_reward = _registry_mod.get_reward
+register_reward = _registry_mod.register_reward
+list_registered = _registry_mod.list_registered
+
+# Load router module (depends on registry already being in sys.modules)
+_router_mod = _load_module_from_file(
+    "relax.engine.rewards.router",
+    _REWARDS_DIR / "router.py",
+)
+resolve_rm_type = _router_mod.resolve_rm_type
+
+# Sample from relax.utils.types requires torch+numpy.  Use a lightweight
+# stand-in for router/registry tests; the full pipeline tests (which need
+# Ray anyway) get the real Sample when Ray is available.
+class _SampleStub:
+    """Minimal Sample stand-in for router tests (no ML deps)."""
+
+    __slots__ = ("response", "label", "metadata")
+
+    def __init__(self, response="", label=None, metadata=None):
+        self.response = response
+        self.label = label
+        self.metadata = metadata if metadata is not None else {}
+
+Sample = _SampleStub  # used by router/registry tests
+
+_FULL_SAMPLE = None  # set to the real Sample when Ray pipeline is available
+
+# -- optional: full pipeline (requires Ray) -----------------------------------
+
+try:
+    import ray
+
+    if not ray.is_initialized():
+        try:
+            ray.init(num_cpus=8, ignore_reinit_error=True)
+        except ValueError as e:
+            if "When connecting to an existing cluster" in str(e):
+                ray.init(ignore_reinit_error=True)
+            else:
+                raise
+
+    from relax.engine.rewards import RewardExecutor, RewardWorker, async_rm, batched_async_rm
+    from relax.utils.types import Sample as _RealSample
+
+    Sample = _RealSample  # replace stub with real Sample for integration tests
+    _HAS_FULL_PIPELINE = True
+except ImportError:
+    pass
+
+
+requires_full_pipeline = pytest.mark.skipif(
+    not _HAS_FULL_PIPELINE,
+    reason="Full pipeline requires Ray",
+)
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _make_sample(response: str = "", label=None, metadata: dict | None = None):
+    """Create a Sample with the given fields."""
+    return Sample(response=response, label=label, metadata=metadata or {})
+
+
+def _make_args(**overrides):
+    """Create a mock args namespace."""
+    defaults = {
+        "rm_type": None,
+        "custom_rm_path": None,
+        "reward_max_concurrency": 64,
+        "reward_num_workers": 4,
+        "rm_url": None,
+        "reward_key": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _kill_executor_workers():
+    """Clean up Ray actors from the singleton executor."""
+    inst = RewardExecutor._instance
+    if inst is None:
+        return
+    for w in inst._workers:
+        try:
+            ray.kill(w)
+        except Exception:
+            pass
+    inst._workers = []
+
+
+# ===========================================================================
+# Registry tests
+# ===========================================================================
+
+
+class TestRegistry:
+    """Tests for the reward function registry."""
+
+    def teardown_method(self):
+        """Clean up test entries from the global registry."""
+        for key in list(REWARD_REGISTRY.keys()):
+            if key.startswith("test_"):
+                del REWARD_REGISTRY[key]
+
+    def test_register_and_retrieve(self):
+        @register_reward("test_register")
+        def fn(response, label, metadata=None):
+            return 42
+
+        assert get_reward("test_register") is fn
+        assert fn(response="", label="") == 42
+
+    def test_get_unknown_returns_none(self):
+        assert get_reward("test_nonexistent_xyz") is None
+
+    def test_list_registered(self):
+        @register_reward("test_list_a")
+        def a(response, label, metadata=None):
+            return 1
+
+        @register_reward("test_list_b")
+        def b(response, label, metadata=None):
+            return 2
+
+        names = list_registered()
+        assert "test_list_a" in names
+        assert "test_list_b" in names
+
+    def test_duplicate_registration_overwrites(self):
+        @register_reward("test_dup")
+        def first(response, label, metadata=None):
+            return 1
+
+        @register_reward("test_dup")
+        def second(response, label, metadata=None):
+            return 2
+
+        # Last registration wins
+        assert get_reward("test_dup") is second
+        assert REWARD_REGISTRY["test_dup"](response="", label="") == 2
+
+    def test_registry_custom_metadata_keys(self):
+        """A reward function in the registry receives metadata if passed."""
+        received_meta = []
+
+        @register_reward("test_meta")
+        def fn(response, label, metadata=None):
+            received_meta.append(metadata)
+            return len(metadata) if metadata else 0
+
+        result = fn(response="x", label="y", metadata={"key": "val"})
+        assert result == 1
+        assert received_meta[0] == {"key": "val"}
+
+
+# ===========================================================================
+# Router tests
+# ===========================================================================
+
+
+class TestRouterMetadataPriority:
+    """Tests for rm_type resolution via sample metadata."""
+
+    def test_rm_type_from_metadata(self):
+        s = _make_sample(metadata={"rm_type": "math"})
+        assert resolve_rm_type(s) == "math"
+
+    def test_task_type_from_metadata(self):
+        s = _make_sample(metadata={"task_type": "multiple_choice"})
+        assert resolve_rm_type(s) == "multiple_choice"
+
+    def test_label_type_from_metadata(self):
+        s = _make_sample(metadata={"label_type": "biology"})
+        assert resolve_rm_type(s) == "biology"
+
+    def test_rm_type_beats_task_type(self):
+        """rm_type has higher priority than task_type."""
+        s = _make_sample(metadata={"rm_type": "math", "task_type": "dapo"})
+        assert resolve_rm_type(s) == "math"
+
+    def test_task_type_beats_label_type(self):
+        """task_type has higher priority than label_type."""
+        s = _make_sample(metadata={"task_type": "math", "label_type": "dapo"})
+        assert resolve_rm_type(s) == "math"
+
+    def test_metadata_beats_cli_default(self):
+        """Sample metadata overrides CLI --rm-type."""
+        s = _make_sample(metadata={"rm_type": "multiple_choice"})
+        assert resolve_rm_type(s, default_rm_type="deepscaler") == "multiple_choice"
+
+    def test_strips_whitespace(self):
+        s = _make_sample(metadata={"rm_type": "  math  "})
+        assert resolve_rm_type(s) == "math"
+
+
+class TestRouterFallback:
+    """Tests for fallback behavior when metadata is missing or empty."""
+
+    def test_cli_fallback_when_no_metadata(self):
+        s = _make_sample()
+        assert resolve_rm_type(s, default_rm_type="deepscaler") == "deepscaler"
+
+    def test_none_when_no_type_at_all(self):
+        s = _make_sample()
+        assert resolve_rm_type(s) is None
+
+    def test_none_when_empty_metadata_dict(self):
+        s = _make_sample(metadata={})
+        assert resolve_rm_type(s) is None
+
+    def test_none_when_default_is_none(self):
+        s = _make_sample(metadata={"rm_type": "math"})
+        assert resolve_rm_type(s, default_rm_type=None) == "math"
+
+    def test_sample_without_metadata_attribute(self):
+        """Graceful handling of objects without a metadata attribute."""
+
+        class BareSample:
+            pass
+
+        assert resolve_rm_type(BareSample(), default_rm_type="math") == "math"
+        assert resolve_rm_type(BareSample()) is None
+
+    def test_metadata_is_not_a_dict(self):
+        """Graceful handling when metadata is not a dict (e.g. None or list)."""
+        s = _make_sample()
+        s.metadata = None
+        assert resolve_rm_type(s, default_rm_type="math") == "math"
+
+        s.metadata = ["not", "a", "dict"]
+        assert resolve_rm_type(s, default_rm_type="math") == "math"
+
+
+class TestRouterConflictDetection:
+    """Tests for conflict logging when multiple sources disagree."""
+
+    def test_metadata_vs_cli_conflict(self):
+        """Metadata takes priority, conflict is logged."""
+        s = _make_sample(metadata={"rm_type": "math"})
+        result = resolve_rm_type(s, default_rm_type="deepscaler")
+        assert result == "math"  # metadata wins
+
+    def test_duplicate_same_value_no_conflict(self):
+        """Same value from multiple sources should not conflict."""
+        s = _make_sample(metadata={"rm_type": "math", "task_type": "math"})
+        result = resolve_rm_type(s)
+        assert result == "math"
+
+
+# ===========================================================================
+# Integration tests (require Ray)
+# ===========================================================================
+
+
+@requires_full_pipeline
+class TestRewardWorkerRegistry:
+    """Test RewardWorker.compute() dispatch via the format-aware registry."""
+
+    @pytest.fixture(autouse=True)
+    def _worker(self):
+        self.worker = RewardWorker.remote()
+        yield
+        ray.kill(self.worker)
+
+    def test_math_via_registry_correct(self):
+        result = ray.get(self.worker.compute.remote("math", "\\boxed{7}", "7"))
+        assert result == 1
+
+    def test_math_via_registry_wrong(self):
+        result = ray.get(self.worker.compute.remote("math", "\\boxed{8}", "7"))
+        assert result == 0
+
+    def test_multiple_choice_via_registry_correct(self):
+        result = ray.get(
+            self.worker.compute.remote(
+                "multiple_choice",
+                "<answer>A</answer>",
+                "<answer>A</answer>",
+            )
+        )
+        assert result == 1.0
+
+    def test_multiple_choice_via_registry_wrong(self):
+        result = ray.get(
+            self.worker.compute.remote(
+                "multiple_choice",
+                "<answer>B</answer>",
+                "<answer>A</answer>",
+            )
+        )
+        assert result == 0.0
+
+    def test_random_via_registry(self):
+        result = ray.get(self.worker.compute.remote("random", "", ""))
+        assert result in (0, 1)
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ray.exceptions.RayTaskError):
+            ray.get(self.worker.compute.remote("nonexistent_rm_type_xyz", "foo", "bar"))
+
+
+@requires_full_pipeline
+class TestRewardExecutorRouter:
+    """Test RewardExecutor.execute() with the format-aware router."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_executor(self):
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+        yield
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+
+    @pytest.mark.asyncio
+    async def test_metadata_rm_type_math(self):
+        args = _make_args()
+        sample = _make_sample(
+            response="\\boxed{42}",
+            label="42",
+            metadata={"rm_type": "math"},
+        )
+        result = await async_rm(args, sample)
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_metadata_rm_type_multiple_choice(self):
+        args = _make_args()
+        sample = _make_sample(
+            response="<answer>C</answer>",
+            label="<answer>C</answer>",
+            metadata={"rm_type": "multiple_choice"},
+        )
+        result = await async_rm(args, sample)
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_metadata_overrides_cli(self):
+        """Per-sample rm_type in metadata should override CLI --rm-type."""
+        args = _make_args(rm_type="deepscaler")
+        sample = _make_sample(
+            response="\\boxed{7}",
+            label="7",
+            metadata={"rm_type": "openr1mm"},
+        )
+        result = await async_rm(args, sample)
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_task_type_metadata(self):
+        args = _make_args()
+        sample = _make_sample(
+            response="\\boxed{42}",
+            label="42",
+            metadata={"task_type": "openr1mm"},
+        )
+        result = await async_rm(args, sample)
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_fallback_zero(self):
+        """Unknown/missing rm_type should fall back to 0.0 with a warning."""
+        args = _make_args()
+        sample = _make_sample(
+            response="foo",
+            label="bar",
+            metadata={"rm_type": "completely_unknown_type_xyz"},
+        )
+        result = await async_rm(args, sample)
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_missing_type_fallback_zero(self):
+        """Missing rm_type entirely should fall back to 0.0."""
+        args = _make_args()  # rm_type=None
+        sample = _make_sample(response="foo", label="bar", metadata={})
+        result = await async_rm(args, sample)
+        assert result == 0.0
+
+
+@requires_full_pipeline
+class TestMixedBatchRouting:
+    """Test that a mixed batch routes each sample to the correct reward."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_executor(self):
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+        yield
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+
+    @pytest.mark.asyncio
+    async def test_mixed_math_and_multiple_choice(self):
+        """Each sample in a mixed batch should hit the correct reward function."""
+        args = _make_args()
+        samples = [
+            _make_sample(response="\\boxed{7}", label="7", metadata={"rm_type": "math"}),
+            _make_sample(response="\\boxed{99}", label="7", metadata={"rm_type": "math"}),
+            _make_sample(response="<answer>A</answer>", label="<answer>A</answer>",
+                         metadata={"rm_type": "multiple_choice"}),
+            _make_sample(response="<answer>B</answer>", label="<answer>A</answer>",
+                         metadata={"rm_type": "multiple_choice"}),
+        ]
+        rewards = await asyncio.wait_for(batched_async_rm(args, samples), timeout=60)
+        assert rewards == [1, 0, 1.0, 0.0]
+
+    @pytest.mark.asyncio
+    async def test_mixed_with_unknown_type(self):
+        """Unknown types in a mixed batch should get 0.0 reward."""
+        args = _make_args()
+        samples = [
+            _make_sample(response="\\boxed{7}", label="7", metadata={"rm_type": "math"}),
+            _make_sample(response="x", label="y", metadata={"rm_type": "unknown_xyz_type"}),
+            _make_sample(response="<answer>A</answer>", label="<answer>A</answer>",
+                         metadata={"rm_type": "multiple_choice"}),
+        ]
+        rewards = await asyncio.wait_for(batched_async_rm(args, samples), timeout=60)
+        assert rewards[0] == 1       # math: correct
+        assert rewards[1] == 0.0     # unknown: fallback
+        assert rewards[2] == 1.0     # mc: correct
+
+    @pytest.mark.asyncio
+    async def test_mixed_via_task_type_and_rm_type(self):
+        """Samples using different metadata keys should all route correctly."""
+        args = _make_args()
+        samples = [
+            _make_sample(response="\\boxed{42}", label="42", metadata={"rm_type": "openr1mm"}),
+            _make_sample(response="\\boxed{42}", label="42", metadata={"task_type": "openr1mm"}),
+            _make_sample(response="\\boxed{42}", label="42", metadata={"label_type": "openr1mm"}),
+        ]
+        rewards = await asyncio.wait_for(batched_async_rm(args, samples), timeout=60)
+        assert rewards == [1.0, 1.0, 1.0]
+
+    @pytest.mark.asyncio
+    async def test_mixed_defaults_to_cli(self):
+        """Samples without metadata should use the CLI default."""
+        args = _make_args(rm_type="openr1mm")
+        samples = [
+            _make_sample(response="\\boxed{7}", label="7", metadata={"rm_type": "math"}),
+            _make_sample(response="\\boxed{42}", label="42"),  # no metadata → CLI
+        ]
+        rewards = await asyncio.wait_for(batched_async_rm(args, samples), timeout=60)
+        assert rewards[0] == 1     # math via metadata
+        assert rewards[1] == 1.0   # openr1mm via CLI fallback
+
+    @pytest.mark.asyncio
+    async def test_mixed_empty_batch(self):
+        args = _make_args()
+        rewards = await batched_async_rm(args, [])
+        assert rewards == []
+
+
+# ===========================================================================
+# Backward-compatibility tests
+# ===========================================================================
+
+
+@requires_full_pipeline
+class TestBackwardCompatibility:
+    """Verify existing reward types still work end-to-end."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_executor(self):
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+        yield
+        _kill_executor_workers()
+        RewardExecutor._instance = None
+
+    @pytest.mark.asyncio
+    async def test_explicit_rm_type_via_args(self):
+        """Using --rm-type on CLI should still work (backward compat)."""
+        args = _make_args(rm_type="openr1mm")
+        sample = _make_sample(response="\\boxed{7}", label="7")
+        result = await async_rm(args, sample)
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_boxed_prefix_still_works(self):
+        """The boxed_ prefix is handled by the executor before registry lookup."""
+        args = _make_args()
+        sample = _make_sample(
+            response="The final answer is \\boxed{42} extra text",
+            label="42",
+            metadata={"rm_type": "boxed_openr1mm"},
+        )
+        result = await async_rm(args, sample)
+        assert result == 1.0


### PR DESCRIPTION
### Summary

Closes #142

#### 解决的问题

当前 Relax reward pipeline 使用单一 `--rm-type`，无法支持同一个 batch 内包含不同任务类型的问题。

例如：`math`、`multiple_choice`，需要根据 sample 信息动态选择 reward。


#### 为什么采用该方案

采用 registry + router 架构：

- router 负责 sample-level reward type resolution
- registry 负责 reward function lookup

相比 if/elif 分支：

- 新增 reward 不需要修改核心路由逻辑
- 支持 mixed-task batch
- 降低维护成本


### Changes

#### New files

#### 1、relax/engine/rewards/registry.py

新增 reward registry:

```python
register_reward()
get_reward()
list_registered()
````

支持 decorator 注册。


#### 2、relax/engine/rewards/router.py

新增：

```python
resolve_rm_type()
```

支持：`metadata["rm_type"]`>`metadata["task_type"]`>`metadata["label_type"]`>`CLI --rm-type`


#### 3、tests/engine/rewards/test_reward_router.py

新增 39 个测试：

覆盖：

* registry
* routing priority
* fallback
* mixed batch
* backward compatibility


#### Modified files

#### 1、relax/engine/rewards/**init**.py

主要修改：

before:

```python
if rm_type == "math":
...
elif rm_type == "multiple_choice":
...
```

after:

```python
reward_fn = get_reward(rm_type)
```

RewardWorker 改为 registry dispatch。


#### 2、math_utils.py

新增：`@register_reward("math")`


#### 3、multiple_choice.py

新增：`@register_reward("multiple_choice")`


#### Compatibility

- CLI 保持：`--rm-type math` 仍然有效。
- boxed reward 保持：`boxed_math`、`boxed_openr1mm` 解析逻辑。
- custom reward 保持原行为。


### Verification

#### Environment

* Repository: Relax
* Base commit: cfda05351d4b137f60e2b71d048beab1316d9d9f
* Development branch: feature/format-aware-reward-router
* Python: 3.12.3
* CUDA: 12.8
* GPU: Not required

#### Command

```bash
python -m pytest -v tests/engine/rewards/test_reward_router.py
```

Result：`39 passed`


#### Test cases

#### Mixed batch

输入：

```
math sample
multiple_choice sample
```

结果：

```
[
 math_reward,
 multiple_choice_reward
]
```

逐样本命中正确 reward。


#### Fallback

Unknown: `rm_type=unknown`

结果：

```
reward=0.0
warning logged
```

Missing: `metadata={}`

结果：

```
reward=0.0
warning logged
```


### Risk & Rollback

#### Known limitations
Reward registration depends on proper importing of corresponding modules. When adding new reward implementations, ensure relevant modules are explicitly imported; centralized imports can be placed in `relax/engine/rewards/__init__.py`.

#### Risk
Conflicting metadata keys within samples
The reward resolver uses a fixed priority sequence: `rm_type > task_type > label_type > CLI --rm-type`.
For legacy samples carrying multiple type labels simultaneously, the resolved reward type may mismatch user expectations and alter the overall reward distribution.


#### Rollback

删除：`registry.py`、`router.py`，恢复 RewardWorker 原 if/elif dispatch 即可。


### Checklist

- [x] Diff 仅包含本任务必要改动
- [x] 新增/相关测试全部通过
- [x] 文档、脚本和默认值已更新
- [x] 不含密钥、数据集、checkpoint 或机器隐私信息
- [ ] 已逐条回复 review comment