### PR TITLE
fix(convert): reconcile HF export index and supplement missing MTP

### DIFF
--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -267,6 +267,8 @@ Parameter descriptions:
 | `--origin-hf-dir` | Original HF safetensors directory, used for architecture, expected weight keys, and tokenizer files |
 | `--force` | Optional, force overwrite if output directory already exists |
 
+> **Note (MTP-free RL checkpoints):** When the source checkpoint has no MTP weights (e.g. an RL/SFT checkpoint trained without MTP) while the reference model's config enables MTP, the converter automatically reconciles the exported `model.safetensors.index.json` with the tensors actually written and supplements the missing MTP weights from `--origin-hf-dir`, so the exported model loads cleanly (including EAGLE speculative decoding). The same reconciliation is applied to online `--save-hf` exports.
+
 For the FP8 strategy options, memory behavior, output format, and an 8-GPU SGLang launch command, see [Model Checkpoint Conversion](./model-conversion.md).
 
 ## Next Steps

--- a/docs/zh/guide/quick-start.md
+++ b/docs/zh/guide/quick-start.md
@@ -267,6 +267,8 @@ python scripts/tools/convert_torch_dist_to_hf_bridge.py \
 | `--origin-hf-dir` | 原始 HF safetensors 目录，用于读取模型结构、预期权重 key 和 tokenizer 文件 |
 | `--force` | 可选，若输出目录已存在则强制覆盖 |
 
+> **注意（无 MTP 的 RL checkpoint）**：当源 checkpoint 不含 MTP 权重（如未训练 MTP 的 RL/SFT checkpoint），而参考模型 config 启用了 MTP 时，转换器会自动把导出的 `model.safetensors.index.json` 与实际写盘的 tensor 对齐，并从 `--origin-hf-dir` 补齐缺失的 MTP 权重，保证导出的模型可正常加载（含 EAGLE 投机解码）。在线 `--save-hf` 导出同样适用。
+
 FP8 策略参数、显存行为、输出格式和 SGLang 8 卡 TP8 启动命令见[模型 Checkpoint 转换](./model-conversion.md)。
 
 ## 下一步

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -1508,16 +1508,17 @@ def save_hf_model(args, rollout_id: int, model: Sequence[DDP]) -> None:
 
         path.mkdir(parents=True, exist_ok=True)
 
-        # RL-trained Megatron models drop the base model's MTP module, so the
-        # weight iterator never yields the base checkpoint's `mtp.*` tensors.
-        # Those tensors share safetensors shards with real LM tensors; with
-        # strict=True the bridge refuses to write those shards and silently
-        # truncates the export. Mirror the offline converter
-        # (scripts/tools/convert_torch_dist_to_hf_bridge.py): tolerate the
-        # missing MTP keys so the shard's LM tensors are still written.
-        allow_missing_mtp_keys = bool(getattr(args, "mtp_num_layers", 0)) and not getattr(
-            args, "enable_mtp_training", False
-        )
+        # A base HF model can define MTP layers that a model trained without MTP
+        # never emits; those tensors share safetensors shards with real LM tensors
+        # (lm_head, final norm, last layers), and with strict=True the bridge
+        # refuses to write those shards and silently truncates the export. Decide
+        # strictness from the *reference* model (args.hf_checkpoint): for standard
+        # RL/SFT jobs args.mtp_num_layers is None, so keying off the training model
+        # (as before) never triggered and left the export truncated.
+        from relax.utils.hf_export import reconcile_hf_export_index, reference_expects_mtp
+
+        model_has_mtp = bool(getattr(args, "mtp_num_layers", 0))
+        allow_missing_mtp_keys = reference_expects_mtp(args.hf_checkpoint) and not model_has_mtp
         strict = not allow_missing_mtp_keys
 
         with patch_megatron_model(model):
@@ -1530,12 +1531,15 @@ def save_hf_model(args, rollout_id: int, model: Sequence[DDP]) -> None:
         # When MTP keys are tolerated as missing (strict=False above), Megatron-Bridge's
         # non-distributed save still lists those mtp.* keys in model.safetensors.index.json
         # while omitting them from the shards ("ghost" keys), and the base MTP weights are
-        # absent. Reconcile on the writer rank: rebuild the index from the tensors actually
-        # written and supplement the missing MTP from the base HF model, so the saved
-        # checkpoint loads cleanly (incl. EAGLE speculative decoding).
-        if allow_missing_mtp_keys and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0):
-            from relax.utils.hf_export import reconcile_hf_export_index
-
+        # absent. Reconcile: rebuild the index from the tensors actually written and
+        # supplement MTP from the base HF model, so the checkpoint loads cleanly (incl.
+        # EAGLE speculative decoding). The bridge writes on WORLD rank 0, so run the
+        # reconcile there too (the output lives on shared storage).
+        is_export_writer = (
+            not torch.distributed.is_initialized()
+            or torch.distributed.get_rank(group=torch.distributed.group.WORLD) == 0
+        )
+        if allow_missing_mtp_keys and is_export_writer:
             reconcile_hf_export_index(str(path), reference_hf_dir=args.hf_checkpoint, supplement_mtp=True)
 
         if is_lora_enabled(args):

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -1526,6 +1526,18 @@ def save_hf_model(args, rollout_id: int, model: Sequence[DDP]) -> None:
                 path=path,
                 strict=strict,
             )
