### PR TITLE
【No.17】DeepEyes 动态 processor 的 A6000 E2E 配置

### DIFF
--- a/examples/deepeyes/README.md
+++ b/examples/deepeyes/README.md
@@ -44,6 +44,30 @@ bash benchmark.sh run_deepeyes
 bash examples/deepeyes/run_deepeyes.sh
 ```
 
+R3 配方默认启用动态 processor：
+
+```bash
+MODEL_DIR=/path/to/models \
+DATA_DIR=/path/to/data \
+SAVE_DIR=/path/to/save \
+bash examples/deepeyes/run_deepeyes_r3.sh
+```
+
+`run_deepeyes_r3.sh` 默认保持单卡 rollout engine，适用于已验证的
+8×H800 80GB 环境。在 8×RTX A6000 48GB 等单卡无法容纳 30B rollout
+模型的环境中，应显式使用两卡 tensor parallel；该设置只改变 SGLang
+engine 的模型分片，不改变 processor patch 行为：
+
+```bash
+ROLLOUT_NUM_GPUS_PER_ENGINE=2 \
+MODEL_DIR=/path/to/models \
+DATA_DIR=/path/to/data \
+SAVE_DIR=/path/to/save \
+bash examples/deepeyes/run_deepeyes_r3.sh
+```
+
+`ROLLOUT_NUM_GPUS_PER_ENGINE` 必须是正整数，并且应能整除脚本为 rollout
+角色分配的 8 张 GPU；无效值会在提交 Ray job 前直接报错。
 在单机 8×H800（80GB）上运行 `run_deepeyes.sh` 时的 GPU 使用率监控（平均约 66%）：
 
 ![单机 8×H800（80GB）运行 run_deepeyes.sh 的 GPU 使用率](../../docs/public/deepeyes-h800.png)

--- a/examples/deepeyes/processor_patch_utils.py
+++ b/examples/deepeyes/processor_patch_utils.py
@@ -9,8 +9,11 @@ from typing import Any, Awaitable, Callable
 
 from packaging.version import Version
 
+from relax.utils.logging_utils import get_logger
+
 
 SUPPORTED_SGLANG_VERSION = Version("0.5.12.post1")
+logger = get_logger(__name__)
 
 
 def collapse_consecutive_image_tokens(input_ids: Any, image_token_id: int) -> Any:
@@ -99,6 +102,16 @@ async def process_preexpanded_inputs(
         raise RuntimeError(
             "DeepEyes processor registration received an unsupported SGLang output type "
             f"{type(output).__name__}; review the processor contract for this SGLang release."
+        )
+
+    hit_count = getattr(processor, "_deepeyes_processor_hit_count", 0) + 1
+    processor._deepeyes_processor_hit_count = hit_count
+    if hit_count == 1:
+        logger.info(
+            "DeepEyes processor first hit: class=%s rid=%s input_tokens=%s",
+            type(processor).__name__,
+            getattr(request_obj, "rid", "anonymous_rid"),
+            len(original_input_ids),
         )
 
     mrope_items = merge_mrope_grid_items(output.mm_items)

--- a/examples/deepeyes/run_deepeyes_r3.sh
+++ b/examples/deepeyes/run_deepeyes_r3.sh
@@ -69,6 +69,15 @@ PROMPT_SET="[$(IFS=,; echo "${TRAIN_FILES[*]}")]"
 ###############################################################################
 
 NUM_ROLLOUT="${NUM_ROLLOUT:=2000}"
+ROLLOUT_NUM_GPUS_PER_ENGINE="${ROLLOUT_NUM_GPUS_PER_ENGINE:-1}"
+if ! [[ "${ROLLOUT_NUM_GPUS_PER_ENGINE}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: ROLLOUT_NUM_GPUS_PER_ENGINE must be a positive integer." >&2
+    exit 1
+fi
+if ((8 % ROLLOUT_NUM_GPUS_PER_ENGINE != 0)); then
+    echo "ERROR: ROLLOUT_NUM_GPUS_PER_ENGINE must divide the 8 rollout GPUs." >&2
+    exit 1
+fi
 
 ROLLOUT_ARGS=(
     --prompt-data "${PROMPT_SET}"
@@ -199,7 +208,7 @@ MEGATRON_ARGS=(
 ###############################################################################
 
 RAY_RESOURCE_ARGS=(
-    --rollout-num-gpus-per-engine 1
+    --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE}"
     --resource '{"actor": [1, 8], "rollout": [1, 8]}'
     --max-staleness 0
     --num-data-storage-units 1

--- a/tests/examples/test_deepeyes_processor_patch.py
+++ b/tests/examples/test_deepeyes_processor_patch.py
@@ -62,6 +62,16 @@ def test_deepeyes_does_not_overwrite_sglang_installation():
     assert not (repo_root / "examples/deepeyes/qwen_vl.py").exists()
 
 
+def test_r3_recipe_exposes_validated_rollout_tensor_parallelism():
+    repo_root = Path(__file__).resolve().parents[2]
+    run_script = (repo_root / "examples/deepeyes/run_deepeyes_r3.sh").read_text()
+
+    assert 'ROLLOUT_NUM_GPUS_PER_ENGINE="${ROLLOUT_NUM_GPUS_PER_ENGINE:-1}"' in run_script
+    assert "ROLLOUT_NUM_GPUS_PER_ENGINE must be a positive integer" in run_script
+    assert "8 % ROLLOUT_NUM_GPUS_PER_ENGINE" in run_script
+    assert '--rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE}"' in run_script
+
+
 def test_patch_preserves_upstream_outputs_and_recomputes_mrope():
     calls = []
     processor_cls = _processor_class(calls)

--- a/tests/examples/test_deepeyes_processor_patch.py
+++ b/tests/examples/test_deepeyes_processor_patch.py
@@ -94,6 +94,7 @@ def test_patch_preserves_upstream_outputs_and_recomputes_mrope():
     assert output.mm_items == ["image"]
     assert output.mrope_positions == "restored positions"
     assert output.mrope_position_delta == "restored delta"
+    assert processor._deepeyes_processor_hit_count == 1
 
 
 def test_merge_mrope_grid_items_combines_multi_turn_image_grids():


### PR DESCRIPTION
## Scope

This is the environment-reproducibility follow-up for #150. The dynamic DeepEyes processor registration itself is already present on `main` via #164; this PR keeps its output semantics unchanged and makes the real 30B smoke observable and runnable on the fixed 8×RTX A6000 48GB environment.

- Add `ROLLOUT_NUM_GPUS_PER_ENGINE` to `run_deepeyes_r3.sh` with the existing one-GPU behavior as the default.
- Validate that the value is a positive integer and divides the eight rollout GPUs before submitting the Ray job.
- Document the explicit two-GPU tensor-parallel setting required when one 48GB GPU cannot hold the Qwen3-VL-30B-A3B rollout engine.
- Emit one content-free activation marker per processor instance so the E2E can prove that a real pre-expanded request reached the adapter.
- Add targeted assertions so the launch and activation contracts cannot silently regress.

## Motivation

The accepted R3 recipe starts one SGLang engine per rollout GPU. That is appropriate for the documented 80GB H800 environment, but the fixed Task 17 validation host uses 48GB A6000 GPUs. `ROLLOUT_NUM_GPUS_PER_ENGINE=2` shards each rollout engine across two GPUs while preserving the total actor/rollout resource pool and all dynamic-processor semantics.

## Launch command

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  ROLLOUT_NUM_GPUS_PER_ENGINE=2 \
  MODEL_DIR=/data01/LWX/task17/models \
  DATA_DIR=/data01/LWX/task17/data \
  SAVE_DIR=/data01/LWX/task17/checkpoints \
  NUM_ROLLOUT=1 \
  bash examples/deepeyes/run_deepeyes_r3.sh
```

