### PR TITLE
perf(megatron): backport upstream frozen-weight DGRAD fold to the image patch

### DIFF
--- a/docker/patch/megatron/20260506-85bced0ae.patch
+++ b/docker/patch/megatron/20260506-85bced0ae.patch
@@ -562,6 +562,25 @@ index 465e83f28..707162f47 100644
  
          tensor_recv_prev = None
          tensor_recv_next = None
+diff --git a/megatron/core/tensor_parallel/layers.py b/megatron/core/tensor_parallel/layers.py
+--- a/megatron/core/tensor_parallel/layers.py
++++ b/megatron/core/tensor_parallel/layers.py
+@@ -358,7 +358,14 @@
+     def backward(ctx, grad_output):
+         """Backward with frozen weight."""
+         (weight,) = ctx.saved_tensors
+-        grad_input = grad_output.matmul(weight)
++        if grad_output.dim() > 2:
++            # Work around PyTorch matmul not folding some size-1 leading dims to mm.
++            # Remove this once https://github.com/pytorch/pytorch/issues/186148 is fixed.
++            grad_output_2d = grad_output.reshape(-1, grad_output.size(-1))
++            grad_input = grad_output_2d.matmul(weight)
++            grad_input = grad_input.reshape(*grad_output.shape[:-1], weight.size(1))
++        else:
++            grad_input = grad_output.matmul(weight)
+ 
+         if ctx.allreduce_dgrad:
+             # All-reduce. Note: here async and sync are effectively the same.
 diff --git a/megatron/core/transformer/moe/moe_utils.py b/megatron/core/transformer/moe/moe_utils.py
 index d316d23de..9bb6d2bd6 100644
 --- a/megatron/core/transformer/moe/moe_utils.py