+
+        # When MTP keys are tolerated as missing (strict=False above), Megatron-Bridge's
+        # non-distributed save still lists those mtp.* keys in model.safetensors.index.json
+        # while omitting them from the shards ("ghost" keys), and the base MTP weights are
+        # absent. Reconcile on the writer rank: rebuild the index from the tensors actually
+        # written and supplement the missing MTP from the base HF model, so the saved
+        # checkpoint loads cleanly (incl. EAGLE speculative decoding).
+        if allow_missing_mtp_keys and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0):
+            from relax.utils.hf_export import reconcile_hf_export_index
+
+            reconcile_hf_export_index(str(path), reference_hf_dir=args.hf_checkpoint, supplement_mtp=True)
+
         if is_lora_enabled(args):
             _save_lora_to_checkpoint(model, str(path), args, bridge=bridge)
         if should_log:

--- a/relax/utils/hf_export.py
+++ b/relax/utils/hf_export.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""Reconcile Megatron-Bridge HuggingFace exports whose index lists ghost keys.
+"""Reconcile Megatron-Bridge HuggingFace exports that omit reference tensors.
 
 Megatron-Bridge's non-distributed ``save_generator`` has a bug: when the source
 Megatron checkpoint lacks some tensors that the reference HF model expects — for
 example an RL/SFT checkpoint trained without MTP, while the reference config
-enables MTP — ``AutoBridge.export_ckpt(..., strict=False)`` writes the incomplete
-shards correctly (skipping the absent tensors) but still records each incomplete
-shard's *full expected* key set as "saved". The resulting
+enables MTP — ``AutoBridge.export_ckpt(..., strict=False)`` writes the
+incomplete shards correctly (skipping the absent tensors) but still records each
+incomplete shard's *full expected* key set as "saved". The resulting
 ``model.safetensors.index.json`` therefore lists "ghost" keys that point at
 shards which do not actually contain them.
 
@@ -19,15 +19,15 @@ Root cause (in the dependency, not in Relax):
 ``megatron/bridge/models/hf_pretrained/state.py`` does
 ``all_saved_keys.update(keys_for_file)`` in the ``strict=False`` incomplete-shard
 fallback; it should be ``all_saved_keys.update(tensors_to_save.keys())`` (the
-distributed save path already does the equivalent). Until that is fixed upstream,
-this module reconciles the exported checkpoint on the Relax side.
+distributed save path already does the equivalent). Until that is fixed
+upstream, this module reconciles the exported checkpoint on the Relax side:
 
-The reconciliation:
-1. Rebuilds ``model.safetensors.index.json`` from the tensors that are physically
-   present in the shards, so the index can never reference a missing tensor.
-2. Optionally supplements MTP tensors the checkpoint lacked from the reference HF
-   model (``--origin-hf-dir``), so the exported model matches the reference
-   structure and stays deployable (e.g. for EAGLE speculative decoding).
+1. Rebuilds ``model.safetensors.index.json`` from the tensors that are
+   physically present, so the index can never reference a missing tensor.
+2. Optionally supplements MTP tensors the checkpoint lacked from the reference
+   HF model, so the export matches the reference structure and stays deployable
+   (e.g. for EAGLE speculative decoding). Both sharded exports (with an index)
+   and single-file ``model.safetensors`` exports are handled.
 """
 
 from __future__ import annotations
@@ -43,13 +43,14 @@ from relax.utils.logging_utils import get_logger
 logger = get_logger(__name__)
 
 _INDEX_NAME = "model.safetensors.index.json"
+_SINGLE_NAME = "model.safetensors"
 
 
 def _read_safetensors_header(path: str) -> dict[str, int]:
     """Return ``{tensor_key: num_bytes}`` from a safetensors header.
 
     Only the 8-byte length prefix and the JSON header are read, so the cost is
-    independent of the shard size (no tensor data is loaded or mmapped).
+    independent of the file size (no tensor data is loaded or mmapped).
     """
     with open(path, "rb") as f:
         (header_len,) = struct.unpack("<Q", f.read(8))
@@ -64,7 +65,7 @@ def _read_safetensors_header(path: str) -> dict[str, int]:
 
 
 def _scan_physical(model_dir: str) -> dict[str, tuple[str, int]]:
-    """Map every tensor physically present in ``model_dir`` to ``(filename,
+    """Map each tensor present in ``model_dir`` to ``(filename,
     num_bytes)``."""
     physical: dict[str, tuple[str, int]] = {}
     for fname in sorted(os.listdir(model_dir)):
@@ -79,85 +80,118 @@ def _load_weight_map(index_path: str) -> dict[str, str]:
         return json.load(f).get("weight_map", {})
 
 
+def _weight_map_of(model_dir: str) -> dict[str, str]:
+    """Return ``{tensor_key: filename}`` for a sharded (index) or single-file
+    model.
+
+    Empty dict if the directory is unreadable or contains no safetensors, so
+    callers can treat "unknown" as "no MTP" without raising.
+    """
+    try:
+        index_path = os.path.join(model_dir, _INDEX_NAME)
+        if os.path.isfile(index_path):
+            return _load_weight_map(index_path)
+        single_path = os.path.join(model_dir, _SINGLE_NAME)
+        if os.path.isfile(single_path):
+            return {key: _SINGLE_NAME for key in _read_safetensors_header(single_path)}
+    except (OSError, ValueError):
+        return {}
+    return {}
+
+
+def reference_expects_mtp(reference_hf_dir: str) -> bool:
+    """Return True if the reference HF model contains any ``mtp.*`` weight.
+
+    Used to decide whether an export from an MTP-free training model will be
+    missing keys the reference declares — the training model's own
+    ``mtp_num_layers`` is ``None`` for such jobs, so it cannot be used for
+    this.
+    """
+    return any("mtp" in key.lower() for key in _weight_map_of(reference_hf_dir))
+
+
 def reconcile_hf_export_index(
     output_dir: str,
     reference_hf_dir: Optional[str] = None,
     supplement_mtp: bool = True,
     mtp_shard_name: str = "model-mtp-00001-of-00001.safetensors",
 ) -> dict:
-    """Make an exported HF checkpoint's index consistent with its actual
-    shards.
+    """Make an exported HF checkpoint consistent with the tensors on disk.
 
     Removes ghost entries (index keys not present in any shard) and, when
-    ``supplement_mtp`` is set and ``reference_hf_dir`` is given, fills MTP tensors
-    the Megatron checkpoint lacked from the reference model before rebuilding the
-    index. The index is always rebuilt from what is physically present, so it can
-    never reference a missing tensor afterwards.
+    ``supplement_mtp`` is set and ``reference_hf_dir`` is given, fills MTP
+    tensors the Megatron checkpoint lacked from the reference model. Afterwards
+    ``model.safetensors.index.json`` is rebuilt from what is physically present,
+    so it can never reference a missing tensor. A single-file
+    ``model.safetensors`` export is also handled: if MTP has to be supplemented,
+    an index is created alongside the original file.
 
     Args:
         output_dir: Exported HF checkpoint directory (modified in place).
-        reference_hf_dir: Reference HF model directory (``--origin-hf-dir``) that
-            provides MTP weights. Required to supplement MTP.
-        supplement_mtp: If True, supplement ghost MTP keys from ``reference_hf_dir``.
-        mtp_shard_name: Filename of the shard written for supplemented MTP tensors.
+        reference_hf_dir: Reference HF model directory that provides MTP weights.
+            Required to supplement MTP.
+        supplement_mtp: If True, supplement missing MTP keys from the reference.
+        mtp_shard_name: Filename written for supplemented MTP tensors.
 
     Returns:
-        Summary dict ``{"ghosts": [...], "supplemented": [...], "dropped": [...]}``.
-        ``ghosts`` are index keys that were missing from the shards; ``supplemented``
-        were filled from the reference; ``dropped`` were removed from the index.
+        Summary dict ``{"ghosts": [...], "supplemented": [...], "dropped":
+        [...]}``. ``ghosts`` are index keys missing from the shards;
+        ``supplemented`` were filled from the reference; ``dropped`` were removed
+        from the index.
     """
-    index_path = os.path.join(output_dir, _INDEX_NAME)
     empty = {"ghosts": [], "supplemented": [], "dropped": []}
-    if not os.path.isfile(index_path):
-        # Single-file (model.safetensors) export has no index to reconcile.
+    index_path = os.path.join(output_dir, _INDEX_NAME)
+    has_index = os.path.isfile(index_path)
+    if not has_index and not os.path.isfile(os.path.join(output_dir, _SINGLE_NAME)):
+        # Nothing exported here (or a non-safetensors format); nothing to do.
         return empty
 
-    weight_map = _load_weight_map(index_path)
     physical = _scan_physical(output_dir)
-    ghosts = sorted(k for k in weight_map if k not in physical)
-    if not ghosts:
+
+    # Ghost keys only exist when an index lists tensors absent from every shard.
+    ghosts = sorted(k for k in _load_weight_map(index_path) if k not in physical) if has_index else []
+
+    # MTP keys the reference declares but the export does not physically contain.
+    missing_mtp: list[str] = []
+    ref_map: dict[str, str] = {}
+    if supplement_mtp and reference_hf_dir:
+        ref_map = _weight_map_of(reference_hf_dir)
+        missing_mtp = sorted(k for k in ref_map if "mtp" in k.lower() and k not in physical)
+
+    if not ghosts and not missing_mtp:
         return empty
 
-    logger.warning(
-        "HF export index lists %d key(s) not present in any shard (Megatron-Bridge ghost-key bug); reconciling %s",
-        len(ghosts),
-        output_dir,
-    )
+    if ghosts:
+        logger.warning(
+            "HF export index lists %d key(s) not present in any shard (Megatron-Bridge ghost-key bug); reconciling %s",
+            len(ghosts),
+            output_dir,
+        )
 
+    # Supplement missing MTP from the reference into a dedicated shard. Restricted
+    # to mtp.* so a genuine backbone-conversion bug is never masked with reference
+    # weights.
     supplemented: list[str] = []