The external reproducibility runner pins candidate `2da673bf00a04e08e691232814baeadf33f8a06d` and base `9a5674afde12f608698ab4f60cdb9849a0eb6cb3`, validates tool hashes and assets, removes all proxy variables for training, captures GPU utilization/peak memory, and rejects unexplained exceptions or NaN/Inf.

## Impact and non-goals

- Default behavior remains `--rollout-num-gpus-per-engine 1`.
- The change affects only the R3 launch topology when the environment variable is set.
- It does not change DeepEyes processor outputs, the SGLang installation, rollout logic, rewards, model/data selection, GRPO, optimizer, or sampling parameters. The new log contains only class, request ID, and input-token count—never prompt, response, token IDs, or image bytes.
- It introduces no dependency and no automatic GPU-memory detection.

## Verification

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q \
  tests/examples/test_deepeyes_processor_patch.py

8 passed
```

Ruff, Ruff format, pre-commit, `bash -n`, ShellCheck with pre-existing recipe warnings excluded, and `git diff --check` pass locally. GitHub CI passes Lint, Pre-commit Checks, and Tests on Python 3.10, 3.11, and 3.12 at `2da673bf00a04e08e691232814baeadf33f8a06d`.

### Fixed OCI SGLang/CUDA contract

On physical GPU 4 in the pinned image:

```text
sglang 0.5.12.post1
torch 2.11.0+cu129
ray 2.56.0
transformers 5.6.0
cuda_probe NVIDIA RTX A6000 1.0
REAL_SGLANG_CONTRACT_OK 0.5.12.post1 ... registry sizes 0 8 8
8 passed
```

The real registry was imported twice with `overwrite=True`; all eight Qwen-family target mappings remained on `DeepEyesQwenVLImageProcessor` and the mapping size stayed 8. Raw log: `/data01/LWX/task17/logs/real-sglang-contract-2da673b-20260811-173504.log`, SHA256 `b66f5fde2dbc20cbd3655b6e80c47fbe5c09fea94cc9199ec95e0d64df22be33`. The observed TorchAO/deprecated CUDA import warnings and read-only pytest-cache warning are dependency/test-harness diagnostics, not fallback or test failures.

## Real E2E status

The pinned 30B actor/judge/data assets are still downloading to `/data01/LWX/task17`; the complete eight-GPU A6000 set is also currently occupied by unrelated jobs. The PR remains Draft until the SHA256 asset gate and one-iteration DeepEyes E2E smoke pass. The final update will attach the raw command, logs, processor activation evidence, throughput/latency, at least three stable GPU monitoring windows, and peak GPU memory. Unit tests are not presented as an E2E substitute.

## Rollback

Unset `ROLLOUT_NUM_GPUS_PER_ENGINE` to restore the accepted single-GPU-per-engine recipe. The dynamic processor registration and the prohibition on copying into SGLang remain unchanged.