--- a/tests/backends/megatron/test_frozen_weight_dgrad.py
+++ b/tests/backends/megatron/test_frozen_weight_dgrad.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Alarm for the frozen-weight DGRAD fold in the Megatron image patch.
+
+``docker/patch/megatron/20260506-85bced0ae.patch`` backports the
+``LinearWithFrozenWeight.backward`` hunk from NVIDIA/Megatron-LM#5092; a
+Megatron bump could drop it silently, so the first test guards the patch text
+and runs in CI while the rest check the behaviour and need Megatron.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+try:
+    from megatron.core.tensor_parallel.layers import LinearWithFrozenWeight
+except ImportError:  # CI installs no training dependencies
+    LinearWithFrozenWeight = None
+
+needs_megatron = pytest.mark.skipif(LinearWithFrozenWeight is None, reason="requires Megatron")
+
+PATCH = Path(__file__).resolve().parents[3] / "docker" / "patch" / "latest" / "megatron.patch"
+HINT = f"the LinearWithFrozenWeight.backward hunk from NVIDIA/Megatron-LM#5092 is missing from {PATCH}"
+
+
+def test_megatron_patch_carries_dgrad_fold():
+    """Runs without Megatron installed, so CI covers it."""
+    assert PATCH.is_file(), HINT
+    patch = PATCH.read_text()
+    assert "megatron/core/tensor_parallel/layers.py" in patch, HINT
+    assert "grad_output.reshape(-1, grad_output.size(-1))" in patch, HINT
+    assert "grad_input.reshape(*grad_output.shape[:-1], weight.size(1))" in patch, HINT
+
+
+class _MatmulSpy(TorchDispatchMode):
+    """Records which matmul-family aten op a block dispatches to."""
+
+    def __init__(self):
+        self.ops = []
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        name = str(func)
+        if "bmm" in name:
+            self.ops.append("bmm")
+        elif name.endswith("mm.default"):
+            self.ops.append("mm")
+        return func(*args, **(kwargs or {}))
+
+
+def _run(batch, tokens, vocab, hidden, dtype=torch.float32, device="cpu"):
+    """Drive the real autograd Function with the strides production produces.
+
+    Returns the matmul ops dispatched, the DGRAD produced, and the DGRAD from
+    ``grad_output.matmul(weight)`` -- an oracle independent of the patch, being verbatim
+    the line the hunk replaced.
+    """
+    grad_output = torch.randn(batch, tokens, vocab, dtype=dtype, device=device).transpose(0, 1)
+    weight = torch.randn(vocab, hidden, dtype=dtype, device=device)
+    # Load-bearing: ATen folds unconditionally when the operand requires grad, so a
+    # non-detached weight would pass the assertions below on an unpatched Megatron.
+    assert not weight.requires_grad, "fixture must stay detached, like the output weight after .detach()"
+    inp = torch.randn(tokens, batch, hidden, dtype=dtype, device=device, requires_grad=True)
+    out = LinearWithFrozenWeight.apply(inp, weight, None, False, None)
+    assert out.shape == grad_output.shape
+
+    spy = _MatmulSpy()
+    with spy:
+        dgrad = torch.autograd.grad(out, inp, grad_outputs=grad_output)[0]
+    return spy.ops, dgrad, grad_output.matmul(weight)
+
+
+@needs_megatron
+@pytest.mark.parametrize("batch", [1, 3])
+def test_frozen_weight_dgrad_folds_to_a_single_mm(batch):
+    """batch 1 reshapes as a view, batch 3 has to copy."""
+    torch.manual_seed(0)
+    ops, dgrad, oracle = _run(batch, tokens=32, vocab=64, hidden=16)
+
+    assert ops == ["mm"], f"dispatched {ops}; {HINT}"
+    assert dgrad.shape == (32, batch, 16)
+    assert torch.allclose(dgrad, oracle, atol=1e-5, rtol=1e-5)
+
+
+@needs_megatron
+def test_frozen_weight_dgrad_passes_2d_grad_through():
+    """A 2-D ``grad_output`` keeps the original single-matmul path."""
+    torch.manual_seed(0)
+    grad_output = torch.randn(32, 64)
+    weight = torch.randn(64, 16)
+    inp = torch.randn(32, 16, requires_grad=True)
+    out = LinearWithFrozenWeight.apply(inp, weight, None, False, None)
+
+    spy = _MatmulSpy()
+    with spy:
+        dgrad = torch.autograd.grad(out, inp, grad_outputs=grad_output)[0]
+
+    assert spy.ops == ["mm"]
+    assert dgrad.shape == (32, 16)
+    assert torch.allclose(dgrad, grad_output.matmul(weight), atol=1e-6, rtol=1e-6)
+
+
+@needs_megatron
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_frozen_weight_dgrad_folds_to_a_single_mm_in_bf16_on_cuda():
+    """bf16 on device is what training actually runs."""
+    torch.manual_seed(0)
+    ops, dgrad, oracle = _run(1, tokens=256, vocab=512, hidden=128, dtype=torch.bfloat16, device="cuda")
+
+    assert ops == ["mm"], f"dispatched {ops}; {HINT}"
+    # Bitwise-identical where measured, but mm and bmm may accumulate differently elsewhere.
+    assert torch.allclose(dgrad.float(), oracle.float(), atol=1e-2, rtol=1e-2)