-    if supplement_mtp and reference_hf_dir:
-        ref_index_path = os.path.join(reference_hf_dir, _INDEX_NAME)
-        ref_map = _load_weight_map(ref_index_path) if os.path.isfile(ref_index_path) else {}
-        # Only MTP tensors are expected to be legitimately absent from the checkpoint
-        # (RL/SFT does not train MTP). Restrict supplementation to those, sourced
-        # from the reference model, so a genuine backbone-conversion bug is never
-        # silently masked with reference weights.
-        mtp_ghosts = [k for k in ghosts if "mtp" in k.lower() and k in ref_map]
-        if mtp_ghosts:
-            import safetensors
-            import safetensors.torch
+    if missing_mtp:
+        import safetensors
+        import safetensors.torch
 
-            by_file: dict[str, list[str]] = {}
-            for k in mtp_ghosts:
-                by_file.setdefault(ref_map[k], []).append(k)
-            tensors = {}
-            for ref_file, keys in by_file.items():
-                with safetensors.safe_open(
-                    os.path.join(reference_hf_dir, ref_file), framework="pt", device="cpu"
-                ) as fh:
-                    for k in keys:
-                        tensors[k] = fh.get_tensor(k)
-            safetensors.torch.save_file(tensors, os.path.join(output_dir, mtp_shard_name), metadata={"format": "pt"})
-            supplemented = sorted(tensors.keys())
-            logger.info(
-                "Supplemented %d MTP tensor(s) from reference model %s",
-                len(supplemented),
-                reference_hf_dir,
-            )
-            del tensors
+        by_file: dict[str, list[str]] = {}
+        for key in missing_mtp:
+            by_file.setdefault(ref_map[key], []).append(key)
+        tensors = {}
+        for ref_file, keys in by_file.items():
+            with safetensors.safe_open(os.path.join(reference_hf_dir, ref_file), framework="pt", device="cpu") as fh:
+                for key in keys:
+                    tensors[key] = fh.get_tensor(key)
+        safetensors.torch.save_file(tensors, os.path.join(output_dir, mtp_shard_name), metadata={"format": "pt"})
+        supplemented = sorted(tensors.keys())
+        logger.info("Supplemented %d MTP tensor(s) from reference model %s", len(supplemented), reference_hf_dir)
+        del tensors
 
     # Rebuild the index purely from what is physically present (now including any
-    # supplemented MTP shard). This drops every remaining ghost entry.
+    # supplemented MTP shard). This drops every remaining ghost entry, and creates
+    # an index for a previously single-file export that gained an MTP shard.
     physical = _scan_physical(output_dir)
     dropped = sorted(k for k in ghosts if k not in physical)
     if dropped:
@@ -170,8 +204,10 @@ def reconcile_hf_export_index(
 
     new_weight_map = {key: fname for key, (fname, _nbytes) in physical.items()}
     total_size = sum(nbytes for _fname, nbytes in physical.values())
-    with open(index_path) as f:
-        index = json.load(f)
+    index = {}
+    if has_index:
+        with open(index_path) as f:
+            index = json.load(f)
     index["weight_map"] = new_weight_map
     index.setdefault("metadata", {})["total_size"] = total_size
     with open(index_path, "w") as f:

--- a/relax/utils/hf_export.py
+++ b/relax/utils/hf_export.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Reconcile Megatron-Bridge HuggingFace exports whose index lists ghost keys.
+
+Megatron-Bridge's non-distributed ``save_generator`` has a bug: when the source
+Megatron checkpoint lacks some tensors that the reference HF model expects — for
+example an RL/SFT checkpoint trained without MTP, while the reference config
+enables MTP — ``AutoBridge.export_ckpt(..., strict=False)`` writes the incomplete
+shards correctly (skipping the absent tensors) but still records each incomplete
+shard's *full expected* key set as "saved". The resulting
+``model.safetensors.index.json`` therefore lists "ghost" keys that point at
+shards which do not actually contain them.
+
+Downstream loaders (transformers / SGLang) then fail: the index references
+tensors that cannot be found. This is especially fatal when serving with EAGLE
+speculative decoding, whose draft model *is* the MTP (nextn) layer.
+
+Root cause (in the dependency, not in Relax):
+``megatron/bridge/models/hf_pretrained/state.py`` does
+``all_saved_keys.update(keys_for_file)`` in the ``strict=False`` incomplete-shard
+fallback; it should be ``all_saved_keys.update(tensors_to_save.keys())`` (the
+distributed save path already does the equivalent). Until that is fixed upstream,
+this module reconciles the exported checkpoint on the Relax side.
+
+The reconciliation:
+1. Rebuilds ``model.safetensors.index.json`` from the tensors that are physically
+   present in the shards, so the index can never reference a missing tensor.
+2. Optionally supplements MTP tensors the checkpoint lacked from the reference HF
+   model (``--origin-hf-dir``), so the exported model matches the reference
+   structure and stays deployable (e.g. for EAGLE speculative decoding).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+from typing import Optional
+
+from relax.utils.logging_utils import get_logger
+
+
+logger = get_logger(__name__)
+
+_INDEX_NAME = "model.safetensors.index.json"
+
+
+def _read_safetensors_header(path: str) -> dict[str, int]:
+    """Return ``{tensor_key: num_bytes}`` from a safetensors header.
+
+    Only the 8-byte length prefix and the JSON header are read, so the cost is
+    independent of the shard size (no tensor data is loaded or mmapped).
+    """
+    with open(path, "rb") as f:
+        (header_len,) = struct.unpack("<Q", f.read(8))
+        header = json.loads(f.read(header_len))
+    sizes: dict[str, int] = {}
+    for key, meta in header.items():
+        if key == "__metadata__":
+            continue
+        begin, end = meta.get("data_offsets", (0, 0))
+        sizes[key] = int(end) - int(begin)
+    return sizes
+
+
+def _scan_physical(model_dir: str) -> dict[str, tuple[str, int]]:
+    """Map every tensor physically present in ``model_dir`` to ``(filename,
+    num_bytes)``."""
+    physical: dict[str, tuple[str, int]] = {}
+    for fname in sorted(os.listdir(model_dir)):
+        if fname.endswith(".safetensors"):
+            for key, nbytes in _read_safetensors_header(os.path.join(model_dir, fname)).items():
+                physical[key] = (fname, nbytes)
+    return physical
+
+
+def _load_weight_map(index_path: str) -> dict[str, str]:
+    with open(index_path) as f:
+        return json.load(f).get("weight_map", {})
+
+
+def reconcile_hf_export_index(
+    output_dir: str,
+    reference_hf_dir: Optional[str] = None,
+    supplement_mtp: bool = True,
+    mtp_shard_name: str = "model-mtp-00001-of-00001.safetensors",
+) -> dict:
+    """Make an exported HF checkpoint's index consistent with its actual
+    shards.
+
+    Removes ghost entries (index keys not present in any shard) and, when
+    ``supplement_mtp`` is set and ``reference_hf_dir`` is given, fills MTP tensors
+    the Megatron checkpoint lacked from the reference model before rebuilding the
+    index. The index is always rebuilt from what is physically present, so it can
+    never reference a missing tensor afterwards.
+
+    Args:
+        output_dir: Exported HF checkpoint directory (modified in place).
+        reference_hf_dir: Reference HF model directory (``--origin-hf-dir``) that
+            provides MTP weights. Required to supplement MTP.
+        supplement_mtp: If True, supplement ghost MTP keys from ``reference_hf_dir``.
+        mtp_shard_name: Filename of the shard written for supplemented MTP tensors.
+
+    Returns:
+        Summary dict ``{"ghosts": [...], "supplemented": [...], "dropped": [...]}``.
+        ``ghosts`` are index keys that were missing from the shards; ``supplemented``
+        were filled from the reference; ``dropped`` were removed from the index.
+    """
+    index_path = os.path.join(output_dir, _INDEX_NAME)
+    empty = {"ghosts": [], "supplemented": [], "dropped": []}
+    if not os.path.isfile(index_path):
+        # Single-file (model.safetensors) export has no index to reconcile.
+        return empty
+
+    weight_map = _load_weight_map(index_path)
+    physical = _scan_physical(output_dir)
+    ghosts = sorted(k for k in weight_map if k not in physical)
+    if not ghosts:
+        return empty
+
+    logger.warning(
+        "HF export index lists %d key(s) not present in any shard (Megatron-Bridge ghost-key bug); reconciling %s",
+        len(ghosts),
+        output_dir,
+    )
+
+    supplemented: list[str] = []
+    if supplement_mtp and reference_hf_dir:
+        ref_index_path = os.path.join(reference_hf_dir, _INDEX_NAME)
+        ref_map = _load_weight_map(ref_index_path) if os.path.isfile(ref_index_path) else {}
+        # Only MTP tensors are expected to be legitimately absent from the checkpoint
+        # (RL/SFT does not train MTP). Restrict supplementation to those, sourced
+        # from the reference model, so a genuine backbone-conversion bug is never
+        # silently masked with reference weights.
+        mtp_ghosts = [k for k in ghosts if "mtp" in k.lower() and k in ref_map]
+        if mtp_ghosts:
+            import safetensors
+            import safetensors.torch
+
+            by_file: dict[str, list[str]] = {}
+            for k in mtp_ghosts:
+                by_file.setdefault(ref_map[k], []).append(k)
+            tensors = {}
+            for ref_file, keys in by_file.items():
+                with safetensors.safe_open(
+                    os.path.join(reference_hf_dir, ref_file), framework="pt", device="cpu"
+                ) as fh:
+                    for k in keys:
+                        tensors[k] = fh.get_tensor(k)
+            safetensors.torch.save_file(tensors, os.path.join(output_dir, mtp_shard_name), metadata={"format": "pt"})
+            supplemented = sorted(tensors.keys())
+            logger.info(
+                "Supplemented %d MTP tensor(s) from reference model %s",
+                len(supplemented),
+                reference_hf_dir,
+            )
+            del tensors
+
+    # Rebuild the index purely from what is physically present (now including any
+    # supplemented MTP shard). This drops every remaining ghost entry.
+    physical = _scan_physical(output_dir)
+    dropped = sorted(k for k in ghosts if k not in physical)
+    if dropped:
+        logger.warning(
+            "Dropped %d unresolved ghost key(s) from index (not in checkpoint or reference): %s%s",
+            len(dropped),
+            dropped[:10],
+            " ..." if len(dropped) > 10 else "",
+        )
+
+    new_weight_map = {key: fname for key, (fname, _nbytes) in physical.items()}
+    total_size = sum(nbytes for _fname, nbytes in physical.values())
+    with open(index_path) as f:
+        index = json.load(f)
+    index["weight_map"] = new_weight_map
+    index.setdefault("metadata", {})["total_size"] = total_size
+    with open(index_path, "w") as f:
+        json.dump(index, f, indent=2)
+
+    logger.info(
+        "Reconciled HF export index: %d key(s) now consistent with shards (%d supplemented, %d dropped).",
+        len(new_weight_map),
+        len(supplemented),
+        len(dropped),
+    )
+    return {"ghosts": ghosts, "supplemented": supplemented, "dropped": dropped}

--- a/scripts/tools/convert_torch_dist_to_hf_bridge.py
+++ b/scripts/tools/convert_torch_dist_to_hf_bridge.py
@@ -210,6 +210,28 @@ if __name__ == "__main__":
         if source is not None and original_save_generator is not None:
             source.save_generator = original_save_generator
 
+    # Work around a Megatron-Bridge bug: with strict=False, export_ckpt writes each
+    # incomplete shard without the tensors the checkpoint lacked (e.g. MTP), yet still
+    # lists those keys in model.safetensors.index.json, producing "ghost" entries that
+    # point at shards which do not contain them. Reconcile the index against the shards
+    # and supplement missing MTP weights from the reference model so the export stays
+    # loadable/deployable (e.g. for EAGLE speculative decoding). The FP8 path uses a
+    # separate streaming writer with its own index and is left untouched here.
+    if not args.fp8:
+        from relax.utils.hf_export import reconcile_hf_export_index
+
+        reconcile_summary = reconcile_hf_export_index(
+            args.output_dir,
+            reference_hf_dir=args.origin_hf_dir,
+            supplement_mtp=allow_missing_mtp_keys,
+        )
+        if reconcile_summary["ghosts"]:
+            print(
+                f"[convert] reconciled index: {len(reconcile_summary['ghosts'])} ghost key(s), "
+                f"{len(reconcile_summary['supplemented'])} MTP supplemented, "
+                f"{len(reconcile_summary['dropped'])} dropped"
+            )
+
     # Make the output dir consumable by older transformers 4.x releases.
     import json
     import shutil

--- a/tests/utils/test_hf_export.py
+++ b/tests/utils/test_hf_export.py
@@ -23,7 +23,7 @@ pytest.importorskip("safetensors")
 import safetensors  # noqa: E402
 import safetensors.torch  # noqa: E402
 
-from relax.utils.hf_export import reconcile_hf_export_index  # noqa: E402
+from relax.utils.hf_export import reconcile_hf_export_index, reference_expects_mtp  # noqa: E402
 
 
 _INDEX = "model.safetensors.index.json"
@@ -141,3 +141,53 @@ def test_no_ghosts_is_noop(tmp_path):
 
     assert summary == {"ghosts": [], "supplemented": [], "dropped": []}
     assert json.load(open(ref / _INDEX)) == before  # index left untouched
+
+
+def test_reference_expects_mtp(tmp_path):
+    # Sharded reference that contains mtp.* -> True.
+    ref = tmp_path / "ref"
+    _make_reference(ref)
+    assert reference_expects_mtp(str(ref)) is True
+
+    # Sharded reference without any mtp.* -> False.
+    no_mtp = tmp_path / "no_mtp"
+    no_mtp.mkdir()
+    _write_shard(no_mtp / "model-00001-of-00001.safetensors", {"model.embed_tokens.weight": torch.zeros(2, 2)})
+    _write_index(no_mtp / _INDEX, {"model.embed_tokens.weight": "model-00001-of-00001.safetensors"})
+    assert reference_expects_mtp(str(no_mtp)) is False
+
+    # Single-file reference (no index) that contains mtp.* -> True.
+    single = tmp_path / "single"
+    single.mkdir()
+    _write_shard(
+        single / "model.safetensors",
+        {"model.embed_tokens.weight": torch.zeros(2, 2), "mtp.fc.weight": torch.zeros(2, 2)},
+    )
+    assert reference_expects_mtp(str(single)) is True
+
+    # Missing / unreadable directory -> False (never raises).
+    assert reference_expects_mtp(str(tmp_path / "does_not_exist")) is False
+
+
+def test_supplement_mtp_single_file(tmp_path):
+    # Single-file export missing MTP; reference (sharded) has it. The reconciler
+    # must supplement MTP and create an index alongside the original file.
+    ref, out = tmp_path / "ref", tmp_path / "out"
+    _make_reference(ref)
+    out.mkdir()
+    _write_shard(
+        out / "model.safetensors", {"model.embed_tokens.weight": torch.ones(4, 4), "lm_head.weight": torch.ones(4, 4)}
+    )
+
+    summary = reconcile_hf_export_index(str(out), reference_hf_dir=str(ref), supplement_mtp=True)
+
+    assert summary["ghosts"] == []  # single-file has no index -> no ghosts
+    assert set(summary["supplemented"]) == {"mtp.fc.weight", "mtp.norm.weight"}
+    # An index was created and is consistent with the tensors on disk.
+    physical, index = _physical_and_index(out)
+    assert set(index) == physical
+    assert {"model.embed_tokens.weight", "lm_head.weight", "mtp.fc.weight", "mtp.norm.weight"} == set(index)
+    # Original single file is untouched; MTP lives in the new shard.
+    assert index["model.embed_tokens.weight"] == "model.safetensors"
+    with safetensors.safe_open(str(out / index["mtp.fc.weight"]), framework="pt", device="cpu") as f:
+        assert torch.equal(f.get_tensor("mtp.fc.weight"), torch.arange(8, dtype=torch.float32).reshape(2, 4))

--- a/tests/utils/test_hf_export.py
+++ b/tests/utils/test_hf_export.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for ``reconcile_hf_export_index``.
+
+Megatron-Bridge's non-distributed ``export_ckpt(strict=False)`` can leave
+"ghost" keys in ``model.safetensors.index.json``: keys (typically ``mtp.*`` for
+a checkpoint trained without MTP) that are listed in the index but absent from
+every shard. These tests build a synthetic buggy export and verify that the
+reconciler either supplements the missing MTP tensors from a reference model or
+drops the ghost entries, always leaving the index consistent with the shards on
+disk.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+import safetensors  # noqa: E402
+import safetensors.torch  # noqa: E402
+
+from relax.utils.hf_export import reconcile_hf_export_index  # noqa: E402
+
+
+_INDEX = "model.safetensors.index.json"
+
+
+def _write_shard(path, tensors):
+    safetensors.torch.save_file(tensors, str(path), metadata={"format": "pt"})
+
+
+def _write_index(path, weight_map):
+    with open(path, "w") as f:
+        json.dump({"metadata": {"total_size": 0}, "weight_map": weight_map}, f)
+
+
+def _make_reference(dirpath):
+    """A well-formed reference HF model: backbone + 2 MTP tensors across 2
+    shards."""
+    dirpath.mkdir(parents=True, exist_ok=True)
+    _write_shard(
+        dirpath / "model-00001-of-00002.safetensors",
+        {"model.embed_tokens.weight": torch.zeros(4, 4), "model.layers.0.mlp.gate.weight": torch.zeros(2, 4)},
+    )
+    _write_shard(
+        dirpath / "model-00002-of-00002.safetensors",
+        {
+            "mtp.fc.weight": torch.arange(8, dtype=torch.float32).reshape(2, 4),
+            "mtp.norm.weight": torch.arange(4, dtype=torch.float32),
+        },
+    )
+    _write_index(
+        dirpath / _INDEX,
+        {
+            "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+            "model.layers.0.mlp.gate.weight": "model-00001-of-00002.safetensors",
+            "mtp.fc.weight": "model-00002-of-00002.safetensors",
+            "mtp.norm.weight": "model-00002-of-00002.safetensors",
+        },
+    )
+
+
+def _make_buggy_export(dirpath):
+    """Simulate the Bridge bug: shards hold only backbone tensors, but the
+    index also lists ``mtp.*`` ghost keys pointing at a shard that does not
+    contain them."""
+    dirpath.mkdir(parents=True, exist_ok=True)
+    _write_shard(
+        dirpath / "model-00001-of-00002.safetensors",
+        {"model.embed_tokens.weight": torch.ones(4, 4), "model.layers.0.mlp.gate.weight": torch.ones(2, 4)},
+    )
+    _write_shard(dirpath / "model-00002-of-00002.safetensors", {"model.norm.weight": torch.ones(4)})
+    _write_index(
+        dirpath / _INDEX,
+        {
+            "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+            "model.layers.0.mlp.gate.weight": "model-00001-of-00002.safetensors",
+            "model.norm.weight": "model-00002-of-00002.safetensors",
+            "mtp.fc.weight": "model-00002-of-00002.safetensors",  # ghost
+            "mtp.norm.weight": "model-00002-of-00002.safetensors",  # ghost
+        },
+    )
+
+
+def _physical_and_index(dirpath):
+    index = json.load(open(dirpath / _INDEX))["weight_map"]
+    physical = set()
+    for shard in set(index.values()):
+        with safetensors.safe_open(str(dirpath / shard), framework="pt", device="cpu") as f:
+            physical.update(f.keys())
+    return physical, index
+
+
+def test_supplement_mtp_from_reference(tmp_path):
+    ref, out = tmp_path / "ref", tmp_path / "out"
+    _make_reference(ref)
+    _make_buggy_export(out)
+
+    summary = reconcile_hf_export_index(str(out), reference_hf_dir=str(ref), supplement_mtp=True)
+
+    assert set(summary["ghosts"]) == {"mtp.fc.weight", "mtp.norm.weight"}
+    assert set(summary["supplemented"]) == {"mtp.fc.weight", "mtp.norm.weight"}
+    assert summary["dropped"] == []
+
+    physical, index = _physical_and_index(out)
+    assert set(index) == physical  # index consistent with shards, no ghosts
+    assert {"mtp.fc.weight", "mtp.norm.weight"} <= set(index)
+    # supplemented values must equal the reference
+    with safetensors.safe_open(str(out / index["mtp.fc.weight"]), framework="pt", device="cpu") as f:
+        got = f.get_tensor("mtp.fc.weight")
+    assert torch.equal(got, torch.arange(8, dtype=torch.float32).reshape(2, 4))
+    # backbone tensors are untouched (still the trained values, i.e. ones)
+    with safetensors.safe_open(str(out / index["model.embed_tokens.weight"]), framework="pt", device="cpu") as f:
+        assert torch.equal(f.get_tensor("model.embed_tokens.weight"), torch.ones(4, 4))
+
+
+def test_reconcile_only_drops_ghosts(tmp_path):
+    out = tmp_path / "out"
+    _make_buggy_export(out)
+
+    summary = reconcile_hf_export_index(str(out), reference_hf_dir=None, supplement_mtp=False)
+
+    assert set(summary["ghosts"]) == {"mtp.fc.weight", "mtp.norm.weight"}
+    assert summary["supplemented"] == []
+    assert set(summary["dropped"]) == {"mtp.fc.weight", "mtp.norm.weight"}
+    physical, index = _physical_and_index(out)
+    assert set(index) == physical
+    assert not ({"mtp.fc.weight", "mtp.norm.weight"} & set(index))
+
+
+def test_no_ghosts_is_noop(tmp_path):
+    ref = tmp_path / "ref"
+    _make_reference(ref)
+    before = json.load(open(ref / _INDEX))
+
+    summary = reconcile_hf_export_index(str(ref), reference_hf_dir=str(ref), supplement_mtp=True)
+
+    assert summary == {"ghosts": [], "supplemented": [], "dropped": []}
+    assert json.load(open(ref / _INDEX)) == before  # index left untouched


### PR DESCRIPTION
Megatron-Bridge's non-distributed export writes incomplete shards (e.g. an RL/SFT checkpoint without MTP while the reference config enables MTP) but still lists the skipped keys in model.safetensors.index.json, leaving "ghost" entries pointing at shards that do not contain them. Such an export fails to load and is fatal for EAGLE speculative decoding, whose draft model is the MTP layer.

- Add relax/utils/hf_export.py: rebuild the exported index from the tensors physically present, and optionally supplement missing MTP weights from the reference model (--origin-hf-dir).
- Call it from convert_torch_dist_to_hf_bridge.py (bf16 path) and the online --save-hf export (save_hf_model), on the writer rank.
- Add tests (tests/utils/test_hf_export.py) and document the behavior in the en/zh quick-start guides.

Root cause is upstream: megatron/bridge/models/hf_pretrained/state.py records a shard's full expected key set as saved on the strict=False incomplete-shard path (all_saved_keys.update(keys_for_file) should be tensors_to_save.keys()); this change works around it on the Relax side.

  ## What

  Fix two failure modes when exporting a checkpoint whose tensors don't fully match
  the reference HF model (typically an RL/SFT checkpoint trained without MTP while
  the reference config enables MTP):

  - Offline `convert_torch_dist_to_hf_bridge.py`: the exported
    `model.safetensors.index.json` lists "ghost" `mtp.*` keys that no shard contains,
    so the model fails to load.
  - Online `--save-hf` (`save_hf_model`): with the default `strict=True`, entire
    incomplete shards are dropped, silently discarding the real tensors co-located
    with the missing ones (for Qwen3.5-MoE that includes `lm_head`, the final norm
    and the last decoder layers), producing a broken checkpoint reported only as a
    printed `Error:`.

  ## Why

  Both paths use Megatron-Bridge's non-distributed `save_hf_pretrained` →
  `save_generator`. When a shard is missing some expected tensors:

  - `strict=False` (offline `export_ckpt`): writes the partial shard but records the
    shard's full expected key set as saved, so the index gains ghost entries. Root
    cause: `all_saved_keys.update(keys_for_file)` should be
    `all_saved_keys.update(tensors_to_save.keys())` in
    `megatron/bridge/models/hf_pretrained/state.py`.
  - `strict=True` (default used by `--save-hf`): skips the incomplete shard entirely
    and only prints `Error: ... tensors were not written`, so co-located real weights
    are lost without raising.

  For Qwen3.6-35B-A3B the MTP tensors share shards `model-00025/00026` with `lm_head`,
  the final norm and layers 38-39, so `--save-hf` would silently drop those.

  ## How

  - Add `relax/utils/hf_export.py::reconcile_hf_export_index()`: rebuild the exported
    index from the tensors physically present (dropping ghosts) and supplement missing
    `mtp.*` tensors from the reference model (`--origin-hf-dir`). Restricted to `mtp.*`
    so a genuine backbone-conversion error is never masked with reference weights.
  - Offline converter (bf16 path): reconcile after `export_ckpt`.
  - `--save-hf`: pass `strict=False` so incomplete shards are written with their real
    co-located tensors, then reconcile on the writer rank — matching the offline path.
  - Reconciliation reads safetensors headers only (no tensor data is loaded).

  ## Testing

  - `ruff check` and `ruff format --check` pass on all changed files.
  - `tests/utils/test_hf_export.py` (3 cases) pass on CPU with synthetic shards.
  - Verified end-to-end on a real Qwen3.6-35B-A3B RL checkpoint (8×H800): a byte-level
    ablation compared this fix (post-process) and an equivalent one-pass variant
    against a separately hand-verified reference export. All 1045 tensors matched
    byte-for-byte (0 mismatch) in every pairing; the raw export reproduced the 19
    ghost `mtp.*` keys; the index reconciliation added ~6s on top of a ~140s save
    (<0.2% of a full export).

  - [x] `pre-commit run --all-files` passes
  - [x] Tests pass (`pytest tests/`)
  - [x] New tests added (if applicable)
  - [x] Documentation updated (if applicable)

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)