--- a/tests/backends/megatron/test_frozen_weight_dgrad.py
+++ b/tests/backends/megatron/test_frozen_weight_dgrad.py
@@ -8,6 +8,7 @@ Megatron bump could drop it silently, so the first test guards the patch text
 and runs in CI while the rest check the behaviour and need Megatron.
 """
 
+import inspect
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,27 @@ needs_megatron = pytest.mark.skipif(LinearWithFrozenWeight is None, reason="requ
 
 PATCH = Path(__file__).resolve().parents[3] / "docker" / "patch" / "latest" / "megatron.patch"
 HINT = f"the LinearWithFrozenWeight.backward hunk from NVIDIA/Megatron-LM#5092 is missing from {PATCH}"
+FOLD = "grad_output.reshape(-1, grad_output.size(-1))"
+
+
+def _megatron_lacks_dgrad_fold() -> bool:
+    """Whether the Megatron on the path predates the hunk.
+
+    False when Megatron is absent; ``needs_megatron`` gives the better reason.
+    """
+    if LinearWithFrozenWeight is None:
+        return False
+    try:
+        # Bytes: a decode error here would take the whole module down at import.
+        return FOLD.encode() not in Path(inspect.getfile(LinearWithFrozenWeight)).read_bytes()
+    except (OSError, TypeError):
+        return True  # cannot tell -- skip rather than report a regression
+
+
+needs_fold = pytest.mark.skipif(
+    _megatron_lacks_dgrad_fold(),
+    reason=f"the Megatron on the path predates the DGRAD fold; rebuild the image with {PATCH}",
+)
 
 
 def test_megatron_patch_carries_dgrad_fold():
@@ -31,7 +53,7 @@ def test_megatron_patch_carries_dgrad_fold():
     assert PATCH.is_file(), HINT
     patch = PATCH.read_text()
     assert "megatron/core/tensor_parallel/layers.py" in patch, HINT
-    assert "grad_output.reshape(-1, grad_output.size(-1))" in patch, HINT
+    assert FOLD in patch, HINT
     assert "grad_input.reshape(*grad_output.shape[:-1], weight.size(1))" in patch, HINT
 
 
@@ -73,6 +95,7 @@ def _run(batch, tokens, vocab, hidden, dtype=torch.float32, device="cpu"):
 
 
 @needs_megatron
+@needs_fold
 @pytest.mark.parametrize("batch", [1, 3])
 def test_frozen_weight_dgrad_folds_to_a_single_mm(batch):
     """batch 1 reshapes as a view, batch 3 has to copy."""
@@ -103,6 +126,7 @@ def test_frozen_weight_dgrad_passes_2d_grad_through():
 
 
 @needs_megatron
+@needs_fold
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_frozen_weight_dgrad_folds_to_a_single_mm_in_bf16_on_cuda():
     """bf16 on device is what training actually runs."""


### PR DESCRIPTION
#### Summary

- Closes #133

- **解决了什么问题**：
  跑 `scripts/training/text/run-qwen3-4B-8xgpu.sh` 时，词表投影的**反向**没折叠成 `mm`，
  退化为 T 个 `m=1` 的 `bmm` —— 词表权重每 token 重读一次，该 kernel 跑在**峰值 0.37%**，
  占训练侧 GPU 时间 **58.7%**。后果：`actor_train` 64.9 s/步、`mfu/actor_train` **10.8%**，
  而同模型同 batch 的前向能到 39.4% / 45.0%。

  两个条件同时成立才触发（见图 3、图 4）：
  **A** 该 recipe `tie_word_embeddings=true`，`gpt_model.py` 里的 `output_weight.detach()` 生效，
  于是路由到 `LinearWithFrozenWeight.backward` 的 `grad_output.matmul(weight)`；
  **B** `grad_output` 带 `logits.transpose(0, 1)` 留下的 strides。

  | `requires_grad` | strides | 算子 |
  |---|---|---|
  | False | 自然 | `mm` |
  | **False** | **转置** | **`bmm`** ⬅ |
  | True | 任意 | `mm` |

  注意 `b=1` 时该张量 `is_contiguous()` 仍返回 `True`。

- **为什么采用该方案**：
  matmul 前把 `grad_output` 压成 2-D，让 ATen 走回折叠路径，修复后该 matmul 达**峰值 80.0%**。
  只改 dispatch，操作数 / FLOP / 数值语义不变；不动 `.detach()`。
  实现取自上游 [NVIDIA/Megatron-LM#5092](https://github.com/NVIDIA/Megatron-LM/pull/5092)，
  只回填其中的 `layers.py` 一段到 `docker/patch/megatron/20260506-85bced0ae.patch`。

#### Changes

- **文件 / 核心函数 / 行为变化**：

  | 文件 | 改动 |
  |---|---|
  | `docker/patch/megatron/20260506-85bced0ae.patch` | +19 行。新增 `megatron/core/tensor_parallel/layers.py` 一节，即上游 #5092 的 `LinearWithFrozenWeight.backward` hunk：`grad_output.dim() > 2` 时先 `reshape(-1, size(-1))` 再 matmul、结果 reshape 回去，否则走原表达式 |
  | `tests/backends/megatron/test_frozen_weight_dgrad.py` | 新增（+114）。回归护栏：一条纯文本检查（不需要 Megatron / CUDA，跑在现有 CI job 里）+ 行为测试（驱动真实 `LinearWithFrozenWeight` autograd Function，覆盖 `batch=1` 视图路径与 `batch=3` 拷贝路径，比对未打 patch 的原表达式） |

- **CLI、配置或兼容性变化**：
  不新增 CLI 参数、不改默认值。修复随**镜像重建**对所有跑生效；回退方式见末节。

#### Verification

- **环境、硬件、commit**：
  8 × H100 80GB HBM3（NV18）· driver 580.126.09 · torch 2.11.0+cu129 / CUDA 12.9 / NCCL 2.28.9 ·
  SGLang 0.5.12.post1 · Megatron-LM 0.18.0 · transformers 5.6.0 · Xeon 8480+ ×224 / 2015 GB ·
  镜像 `ghcr.io/redai-infra/relaxrl:dev-20260715-8325919e` ·
  测量基准 commit `039ce876`，交付 diff 基于 `main` 的 `8a54679`。
  本机须 `NCCL_NVLS_ENABLE=0`：主机无 IMEX domain（`ClusterUUID` 全零），
  NVLS multicast bind 失败（CUDA error 401），与本 PR 无关。

- **可复制命令**：

  ```bash
  export EXP_DIR=/root && unset RAY_ADDRESS
  rm -rf $EXP_DIR/Qwen3-4B_mcore_8xgpu
  NCCL_NVLS_ENABLE=0 NUM_ROLLOUT=21 bash scripts/training/text/run-qwen3-4B-8xgpu.sh
  ```

  两臂只差 `MEGATRON` 指向哪棵 Megatron 树：镜像原样 / 镜像 + 本 patch。

- **patch 能否干净应用**：
  这台机器没有 docker daemon，**镜像未重建**，改为按 Dockerfile 的方式跑一遍真实的 `patch -p1`。
  先把镜像里的 Megatron 树反向应用当前已发布的 patch，还原出打 patch 之前的树。
  反向时只有 `megatron/bridge/peft/utils.py` 一个文件 reject，它的 hunk 晚于该镜像 tag，属于预期之内。
  再把带新 hunk 的 patch 应用到这棵还原出来的树上，并跑 Dockerfile 自带的冲突标记检查。

  ```
  patch -p1  ->  rc=0，26 个文件，无 .rej，无冲突标记       # PATCH_VERIFY_OK
  两棵应用后的树逐文件 diff  ->  只有 layers.py 不同
  ```

- **算子层：dispatch 与数值等价**（profiled shape：`grad_output [8448, 1, 75968]` 带
  `logits.transpose(0, 1)` 的 strides、`weight [75968, 2560]`、bf16、单卡 H100）：

  | Megatron 树 | dispatch | backward | vs `grad_output.matmul(weight)` |
  |---|---|---|---|
  | 镜像原样 | `bmm` | 909.31 ms（3.61 TFLOP/s） | 基准 |
  | 镜像 + 本 patch | `mm` | **4.15 ms（791.23 TFLOP/s，219×）** | **逐位相等**，max abs diff `0.0` |

- **单元/集成/端到端测试结果**：

  ```
  pytest tests/                             ->  729 passed, 7 skipped
  pre-commit run --all-files                ->  passed
  ruff check / format --check relax/ tests/ ->  passed（ruff 0.15.9，同 CI）
  ```

  行为测试要求 Megatron 树已含本 hunk，在镜像原样的树上会失败并指向该 patch 文件，
  Megatron 不可导入时整段 skip；纯文本检查不依赖 Megatron，CI 的 `test` job 里照常跑。

- **性能 before/after**：

  每跑 21 步，取 step 2–19 共 18 稳态步；下表为跑间 SD（各 3 跑）。
  这组是 review 前以运行时 flag 形态跑的，dispatch 变换与本 patch 相同。

  | 指标 | baseline | +flag | 变化 |
  |---|---|---|---|
  | **`step_token_per_s`** | **9801.1 ± 10.1** | **13427.7 ± 65.6** | **+37.0%** |
  | `step_time` | 171.84 ± 2.72 s | 124.78 ± 0.26 s | −27.4% |
  | `actor_train_time` | 64.91 ± 0.99 s | 18.45 ± 0.06 s | −71.6% |
  | **`mfu/actor_train`** | **10.8%** | **37.7%** | +250% |
  | `mfu/actor_infer` | 39.4% | 39.4% | −0.02% |
  | `mfu/ref_infer` | 45.0% | 45.0% | +0.09% |
  | GPU 利用率 | 90.5 ± 0.3 % | 86.5 ± 0.3 % | 见下 |
  | 峰值显存 | 69.59 ± 0.51 GiB | 69.63 ± 0.47 GiB | 持平 |

  复现性：baseline CV 0.10%、experiment CV 0.49%；B1 与 B3 相隔 4 小时差 −0.21%。

  | 阶段 | baseline | +flag |
  |---|---|---|
  | rollout（含 handoff） | 85.21 s（49.6%） | 84.72 s（**67.9%**） |
  | train | 76.72 s（44.6%） | 30.20 s（24.2%） |
  | 切换 / 显存回收 | 9.74 s（5.7%） | 9.69 s（7.8%） |

  **GPU 利用率下降不是回退**：切换开销绝对值不变（9.74 → 9.69 s），步时间缩短使其占比从
  5.7% 升到 7.8%；外部采样的 0% 利用率样本 5.75% → 8.40%，方向一致。

  kernel 层面（各 1 步 trace）：`nvjet_tst_512x8_*` **45.37 s / 56 次 → 完全消失**，
  训练侧 kernel 总时间 77.29 s → 30.19 s，无其它 kernel 顶上。

  | 质量护栏 | baseline | +flag |
  |---|---|---|
  | `rollout/raw_reward` | −0.5564 ± 0.3044 | −0.5366 ± 0.2905 |
  | `rollout/response_lengths` | 6398 ± 415 | 6343 ± 394 |
  | `train/grad_norm` | 0.1035 ± 0.0262 | 0.1101 ± 0.0352 |
  | `eval/aime/acc/mean` | 0.268 | 0.283（n=3，SD≈0.15） |
  | 样本数/步 | 256（`32×8` 写死） | 256 |
  | NaN / Inf / OOM / 残留进程 | 无 | 无 |

  **交付形态复测（各 2 跑）** —— 跑的就是本 PR 交付的镜像 patch，两臂只差 Megatron 树：

  | 指标 | baseline (n=2) | image patch (n=2) | 变化 |
  |---|---|---|---|
  | **`step_token_per_s`** | **9,779.0 ± 35.8** | **13,330.9 ± 138.3** | **+36.32%** |
  | `step_time` | 175.77 ± 1.85 s | 127.01 ± 2.60 s | −27.74% |
  | `actor_train_time` | 66.90 ± 1.17 s | 18.93 ± 0.48 s | −71.71% |
  | **`mfu/actor_train`** | **10.7% ± 0.01%** | **37.2% ± 0.32%** | **+247.60%** |
  | `mfu/actor_infer`（对照） | 39.1% ± 0.03% | 39.3% ± 0.03% | +0.35% |
  | `mfu/ref_infer`（对照） | 44.2% ± 0.14% | 44.5% ± 0.01% | +0.66% |
  | GPU 利用率（稳态窗口，8 卡均值） | 90.19 ± 0.66 % | 85.92 ± 0.35 % | 见下 |
  | 0% 利用率采样点占比 | 6.82 % | 9.60 % | 见下 |
  | 峰值显存 | 69.95 ± 0.49 GiB | 69.81 ± 0.69 GiB | 持平 |

  | 阶段 | baseline | image patch |
  |---|---|---|
  | rollout（含 handoff） | 86.46 s（49.2%） | 86.02 s（**67.7%**） |
  | train（log_probs + ref + actor_train） | 79.10 s（45.0%） | 30.92 s（**24.3%**） |
  | 切换 / 显存回收 | 10.21 s（5.8%） | 10.06 s（**7.9%**） |

  利用率下降同样是因为步时间变短：切换阶段绝对值几乎不变，占一个更短的步就更多。

  | 质量护栏 | baseline | image patch |
  |---|---|---|
  | `rollout/raw_reward` | −0.6664 ± 0.2412 | −0.6224 ± 0.2911 |
  | `rollout/response_lengths` | 6,566 ± 370 | 6,465 ± 382 |
  | `train/grad_norm` | 0.0931 ± 0.0268 | 0.1016 ± 0.0308 |
  | `train/loss` | 0.0078 ± 0.0091 | 0.0108 ± 0.0109 |
  | `eval/aime/acc/mean` | 0.173 ± 0.027 | 0.265 ± 0.209 |
  | 样本数/步 | 256（`32×8` 写死） | 256 |
  | NaN / Inf / OOM / 残留进程 | 无 | 无 |

  AIME 在 2 跑/臂下没有统计意义：30 题的单点 eval，两次打过 patch 的跑分别是 0.413 与 0.117。
  其余每一行都在一个 SD 内重叠。

  **两组矩阵在不同主机上跑，各自内部同构，不合并统计。**

- **日志、曲线、profile 链接**：

  <img width="2252" height="412" alt="fig1-timeline-one-step" src="https://github.com/user-attachments/assets/3c31a290-fe6c-4008-98c6-c9d815526197" />

  **图 1** 整步 timeline：`rollout` 与 `train` 是仅有的两个大块。

  <img width="2356" height="310" alt="fig2-baseline-nvjet-repeating" src="https://github.com/user-attachments/assets/5eae5dc3-e02c-4992-8b92-7640c3592d5d" />

  **图 2** 基线 stream 7：`nvj…` 绿块等间距反复出现，每块约 900 ms。

  <img width="1092" height="1046" alt="fig3-matmul-requested-2d-weight" src="https://github.com/user-attachments/assets/dc3a0908-a3a6-4345-9da1-b4e88d71b2e2" />

  **图 3** 选中 `aten::matmul`：权重是二维 `[75968, 2560]`，
  `Input Strides[0] = [75968, 641777664, 1]`（`641777664 = 8448 × 75968`，即条件 B 的转置 stride）。

  <img width="1234" height="1010" alt="fig4-bmm-executed-3d-stride0" src="https://github.com/user-attachments/assets/74374c32-c9f2-403d-ba94-6750c8da695b" />

  **图 4** 选中 `aten::bmm`：权重变成 `[8448, 75968, 2560]`，
  `Input Strides[1] = [0, 2560, 1]` —— batch stride 为 0，是广播视图；配合 `m=1` 即权重零复用。

  <img width="2358" height="320" alt="fig5-fixed-nvjet-gone" src="https://github.com/user-attachments/assets/87322631-52bd-45f6-b14c-a9562da7d5ac" />

  **图 5** 修复后同一视角：绿块消失。

  <img width="2250" height="1200" alt="fig6-before-after-curves" src="https://github.com/user-attachments/assets/3bff1715-1986-48ff-97d2-ed3f1e2eac5d" />

  **图 6** 主表两臂各 3 跑的逐步曲线（吞吐 / 步时间 / `actor_train` / 两条 MFU / reward），
  线为 3 跑均值、带为 min–max。

  <img width="2250" height="1200" alt="fig7-before-after-2plus2" src="https://github.com/user-attachments/assets/66e33983-b1c7-4e93-9435-2cbd43a42b35" />

  **图 7** 交付形态复测（镜像 patch，两臂各 2 跑）的同一组曲线。

#### Risk & Rollback

- **已知限制**：
  - **镜像未重建**（该机无 docker daemon），只按 Dockerfile 的方式验证了 `patch -p1` 干净应用；
    建议在真实构建里再确认一次。
  - 端到端只在 GRPO colocate 纯文本、`b=1` 的路径实测。`b > 1` 时 reshape 会多一次拷贝，
    单测覆盖了 `batch=3` 的拷贝路径（数值一致），但没有端到端实测。
  - 条件 A、B 任一不成立时，`dim() > 2` 分支只是等价改写，无收益也无副作用；
    `dim() <= 2` 直接走原表达式。
  - 为控制改动范围，本 PR 只修这一处 dispatch。profiling 中还看到几处可优化点
    （切换阶段的固定等待、`kl_loss_coef=0` 时仍会跑的 reference 前向、
    `entropy_coef=0` 时仍会建的 entropy 计算图），另外修复后 rollout 占到步时间的 67.9%，
    是更大的一块。这些都留作 follow-up，可另开 issue 讨论。

- **风险**：
  - 数值上只改了 matmul 的下发方式，不改运算本身。`mm` 与 `bmm` 的浮点累加次序理论上可能不同，
    本负载实测输出逐位相等；测试按容差比较，不依赖这一点。
  - 后续 Megatron bump 或 patch 刷新可能静默丢掉这段 hunk，而不触发任何其它失败 ——
    `test_frozen_weight_dgrad.py` 的文本检查就是为这种情况加的；不想长期携带可以删掉它。

- **关闭开关或回退方式**：把该 hunk 从 `docker/patch/megatron/20260506-85bced0ae.patch` 删除并重建镜像。
  已构建的镜像可以把 `MEGATRON` 指向一棵没有该 hunk 的 Megatron 树，
  `scripts/entrypoint/local.sh` 与 `ray-job.sh` 会把它排在镜像自带的 `/root/Megatron-LM/` 之前。

#### Checklist

- [x] Diff 仅包含本任务必要改动（2 个文件）
- [x] 新增/相关测试全部通过（`pytest tests/` 729 passed / 7 skipped）
- [ ] 文档、脚本和默认值已更新 —— 无 CLI 与默认值变化；是否补 `docs/` 待维护者意见
- [x] 不含密钥、数据集、checkpoint 或机器隐私信息
- [x] 已逐条回复 review comment（#133）
