### PR TITLE
【No.35】 feat(doctor): add config doctor dry-run

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -246,7 +246,8 @@ export default defineConfig({
                 { text: 'SFT Training', link: '/en/guide/sft-training' },
                 { text: 'PPO Training', link: '/en/guide/ppo-training' },
                 { text: 'Model Checkpoint Conversion', link: '/en/guide/model-conversion' },
-                { text: 'Configuration', link: '/en/guide/configuration' }
+                { text: 'Configuration', link: '/en/guide/configuration' },
+                { text: 'Config Doctor', link: '/en/guide/config-doctor' }
               ]
             },
             {
@@ -355,7 +356,8 @@ export default defineConfig({
                 { text: 'SFT 训练', link: '/zh/guide/sft-training' },
                 { text: 'PPO 训练', link: '/zh/guide/ppo-training' },
                 { text: '模型 Checkpoint 转换', link: '/zh/guide/model-conversion' },
-                { text: '配置说明', link: '/zh/guide/configuration' }
+                { text: '配置说明', link: '/zh/guide/configuration' },
+                { text: 'Config Doctor', link: '/zh/guide/config-doctor' }
               ]
             },
             {

--- a/docs/en/guide/config-doctor.md
+++ b/docs/en/guide/config-doctor.md
@@ -19,7 +19,7 @@ python -m relax.entrypoints.doctor -- \
 The report contains four core sections:
 
 - `Final merged config`: the parsed and normalized training configuration.
-- `Role topology`: algorithm key, base roles, optional roles, per-role resource plan, and placement-group relation.
+- `Role topology`: algorithm key, candidate roles, required roles, planned roles, per-role resource plan, and placement-group relation.
 - `resource_summary`: GPU demand derived from colocate / fully-async / hybrid rules.
 - `Expected launch command`: the training entrypoint command that doctor previews.
 
@@ -46,6 +46,26 @@ python -m relax.entrypoints.doctor --doctor-skip-hf-validate -- <training args>
 ```
 
 This appends `--skip-hf-validate` to the training arguments and avoids fetching remote HF configs during parsing.
+
+## Validation Fallback and Targeted Diagnostics
+
+Doctor first runs the same complete argument parsing and validation as the training entrypoint. If validation fails, it parses again without validation to construct only the merged argument Namespace. This fallback does not fetch remote HF configuration, derive resource fields, run backend validation, or check the TransferQueue version. Mode conflicts and missing roles can therefore retain their targeted rule ids and fixes instead of collapsing into a generic `CONFIG_PARSE_ERROR`.
+
+If argparse cannot parse the arguments themselves, the fallback cannot construct a Namespace and the report retains `CONFIG_PARSE_ERROR`. Both paths only read configuration; neither calls `ray.init()` nor creates training services.
+
+## Topology and Resource Semantics
+
+`candidate_roles` are roles the algorithm registry may create, `required_roles` must have resources for the current configuration, and `roles` are the roles actually planned after applying `--resource`. Fully-async mode requires `reference` only when `--use-kl-loss` or a non-zero `--kl-coef` is set. It does not require `actor_fwd` when the effective configuration is true-on-policy.
+
+In synchronous colocate mode, actor, rollout, and an eligible critic share a placement group, so GPU demand is the maximum among the shared roles. Hybrid mode carries both fully-async and colocate execution flags, but actor and rollout use separate placement groups, so their GPU counts are added.
+
+## Dataset Path Checks
+
+`--prompt-data` accepts one file, a directory, a file list, or the `@[start:end]` slice syntax. Doctor resolves the generalized path before checking each physical file or directory. For example, `[a.jsonl,b.jsonl]@[0:100]` checks `a.jsonl` and `b.jsonl` separately instead of treating the full expression as a filename.
+
+## Sensitive Value Redaction
+
+Text and JSON reports redact sensitive values from `--agent-env`, API keys, tokens, passwords, credentials, private keys, and notification URLs. Redaction covers raw arguments, the expected command, the final merged configuration, parse errors, and diagnostic details. Sensitive values are rendered as `<redacted>`.
 
 ## Covered Error Classes
 

--- a/docs/en/guide/config-doctor.md
+++ b/docs/en/guide/config-doctor.md
@@ -16,8 +16,9 @@ python -m relax.entrypoints.doctor -- \
   --colocate
 ```
 
-The report contains four core sections:
+The report contains these core fields:
 
+- `config_state`: `validated`, `partial`, or `unavailable`, distinguishing complete configurations from fallback results.
 - `Final merged config`: the parsed and normalized training configuration.
 - `Role topology`: algorithm key, candidate roles, required roles, planned roles, per-role resource plan, and placement-group relation.
 - `resource_summary`: GPU demand derived from colocate / fully-async / hybrid rules.
@@ -49,15 +50,19 @@ This appends `--skip-hf-validate` to the training arguments and avoids fetching 
 
 ## Validation Fallback and Targeted Diagnostics
 
-Doctor first runs the same complete argument parsing and validation as the training entrypoint. If validation fails, it parses again without validation to construct only the merged argument Namespace. This fallback does not fetch remote HF configuration, derive resource fields, run backend validation, or check the TransferQueue version. Mode conflicts and missing roles can therefore retain their targeted rule ids and fixes instead of collapsing into a generic `CONFIG_PARSE_ERROR`.
+Doctor first runs the same complete argument parsing and validation as the training entrypoint. If validation fails, it parses again without validation and marks the resulting Namespace as `partial`. This fallback does not fetch remote HF configuration, derive resource fields, run backend validation, or check the TransferQueue version.
 
-If argparse cannot parse the arguments themselves, the fallback cannot construct a Namespace and the report retains `CONFIG_PARSE_ERROR`. Both paths only read configuration; neither calls `ray.init()` nor creates training services.
+A partial configuration runs only rules explicitly declared partial-safe and does not produce a role topology or GPU estimate. The report always retains the original `CONFIG_PARSE_ERROR`, even when targeted rules also match, so the complete validation failure is not hidden. Any rule exception is converted to a structured `DOCTOR_RULE_EXECUTION_ERROR` instead of escaping as a traceback.
+
+Doctor collects the options actually registered by the Relax, Megatron, SGLang, and teacher parsers. An option not registered by any parser produces `CONFIG_UNKNOWN_ARGUMENT`, so a misspelled flag such as `--does-not-exist` is no longer silently ignored.
 
 ## Topology and Resource Semantics
 
 `candidate_roles` are roles the algorithm registry may create, `required_roles` must have resources for the current configuration, and `roles` are the roles actually planned after applying `--resource`. Fully-async mode requires `reference` only when `--use-kl-loss` or a non-zero `--kl-coef` is set. It does not require `actor_fwd` when the effective configuration is true-on-policy.
 
-In synchronous colocate mode, actor, rollout, and an eligible critic share a placement group, so GPU demand is the maximum among the shared roles. Hybrid mode carries both fully-async and colocate execution flags, but actor and rollout use separate placement groups, so their GPU counts are added.
+Role selection, optional roles, managed teachers, placement groups, and GPU totals are derived by `relax/core/service_plan.py`; Controller and Doctor consume the same result. In synchronous colocate mode, actor, rollout, and an eligible critic share a placement group, so GPU demand is the maximum among shared roles. Hybrid actor and rollout services use separate placement groups, so their GPU counts are added.
+
+`advantages` and `sft` are CPU roles that may use `[1, 0]`. Model roles such as actor, rollout, critic, reference, actor_fwd, genrm, and managed teacher require a positive GPU count.
 
 ## Dataset Path Checks
 
@@ -65,14 +70,15 @@ In synchronous colocate mode, actor, rollout, and an eligible critic share a pla
 
 ## Sensitive Value Redaction
 
-Text and JSON reports redact sensitive values from `--agent-env`, API keys, tokens, passwords, credentials, private keys, and notification URLs. Redaction covers raw arguments, the expected command, the final merged configuration, parse errors, and diagnostic details. Sensitive values are rendered as `<redacted>`.
+Text and JSON reports redact `--agent-env`, sensitive fields nested in `--train-env-vars`, `--wandb-key`, API keys, tokens, passwords, credentials, private keys, and notification URLs. Redaction covers raw arguments, the expected command, the final merged configuration, parse errors, and diagnostic details. Sensitive values are rendered as `<redacted>`.
 
 ## Covered Error Classes
 
 Doctor emits diagnostics by rule id. Current rules cover:
 
 - `CONFIG_RESOURCE_REQUIRED`: missing `--resource`.
-- `CONFIG_RESOURCE_SHAPE`: malformed resource entry or `num_serves != 1`.
+- `CONFIG_RESOURCE_SHAPE`: malformed resource entry, `num_serves != 1`, or a model role with zero GPUs.
+- `CONFIG_UNKNOWN_ARGUMENT`: an option is not registered by any runtime parser.
 - `CONFIG_ALGORITHM_SUPPORTED`: unregistered algorithm key.
 - `CONFIG_REQUIRED_ROLES`: required roles are absent from `--resource`.
 - `CONFIG_MODE_CONFLICT`: direct `--fully-async` plus `--colocate` combination.
@@ -97,4 +103,4 @@ Doctor emits diagnostics by rule id. Current rules cover:
 
 Add new rules in `relax/utils/doctor/rules.py` with `@diagnostic_rule(rule_id, title)`. A rule reads `DoctorContext` and returns `DiagnosticResult` objects. It must not start external processes, call Ray, or allocate GPU resources.
 
-When adding an algorithm or backend, update the pure topology mapping in `relax/utils/doctor/topology.py` and add an error sample to `tests/doctor/fixtures/error_cases.json`.
+When adding an algorithm, role, or backend, update the shared plan in `relax/core/service_plan.py` and add plan coverage used by both Controller and Doctor. Error samples live in `tests/doctor/fixtures/error_cases.json`.

--- a/docs/en/guide/config-doctor.md
+++ b/docs/en/guide/config-doctor.md
@@ -1,0 +1,80 @@
+# Config Doctor and Dry-run
+
+`relax.entrypoints.doctor` validates a Relax training configuration before launch. It does not start Ray, Ray Serve, SGLang, GPU workers, or the training loop. It only parses arguments, runs diagnostic rules, derives the role topology, previews resource demand, and prints the expected launch command.
+
+## Basic Usage
+
+Put training arguments after `--`:
+
+```bash
+python -m relax.entrypoints.doctor -- \
+  --resource '{"actor": [1, 8], "rollout": [1, 8]}' \
+  --rollout-batch-size 4 \
+  --n-samples-per-prompt 8 \
+  --global-batch-size 32 \
+  --num-rollout 1 \
+  --colocate
+```
+
+The report contains four core sections:
+
+- `Final merged config`: the parsed and normalized training configuration.
+- `Role topology`: algorithm key, base roles, optional roles, per-role resource plan, and placement-group relation.
+- `resource_summary`: GPU demand derived from colocate / fully-async / hybrid rules.
+- `Expected launch command`: the training entrypoint command that doctor previews.
+
+Use JSON output in CI:
+
+```bash
+python -m relax.entrypoints.doctor --format json -- \
+  --resource '{"actor": [1, 8], "rollout": [1, 8]}' \
+  --rollout-batch-size 4 \
+  --n-samples-per-prompt 8 \
+  --global-batch-size 32 \
+  --num-rollout 1 \
+  --colocate
+```
+
+Valid configurations exit with code `0`. Any `error` diagnostic returns a non-zero exit code. `--strict-warnings` promotes warnings to CI failures.
+
+## Skipping Remote HF Config Access
+
+For purely local static checks in an environment without HuggingFace access, use:
+
+```bash
+python -m relax.entrypoints.doctor --doctor-skip-hf-validate -- <training args>
+```
+
+This appends `--skip-hf-validate` to the training arguments and avoids fetching remote HF configs during parsing.
+
+## Covered Error Classes
+
+Doctor emits diagnostics by rule id. Current rules cover:
+
+- `CONFIG_RESOURCE_REQUIRED`: missing `--resource`.
+- `CONFIG_RESOURCE_SHAPE`: malformed resource entry or `num_serves != 1`.
+- `CONFIG_ALGORITHM_SUPPORTED`: unregistered algorithm key.
+- `CONFIG_REQUIRED_ROLES`: required roles are absent from `--resource`.
+- `CONFIG_MODE_CONFLICT`: direct `--fully-async` plus `--colocate` combination.
+- `CONFIG_DEBUG_MODE_CONFLICT`: both debug-only modes are enabled.
+- `CONFIG_PPO_TOPOLOGY`: PPO missing critic, unsupported async mode, or invalid staleness.
+- `CONFIG_SFT_REQUIREMENTS`: SFT missing data source, dynamic batching, or predict dependencies.
+- `CONFIG_BATCH_SIZE`: missing or inconsistent batch-size fields.
+- `CONFIG_ROLLOUT_COUNT`: missing rollout bound.
+- `CONFIG_OVERSAMPLING`: over-sampling batch smaller than rollout batch.
+- `CONFIG_DYNAMIC_BATCH`: dynamic batching without token budget.
+- `CONFIG_CONTEXT_LENGTH`: context length exceeds per-GPU token budget.
+- `CONFIG_SGLANG_PARALLEL`: SGLang PP/DP parameter conflicts.
+- `CONFIG_EVAL`: eval config missing or incompatible with SFT/RL mode.
+- `CONFIG_SAVE`: save interval without save path.
+- `CONFIG_GENRM_COLOCATE`: invalid GenRM colocate GPU split.
+- `CONFIG_PATHS`: local paths do not exist.
+- `CONFIG_LORA`: LoRA merge / adapter mode conflict.
+- `CONFIG_QKV_FORMAT`: `bshd` conflicts with dynamic batching or non-Megatron backend.
+- `CONFIG_ROTATE_CKPT`: checkpoint rotation missing required options.
+
+## Extending Rules
+
+Add new rules in `relax/utils/doctor/rules.py` with `@diagnostic_rule(rule_id, title)`. A rule reads `DoctorContext` and returns `DiagnosticResult` objects. It must not start external processes, call Ray, or allocate GPU resources.
+
+When adding an algorithm or backend, update the pure topology mapping in `relax/utils/doctor/topology.py` and add an error sample to `tests/doctor/fixtures/error_cases.json`.

--- a/docs/zh/guide/config-doctor.md
+++ b/docs/zh/guide/config-doctor.md
@@ -19,7 +19,7 @@ python -m relax.entrypoints.doctor -- \
 输出包含四类核心信息：
 
 - `Final merged config`：解析和归一化后的训练配置。
-- `Role topology`：算法、基础角色、可选角色、每个 role 的资源计划和 placement group 关系。
+- `Role topology`：算法、候选角色、必需角色、实际规划角色、每个 role 的资源计划和 placement group 关系。
 - `resource_summary`：按 colocate / fully-async / hybrid 规则推导出的 GPU 需求。
 - `Expected launch command`：doctor 预览的训练入口命令。
 
@@ -46,6 +46,26 @@ python -m relax.entrypoints.doctor --doctor-skip-hf-validate -- <training args>
 ```
 
 该选项会把 `--skip-hf-validate` 追加到训练参数中，避免解析阶段读取远端 HF config。
+
+## 校验回退与定向诊断
+
+doctor 首先执行与训练入口相同的完整参数解析和校验。完整校验失败时，它会再执行一次无校验解析，只构造合并后的参数 Namespace，不读取远端 HF 配置、不派生资源参数、不执行 backend 校验或 TransferQueue 版本检查。这样，模式冲突、缺失 role 等配置错误仍能由对应规则给出具体 rule id 和修复说明，而不是只返回通用的 `CONFIG_PARSE_ERROR`。
+
+如果参数本身无法被 argparse 解析，无校验解析也无法构造 Namespace，报告会保留 `CONFIG_PARSE_ERROR`。两种解析路径都只读取配置，不会调用 `ray.init()` 或创建任何训练服务。
+
+## 拓扑与资源语义
+
+`candidate_roles` 表示算法注册表可能创建的角色，`required_roles` 表示当前配置必须提供资源的角色，`roles` 表示结合 `--resource` 后实际进入预览的角色。Fully-async 模式仅在启用 `--use-kl-loss` 或设置非零 `--kl-coef` 时要求 `reference`；满足 true-on-policy 条件时不要求 `actor_fwd`。
+
+同步 colocate 模式下，actor、rollout 及符合条件的 critic 共享 placement group，GPU 需求取共享角色中的最大值。Hybrid 模式虽然同时具有 fully-async 和 colocate 执行标志，但 actor 与 rollout 使用独立 placement group，因此资源总量按两者 GPU 数量求和。
+
+## 数据路径检查
+
+`--prompt-data` 支持单文件、目录、文件列表和 `@[start:end]` 切片语法。doctor 会先解析广义路径，再逐个检查实际文件或目录，例如 `[a.jsonl,b.jsonl]@[0:100]` 会分别检查 `a.jsonl` 和 `b.jsonl`，不会把整个表达式当作文件名。
+
+## 敏感信息脱敏
+
+Text 和 JSON 报告会统一脱敏 `--agent-env`、API key、token、password、credential、private key 和通知 URL 等敏感值。脱敏覆盖原始参数、预计启动命令、最终合并配置、解析错误以及诊断详情，敏感值统一显示为 `<redacted>`。
 
 ## 已覆盖的错误类型
 

--- a/docs/zh/guide/config-doctor.md
+++ b/docs/zh/guide/config-doctor.md
@@ -1,0 +1,80 @@
+# Config Doctor 与 Dry-run
+
+`relax.entrypoints.doctor` 用于在训练启动前检查配置。它不会启动 Ray、Ray Serve、SGLang、GPU worker 或训练循环，只做参数解析、规则检查、角色拓扑推导、资源需求预览和启动命令预览。
+
+## 基本用法
+
+将训练参数放在 `--` 后面：
+
+```bash
+python -m relax.entrypoints.doctor -- \
+  --resource '{"actor": [1, 8], "rollout": [1, 8]}' \
+  --rollout-batch-size 4 \
+  --n-samples-per-prompt 8 \
+  --global-batch-size 32 \
+  --num-rollout 1 \
+  --colocate
+```
+
+输出包含四类核心信息：
+
+- `Final merged config`：解析和归一化后的训练配置。
+- `Role topology`：算法、基础角色、可选角色、每个 role 的资源计划和 placement group 关系。
+- `resource_summary`：按 colocate / fully-async / hybrid 规则推导出的 GPU 需求。
+- `Expected launch command`：doctor 预览的训练入口命令。
+
+JSON 输出可直接接入 CI：
+
+```bash
+python -m relax.entrypoints.doctor --format json -- \
+  --resource '{"actor": [1, 8], "rollout": [1, 8]}' \
+  --rollout-batch-size 4 \
+  --n-samples-per-prompt 8 \
+  --global-batch-size 32 \
+  --num-rollout 1 \
+  --colocate
+```
+
+正确配置返回退出码 `0`。存在 `error` 级诊断时返回非零退出码。`--strict-warnings` 会将 warning 也作为 CI 失败处理。
+
+## 跳过远端 HF 配置读取
+
+如果只需要本地静态检查，且当前环境不能访问 HuggingFace，可以使用：
+
+```bash
+python -m relax.entrypoints.doctor --doctor-skip-hf-validate -- <training args>
+```
+
+该选项会把 `--skip-hf-validate` 追加到训练参数中，避免解析阶段读取远端 HF config。
+
+## 已覆盖的错误类型
+
+doctor 以 rule id 输出诊断结果。当前规则覆盖：
+
+- `CONFIG_RESOURCE_REQUIRED`：缺少 `--resource`。
+- `CONFIG_RESOURCE_SHAPE`：resource 结构非法或 `num_serves != 1`。
+- `CONFIG_ALGORITHM_SUPPORTED`：算法 key 未注册。
+- `CONFIG_REQUIRED_ROLES`：当前模式需要的 role 未写入 resource。
+- `CONFIG_MODE_CONFLICT`：`--fully-async` 与 `--colocate` 直接组合。
+- `CONFIG_DEBUG_MODE_CONFLICT`：两个 debug-only 模式同时启用。
+- `CONFIG_PPO_TOPOLOGY`：PPO 缺 critic、使用不支持的异步模式或 staleness。
+- `CONFIG_SFT_REQUIREMENTS`：SFT 缺数据源、动态 batch 或 predict 依赖。
+- `CONFIG_BATCH_SIZE`：batch size 缺失或互相矛盾。
+- `CONFIG_ROLLOUT_COUNT`：缺少 rollout 次数边界。
+- `CONFIG_OVERSAMPLING`：过采样 batch 小于 rollout batch。
+- `CONFIG_DYNAMIC_BATCH`：动态 batch 缺 token budget。
+- `CONFIG_CONTEXT_LENGTH`：上下文长度超过 per-GPU token budget。
+- `CONFIG_SGLANG_PARALLEL`：SGLang PP/DP 参数冲突。
+- `CONFIG_EVAL`：评测配置缺失或与 SFT/RL 模式不匹配。
+- `CONFIG_SAVE`：保存间隔缺少保存路径。
+- `CONFIG_GENRM_COLOCATE`：GenRM colocate GPU 分配不合法。
+- `CONFIG_PATHS`：本地路径不存在。
+- `CONFIG_LORA`：LoRA merge / adapter 配置冲突。
+- `CONFIG_QKV_FORMAT`：`bshd` 与动态 batch 或非 Megatron 后端冲突。
+- `CONFIG_ROTATE_CKPT`：checkpoint 轮换缺少必要参数。
+
+## 扩展规则
+
+新增规则放在 `relax/utils/doctor/rules.py`，使用 `@diagnostic_rule(rule_id, title)` 注册。规则只读取 `DoctorContext`，返回 `DiagnosticResult` 列表，不启动外部进程，不调用 Ray，不分配 GPU。
+
+新增算法或 backend 时，应同步更新 `relax/utils/doctor/topology.py` 中的纯拓扑映射，并添加对应错误样例。错误样例位于 `tests/doctor/fixtures/error_cases.json`。

--- a/docs/zh/guide/config-doctor.md
+++ b/docs/zh/guide/config-doctor.md
@@ -16,8 +16,9 @@ python -m relax.entrypoints.doctor -- \
   --colocate
 ```
 
-输出包含四类核心信息：
+输出包含以下核心信息：
 
+- `config_state`：`validated`、`partial` 或 `unavailable`，用于区分完整配置与回退结果。
 - `Final merged config`：解析和归一化后的训练配置。
 - `Role topology`：算法、候选角色、必需角色、实际规划角色、每个 role 的资源计划和 placement group 关系。
 - `resource_summary`：按 colocate / fully-async / hybrid 规则推导出的 GPU 需求。
@@ -49,15 +50,19 @@ python -m relax.entrypoints.doctor --doctor-skip-hf-validate -- <training args>
 
 ## 校验回退与定向诊断
 
-doctor 首先执行与训练入口相同的完整参数解析和校验。完整校验失败时，它会再执行一次无校验解析，只构造合并后的参数 Namespace，不读取远端 HF 配置、不派生资源参数、不执行 backend 校验或 TransferQueue 版本检查。这样，模式冲突、缺失 role 等配置错误仍能由对应规则给出具体 rule id 和修复说明，而不是只返回通用的 `CONFIG_PARSE_ERROR`。
+doctor 首先执行与训练入口相同的完整参数解析和校验。完整校验失败时，它会再执行一次无校验解析，只构造标记为 `partial` 的参数 Namespace，不读取远端 HF 配置、不派生资源参数、不执行 backend 校验或 TransferQueue 版本检查。
 
-如果参数本身无法被 argparse 解析，无校验解析也无法构造 Namespace，报告会保留 `CONFIG_PARSE_ERROR`。两种解析路径都只读取配置，不会调用 `ray.init()` 或创建任何训练服务。
+partial 配置只运行明确声明为 partial-safe 的规则，并且不生成角色拓扑或 GPU 需求。报告始终保留原始 `CONFIG_PARSE_ERROR`，即使其他定向规则也命中，因此不会隐藏完整校验的真实失败。任何规则内部异常都会转换为结构化的 `DOCTOR_RULE_EXECUTION_ERROR`，不会让 CLI 直接 traceback。
+
+doctor 会汇总 Relax、Megatron、SGLang 和 teacher parser 实际注册的选项。未被任何 parser 注册的参数返回 `CONFIG_UNKNOWN_ARGUMENT`，例如拼错的 `--does-not-exist` 不会再被静默忽略。
 
 ## 拓扑与资源语义
 
 `candidate_roles` 表示算法注册表可能创建的角色，`required_roles` 表示当前配置必须提供资源的角色，`roles` 表示结合 `--resource` 后实际进入预览的角色。Fully-async 模式仅在启用 `--use-kl-loss` 或设置非零 `--kl-coef` 时要求 `reference`；满足 true-on-policy 条件时不要求 `actor_fwd`。
 
-同步 colocate 模式下，actor、rollout 及符合条件的 critic 共享 placement group，GPU 需求取共享角色中的最大值。Hybrid 模式虽然同时具有 fully-async 和 colocate 执行标志，但 actor 与 rollout 使用独立 placement group，因此资源总量按两者 GPU 数量求和。
+角色选择、optional role、managed teacher、placement group 和 GPU 汇总统一由 `relax/core/service_plan.py` 推导，Controller 与 doctor 使用同一结果。同步 colocate 模式下，actor、rollout 及符合条件的 critic 共享 placement group，GPU 需求取共享角色中的最大值；Hybrid actor 与 rollout 使用独立 placement group，资源总量按各 role 求和。
+
+`advantages` 和 `sft` 是允许 `[1, 0]` 的 CPU role。actor、rollout、critic、reference、actor_fwd、genrm 和 managed teacher 等模型 role 必须配置正数 GPU。
 
 ## 数据路径检查
 
@@ -65,14 +70,15 @@ doctor 首先执行与训练入口相同的完整参数解析和校验。完整�
 
 ## 敏感信息脱敏
 
-Text 和 JSON 报告会统一脱敏 `--agent-env`、API key、token、password、credential、private key 和通知 URL 等敏感值。脱敏覆盖原始参数、预计启动命令、最终合并配置、解析错误以及诊断详情，敏感值统一显示为 `<redacted>`。
+Text 和 JSON 报告会统一脱敏 `--agent-env`、`--train-env-vars` 内的敏感字段、`--wandb-key`、API key、token、password、credential、private key 和通知 URL。脱敏覆盖原始参数、预计启动命令、最终合并配置、解析错误以及诊断详情，敏感值统一显示为 `<redacted>`。
 
 ## 已覆盖的错误类型
 
 doctor 以 rule id 输出诊断结果。当前规则覆盖：
 
 - `CONFIG_RESOURCE_REQUIRED`：缺少 `--resource`。
-- `CONFIG_RESOURCE_SHAPE`：resource 结构非法或 `num_serves != 1`。
+- `CONFIG_RESOURCE_SHAPE`：resource 结构非法、`num_serves != 1` 或模型 role 使用 0 GPU。
+- `CONFIG_UNKNOWN_ARGUMENT`：参数未被任何运行时 parser 注册。
 - `CONFIG_ALGORITHM_SUPPORTED`：算法 key 未注册。
 - `CONFIG_REQUIRED_ROLES`：当前模式需要的 role 未写入 resource。
 - `CONFIG_MODE_CONFLICT`：`--fully-async` 与 `--colocate` 直接组合。
@@ -97,4 +103,4 @@ doctor 以 rule id 输出诊断结果。当前规则覆盖：
 
 新增规则放在 `relax/utils/doctor/rules.py`，使用 `@diagnostic_rule(rule_id, title)` 注册。规则只读取 `DoctorContext`，返回 `DiagnosticResult` 列表，不启动外部进程，不调用 Ray，不分配 GPU。
 
-新增算法或 backend 时，应同步更新 `relax/utils/doctor/topology.py` 中的纯拓扑映射，并添加对应错误样例。错误样例位于 `tests/doctor/fixtures/error_cases.json`。
+新增算法、role 或 backend 时，应更新 `relax/core/service_plan.py` 的共享规划逻辑，并添加 Controller/doctor 共用的计划测试。错误样例位于 `tests/doctor/fixtures/error_cases.json`。

--- a/relax/backends/megatron/arguments.py
+++ b/relax/backends/megatron/arguments.py
@@ -349,7 +349,7 @@ def _derive_cluster_args_from_resource(args):
             logger.info(f"Derived genrm_num_gpus={args.genrm_num_gpus} from --resource")
 
 
-def megatron_parse_args(extra_args_provider, skip_hf_validate=False):
+def megatron_parse_args(extra_args_provider, skip_hf_validate=False, derive_cluster_args=True):
     """Parse megatron args, validate HF config, and set defaults."""
     args = _megatron_parse_args(extra_args_provider=extra_args_provider, ignore_unknown_args=True)
 
@@ -359,7 +359,8 @@ def megatron_parse_args(extra_args_provider, skip_hf_validate=False):
 
     # Derive legacy cluster args from --resource when available, so users
     # don't have to specify both --resource and --actor-num-nodes / etc.
-    _derive_cluster_args_from_resource(args)
+    if derive_cluster_args:
+        _derive_cluster_args_from_resource(args)
 
     args.rank = 0
     if args.critic_train_only:

--- a/relax/backends/megatron/arguments.py
+++ b/relax/backends/megatron/arguments.py
@@ -308,6 +308,8 @@ def _derive_cluster_args_from_resource(args):
     # --- actor ---
     if "actor" in args.resource:
         _, actor_total_gpus = args.resource["actor"]
+        if actor_total_gpus <= 0:
+            raise ValueError("resource role 'actor' requires num_gpus > 0.")
         # Only override when the user relied on the defaults (1 node × 8 gpus)
         derived_gpus_per_node = min(num_gpus_per_node, actor_total_gpus)
         derived_num_nodes = max(1, actor_total_gpus // derived_gpus_per_node)

--- a/relax/core/controller.py
+++ b/relax/core/controller.py
@@ -359,8 +359,7 @@ class Controller:
         if plan.shares_actor_rollout_pg:
             # Sync colocate: actor and rollout share GPUs via time-sharing (offload/onload)
             if actor_rollout_pgs is None:
-                num_gpus = next(spec.num_gpus for spec in plan.planned_specs if spec.role == "actor")
-                actor_rollout_pgs = create_placement_group(num_gpus=num_gpus)
+                actor_rollout_pgs = create_placement_group(num_gpus=plan.shared_gpu)
         else:
             # fully_async (pure or hybrid): actor and rollout use separate GPUs
             actor_rollout_pgs = None

--- a/relax/core/controller.py
+++ b/relax/core/controller.py
@@ -30,11 +30,12 @@ from relax.agentic.session.service import (
     shutdown_agentic_chat_api_services,
 )
 from relax.core.optional_roles import register_extra_roles
-from relax.core.registry import ALGOS, ROLES, process_role
+from relax.core.registry import ALGOS, ROLES
 from relax.core.service import Service, create_placement_group
+from relax.core.service_plan import ACTOR_ROLLOUT_PG_ROLES, ServicePlan, build_service_plan
 from relax.distributed.checkpoint_service.coordinator.service import create_dcs_deployment
 from relax.distributed.coordination import PeerStepBarrier, RolloutOffloadBarrier
-from relax.engine.sft.bootstrap import resolve_sft_algo_key, resolve_sft_num_rollout, validate_sft_resource
+from relax.engine.sft.bootstrap import resolve_sft_algo_key, resolve_sft_num_rollout
 from relax.utils import device as device_utils
 from relax.utils.async_utils import run, shutdown_async_loop
 from relax.utils.health_system import HealthManager
@@ -60,23 +61,6 @@ def _is_colocate(config: Namespace) -> bool:
 
 
 logger = get_logger(__name__)
-
-ACTOR_ROLLOUT_PG_ROLES = ["actor", "rollout", "genrm"]
-
-
-def _actor_rollout_pg_roles(config: Namespace) -> list[str]:
-    """Roles that share the actor/rollout placement group.
-
-    PPO co-hosts the critic on the same GPUs only when its resource entry
-    matches the actor's; otherwise critic runs on its own placement group.
-    """
-    roles = list(ACTOR_ROLLOUT_PG_ROLES)
-    if getattr(config, "advantage_estimator", None) != "ppo":
-        return roles
-    resource = getattr(config, "resource", None) or {}
-    if resource.get("critic") == resource.get("actor"):
-        roles.append("critic")
-    return roles
 
 
 class Controller:
@@ -297,7 +281,9 @@ class Controller:
                 config=self.config,
                 num_gpus=num_gpus,
                 data_source=data_source,
-                actor_rollout_pgs=actor_rollout_pgs if actor_rollout_pgs and role in actor_rollout_pg_roles else None,
+                actor_rollout_pgs=(
+                    actor_rollout_pgs if actor_rollout_pgs and str(role) in actor_rollout_pg_roles else None
+                ),
                 runtime_env=self.runtime_env,
             )
             logger.info(f"Service {role} has been created successfully")
@@ -306,41 +292,26 @@ class Controller:
             logger.exception(f"Failed to create service {role}: {e}")
             return (role, None, str(e))
 
-    def _validate_gpu_resources(self, roles_to_create, colocate, actor_rollout_pg_roles):
+    def _validate_gpu_resources(self, plan: ServicePlan):
         """Validate that the cluster has enough GPUs before creating placement
         groups.
-
-        In colocate mode, roles in actor_rollout_pg_roles share one placement group,
-        so only the max GPU count among them is needed. In non-colocate (fully_async)
-        mode, each role gets its own placement group and GPUs are summed.
 
         Raises:
             RuntimeError: If the cluster does not have enough GPUs.
         """
-        if colocate:
-            shared_gpu = 0
-            independent_gpu = 0
-            for role, _cls, num_gpus, _ds in roles_to_create:
-                if role in actor_rollout_pg_roles:
-                    shared_gpu = max(shared_gpu, num_gpus)
-                else:
-                    independent_gpu += num_gpus
-            total_required = shared_gpu + independent_gpu
-        else:
-            total_required = sum(num_gpus for _, _, num_gpus, _ in roles_to_create)
-
         cluster_resources = ray.cluster_resources()
         accel_resource = device_utils.get_ray_accelerator_name()
         total_available = int(cluster_resources.get(accel_resource, 0))
 
         logger.info(
-            f"Resource validation: required GPUs={total_required}, cluster GPUs={total_available}, colocate={colocate}"
+            f"Resource validation: required GPUs={plan.total_required_gpus}, "
+            f"cluster GPUs={total_available}, shares_actor_rollout_pg={plan.shares_actor_rollout_pg}"
         )
 
-        if total_required > total_available:
-            role_details = ", ".join(f"{role}={num_gpus}" for role, _, num_gpus, _ in roles_to_create)
+        if plan.total_required_gpus > total_available:
+            role_details = ", ".join(f"{spec.role}={spec.num_gpus}" for spec in plan.planned_specs)
             raise RuntimeError(
-                f"Insufficient GPU resources: {total_required} GPUs required but only "
+                f"Insufficient GPU resources: {plan.total_required_gpus} GPUs required but only "
                 f"{total_available} available in the cluster. "
                 f"Role breakdown: [{role_details}]. "
                 f"Either add more GPU nodes, reduce GPU allocation per role, "
@@ -350,60 +321,45 @@ class Controller:
     def register_all_serve(self):
         validate_ppo_config(self.config)
 
+        plan = build_service_plan(self.config)
+        plan.raise_for_errors()
+        self._validate_gpu_resources(plan)
+
         actor_rollout_pgs, self._teacher_manager = maybe_start_managed_opd_teacher(
             self.config,
             runtime_env=self.runtime_env,
         )
 
-        algo_key = resolve_sft_algo_key(self.config)
-        if algo_key not in ALGOS:
-            raise ValueError(f"Algorithm key '{algo_key}' not registered in ALGOS. Available: {list(ALGOS.keys())}")
-        algo: dict = ALGOS.get(algo_key).copy()
-        ROLES = process_role(self.config)
-
-        # Fail-fast on missing SFT producer role; without this the train
-        # workers silently block on TransferQueue forever.
-        validate_sft_resource(self.config)
-        # Register optional services (e.g., GenRM, SFT-side rollout)
-        extra_roles = register_extra_roles(self.config, algo)
-
-        roles_iter = list(ROLES) + extra_roles
-        role_names = {str(r) for r in roles_iter}
-        # SFT path returns ROLES_SFT_ONLY (no `rollout` attr); rollout may be
-        # injected via extra_roles — gate on the unified name set, not the enum.
-        colocate = self.config.colocate and "rollout" in role_names and "actor" in role_names
+        algo: dict = ALGOS[plan.algo_key].copy()
+        register_extra_roles(self.config, algo)
 
         roles_to_create = []
-        for role in roles_iter:
+        for spec in plan.planned_specs:
+            if spec.role == "teacher":
+                # Managed teachers are started separately above.
+                continue
+            role = next((key for key in algo if str(key) == spec.role), spec.role)
             cls = algo.get(role)
             if cls is None:
-                logger.warning(f"No class registered for role '{role}', skipping")
-                continue
-            if str(role) == "rollout":
+                raise ValueError(f"No class registered for planned role {spec.role!r}")
+            if spec.num_gpus is None:
+                raise ValueError(f"Planned role {spec.role!r} is missing num_gpus")
+            if spec.role == "rollout":
                 data_source_cls = load_function(self.config.data_source_path)
                 data_source = ray.remote(num_cpus=1)(data_source_cls).remote(self.config)
             else:
                 data_source = None
-            # Optional roles (e.g. reference) may be absent from resource config
-            if role not in self.config.resource:
-                logger.warning(
-                    f"Role '{role}' not in resource config (available: {list(self.config.resource.keys())}), skipping"
-                )
-                continue
-            num_serves, num_gpus = self.config.resource.get(role)
-            assert num_serves == 1, f"Currently only support num_serves=1 for {role}, but received {num_serves=}"
             self._health_manager.mark_healthy(role)
             logger.info(f"Service {role} start creating.")
 
-            roles_to_create.append((role, cls, num_gpus, data_source))
+            roles_to_create.append((role, cls, spec.num_gpus, data_source))
 
-        actor_rollout_pg_roles = _actor_rollout_pg_roles(self.config)
-        self._validate_gpu_resources(roles_to_create, colocate, actor_rollout_pg_roles)
+        actor_rollout_pg_roles = plan.actor_rollout_pg_roles
 
-        if colocate and not self.config.hybrid:
+        if plan.shares_actor_rollout_pg:
             # Sync colocate: actor and rollout share GPUs via time-sharing (offload/onload)
             if actor_rollout_pgs is None:
-                num_gpus = self.config.resource.get(ROLES.actor)[1]
+                num_gpus = next(spec.num_gpus for spec in plan.planned_specs if spec.role == "actor")
                 actor_rollout_pgs = create_placement_group(num_gpus=num_gpus)
         else:
             # fully_async (pure or hybrid): actor and rollout use separate GPUs

--- a/relax/core/optional_roles.py
+++ b/relax/core/optional_roles.py
@@ -4,13 +4,15 @@
 
 from argparse import Namespace
 
+from relax.core.service_plan import resolve_optional_roles
+
 
 GENRM_ROLE = "genrm"
 
 
 def register_genrm(config: Namespace, algo: dict) -> list[str]:
     """Conditionally register GenRM into the algo dict."""
-    if getattr(config, "genrm_model_path", None) is None:
+    if GENRM_ROLE not in resolve_optional_roles(config):
         return []
 
     from relax.components.genrm import GenRM
@@ -29,9 +31,7 @@ def register_sft_rollout(config: Namespace, algo: dict) -> list:
     Rollout is only spun up when ``--sft-predict-interval`` is set — that is
     the sole consumer of generative eval under SFT today.
     """
-    if getattr(config, "loss_type", None) != "sft":
-        return []
-    if getattr(config, "sft_predict_interval", None) is None:
+    if "rollout" not in resolve_optional_roles(config):
         return []
 
     from relax.components.rollout import Rollout

--- a/relax/core/registry.py
+++ b/relax/core/registry.py
@@ -17,6 +17,18 @@ from relax.components.advantages import Advantages
 from relax.components.critic import Critic
 from relax.components.rollout import Rollout
 from relax.components.sft import SFT
+from relax.core.service_plan import (
+    MODE_COLOCATE,
+    MODE_FULLY_ASYNC,
+    MODE_FULLY_ASYNC_ON_POLICY,
+    MODE_PPO_COLOCATE,
+    MODE_PPO_FULLY_ASYNC,
+    MODE_PPO_FULLY_ASYNC_ON_POLICY,
+    MODE_ROLLOUT_ONLY,
+    MODE_SFT,
+    MODE_TRAIN_ONLY,
+    resolve_role_mode,
+)
 
 
 # NOTE(dev): Use StrEnum and keep visiting order with definition order
@@ -125,27 +137,15 @@ ALGOS = {
 
 
 def process_role(config):
-    if config.debug_rollout_only:
-        return ROLES_ROLLOUT_ONLY
-    if config.debug_train_only:
-        return ROLES_TRAIN_ONLY
-    if getattr(config, "loss_type", None) == "sft":
-        return ROLES_SFT_ONLY
-    if getattr(config, "advantage_estimator", None) == "ppo":
-        if config.fully_async:
-            if getattr(config, "true_on_policy_mode", False):
-                return ROLES_PPO_FULLY_ASYNC_ON_POLICY
-            return ROLES_PPO_FULLY_ASYNC
-        return ROLES_PPO_COLOCATE
-    if config.hybrid:
-        # hybrid mode: actor handles ref/actor_fwd internally
-        # via _switch_model, only need actor + rollout services
-        return ROLES_COLOCATE
-    if config.fully_async:
-        if getattr(config, "true_on_policy_mode", False):
-            # actor_fwd's log_probs equal the train forward's log_probs in this regime
-            # (same weights, deterministic Megatron forward), so we recompute inline.
-            return ROLES_FULLY_ASYNC_ON_POLICY
-        return ROLES
-    else:
-        return ROLES_COLOCATE
+    role_sets = {
+        MODE_TRAIN_ONLY: ROLES_TRAIN_ONLY,
+        MODE_ROLLOUT_ONLY: ROLES_ROLLOUT_ONLY,
+        MODE_COLOCATE: ROLES_COLOCATE,
+        MODE_SFT: ROLES_SFT_ONLY,
+        MODE_FULLY_ASYNC: ROLES,
+        MODE_FULLY_ASYNC_ON_POLICY: ROLES_FULLY_ASYNC_ON_POLICY,
+        MODE_PPO_COLOCATE: ROLES_PPO_COLOCATE,
+        MODE_PPO_FULLY_ASYNC: ROLES_PPO_FULLY_ASYNC,
+        MODE_PPO_FULLY_ASYNC_ON_POLICY: ROLES_PPO_FULLY_ASYNC_ON_POLICY,
+    }
+    return role_sets[resolve_role_mode(config)]

--- a/relax/core/service_plan.py
+++ b/relax/core/service_plan.py
@@ -1,0 +1,426 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+KNOWN_ALGORITHMS = ("cispo", "grpo", "gspo", "ppo", "sapo", "sft")
+
+MODE_TRAIN_ONLY = "train_only"
+MODE_ROLLOUT_ONLY = "rollout_only"
+MODE_COLOCATE = "colocate"
+MODE_SFT = "sft"
+MODE_FULLY_ASYNC = "fully_async"
+MODE_FULLY_ASYNC_ON_POLICY = "fully_async_on_policy"
+MODE_PPO_COLOCATE = "ppo_colocate"
+MODE_PPO_FULLY_ASYNC = "ppo_fully_async"
+MODE_PPO_FULLY_ASYNC_ON_POLICY = "ppo_fully_async_on_policy"
+
+ROLE_NAMES_BY_MODE = {
+    MODE_TRAIN_ONLY: ("actor",),
+    MODE_ROLLOUT_ONLY: ("rollout",),
+    MODE_COLOCATE: ("actor", "critic", "rollout"),
+    MODE_SFT: ("sft", "actor"),
+    MODE_FULLY_ASYNC: ("actor", "critic", "rollout", "advantages", "reference", "actor_fwd"),
+    MODE_FULLY_ASYNC_ON_POLICY: ("actor", "critic", "rollout", "advantages", "reference"),
+    MODE_PPO_COLOCATE: ("actor", "critic", "rollout"),
+    MODE_PPO_FULLY_ASYNC: ("actor", "critic", "rollout", "advantages", "reference", "actor_fwd"),
+    MODE_PPO_FULLY_ASYNC_ON_POLICY: ("actor", "critic", "rollout", "advantages", "reference"),
+}
+
+ALGORITHM_ROLES = {
+    "cispo": frozenset(("actor", "rollout", "advantages", "reference", "actor_fwd")),
+    "grpo": frozenset(("actor", "rollout", "advantages", "reference", "actor_fwd")),
+    "gspo": frozenset(("actor", "rollout", "advantages", "reference", "actor_fwd")),
+    "ppo": frozenset(("actor", "critic", "rollout", "advantages", "reference", "actor_fwd")),
+    "sapo": frozenset(("actor", "rollout", "advantages", "reference", "actor_fwd")),
+    "sft": frozenset(("sft", "actor", "rollout")),
+}
+
+CPU_ONLY_ROLES = frozenset(("advantages", "sft"))
+ACTOR_ROLLOUT_PG_ROLES = ("actor", "rollout", "genrm")
+
+
+@dataclass(frozen=True)
+class PlanError:
+    code: str
+    message: str
+    role: str | None = None
+    value: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        details = {"code": self.code, "message": self.message}
+        if self.role is not None:
+            details["role"] = self.role
+        if self.value is not None:
+            details["value"] = self.value
+        return details
+
+
+@dataclass(frozen=True)
+class ServiceSpec:
+    role: str
+    status: str
+    required: bool
+    num_serves: int | None = None
+    num_gpus: int | None = None
+    placement_group: str | None = None
+    raw: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result = {
+            "role": self.role,
+            "status": self.status,
+            "required": self.required,
+        }
+        if self.num_serves is not None:
+            result["num_serves"] = self.num_serves
+        if self.num_gpus is not None:
+            result["num_gpus"] = self.num_gpus
+        if self.placement_group is not None:
+            result["placement_group"] = self.placement_group
+        if self.raw is not None:
+            result["raw"] = self.raw
+        return result
+
+
+@dataclass(frozen=True)
+class ServicePlan:
+    algo_key: str
+    role_mode: str
+    candidate_roles: tuple[str, ...]
+    required_roles: tuple[str, ...]
+    optional_roles: tuple[str, ...]
+    roles: tuple[str, ...]
+    service_specs: tuple[ServiceSpec, ...]
+    errors: tuple[PlanError, ...]
+    colocate: bool
+    hybrid: bool
+    shares_actor_rollout_pg: bool
+    actor_rollout_pg_roles: tuple[str, ...]
+    shared_gpu: int
+    independent_gpu: int
+    total_required_gpus: int
+    service_creation: str
+
+    @property
+    def planned_specs(self) -> tuple[ServiceSpec, ...]:
+        return tuple(spec for spec in self.service_specs if spec.status == "planned")
+
+    def raise_for_errors(self) -> None:
+        if not self.errors:
+            return
+        messages = "; ".join(error.message for error in self.errors)
+        raise ValueError(f"Invalid service plan: {messages}")
+
+    def to_dict(self) -> dict[str, Any]:
+        missing_roles = [error.role for error in self.errors if error.code == "missing_role" and error.role]
+        invalid_roles = [
+            error.role
+            for error in self.errors
+            if error.code in {"resource_shape", "num_serves", "gpu_count", "gpu_required"} and error.role
+        ]
+        return {
+            "algo_key": self.algo_key,
+            "known_algorithms": list(KNOWN_ALGORITHMS),
+            "role_mode": self.role_mode,
+            "candidate_roles": list(self.candidate_roles),
+            "required_roles": list(self.required_roles),
+            "optional_roles": list(self.optional_roles),
+            "roles": list(self.roles),
+            "role_plan": [spec.to_dict() for spec in self.service_specs],
+            "plan_errors": [error.to_dict() for error in self.errors],
+            "missing_resource_roles": _unique(missing_roles),
+            "invalid_resource_roles": _unique(invalid_roles),
+            "colocate": self.colocate,
+            "hybrid": self.hybrid,
+            "shares_actor_rollout_pg": self.shares_actor_rollout_pg,
+            "actor_rollout_pg_roles": list(self.actor_rollout_pg_roles),
+            "resource_summary": {
+                "shared_gpu": self.shared_gpu,
+                "independent_gpu": self.independent_gpu,
+                "total_required_gpus": self.total_required_gpus,
+                "role_gpus": {spec.role: spec.num_gpus for spec in self.planned_specs if spec.num_gpus is not None},
+            },
+            "startup": {
+                "service_creation": self.service_creation,
+                "will_start_ray": False,
+                "will_start_sglang": False,
+                "will_start_training_workers": False,
+            },
+        }
+
+
+def resolve_algo_key(config: Any) -> str:
+    if getattr(config, "loss_type", None) == "sft":
+        return "sft"
+    return str(getattr(config, "advantage_estimator", "grpo"))
+
+
+def resolve_role_mode(config: Any) -> str:
+    if getattr(config, "debug_rollout_only", False):
+        return MODE_ROLLOUT_ONLY
+    if getattr(config, "debug_train_only", False):
+        return MODE_TRAIN_ONLY
+    if getattr(config, "loss_type", None) == "sft":
+        return MODE_SFT
+    if getattr(config, "advantage_estimator", None) == "ppo":
+        if getattr(config, "fully_async", False):
+            if getattr(config, "true_on_policy_mode", False):
+                return MODE_PPO_FULLY_ASYNC_ON_POLICY
+            return MODE_PPO_FULLY_ASYNC
+        return MODE_PPO_COLOCATE
+    if getattr(config, "hybrid", False):
+        return MODE_COLOCATE
+    if getattr(config, "fully_async", False):
+        if getattr(config, "true_on_policy_mode", False):
+            return MODE_FULLY_ASYNC_ON_POLICY
+        return MODE_FULLY_ASYNC
+    return MODE_COLOCATE
+
+
+def resolve_base_roles(config: Any) -> list[str]:
+    algo_key = resolve_algo_key(config)
+    supported = ALGORITHM_ROLES.get(algo_key, frozenset())
+    return [role for role in ROLE_NAMES_BY_MODE[resolve_role_mode(config)] if role in supported]
+
+
+def resolve_optional_roles(config: Any) -> list[str]:
+    roles = []
+    if getattr(config, "genrm_model_path", None):
+        roles.append("genrm")
+    if getattr(config, "loss_type", None) == "sft" and getattr(config, "sft_predict_interval", None) is not None:
+        roles.append("rollout")
+    return roles
+
+
+def actor_rollout_pg_roles(config: Any) -> list[str]:
+    roles = list(ACTOR_ROLLOUT_PG_ROLES)
+    resource = _resource(config)
+    if resolve_algo_key(config) == "ppo" and resource.get("critic") == resource.get("actor"):
+        roles.append("critic")
+    return roles
+
+
+def is_managed_teacher_enabled(config: Any) -> bool:
+    return (
+        getattr(config, "use_opd", False)
+        and getattr(config, "opd_type", None) == "sglang"
+        and (
+            getattr(config, "teacher_hf_checkpoint", None) is not None
+            or getattr(config, "opd_teacher_routes", None) is not None
+        )
+        and isinstance(getattr(config, "resource", None), Mapping)
+        and "teacher" in config.resource
+    )
+
+
+def is_managed_teacher_colocate(config: Any) -> bool:
+    return (
+        is_managed_teacher_enabled(config)
+        and getattr(config, "colocate", False)
+        and not getattr(config, "hybrid", False)
+        and "actor" in config.resource
+        and "rollout" in config.resource
+    )
+
+
+def build_service_plan(config: Any) -> ServicePlan:
+    algo_key = resolve_algo_key(config)
+    role_mode = resolve_role_mode(config)
+    base_roles = resolve_base_roles(config)
+    optional_roles = resolve_optional_roles(config)
+    candidate_roles = _unique([*base_roles, *optional_roles])
+    required_roles = list(candidate_roles)
+    if "reference" in required_roles and not _needs_reference(config):
+        required_roles.remove("reference")
+
+    managed_teacher = is_managed_teacher_enabled(config)
+    if managed_teacher:
+        candidate_roles.append("teacher")
+        required_roles.append("teacher")
+
+    errors = []
+    if algo_key not in ALGORITHM_ROLES:
+        errors.append(
+            PlanError(
+                code="unsupported_algorithm",
+                message=f"algorithm key {algo_key!r} is not registered; expected one of {list(KNOWN_ALGORITHMS)}.",
+                value=algo_key,
+            )
+        )
+
+    resource = _resource(config)
+    if not isinstance(getattr(config, "resource", None), Mapping):
+        errors.append(
+            PlanError(
+                code="resource_required",
+                message="--resource is missing or is not a mapping.",
+                value=getattr(config, "resource", None),
+            )
+        )
+
+    roles = _unique([role for role in candidate_roles if role in resource or role in required_roles])
+    role_names = set(roles)
+    colocate = bool(getattr(config, "colocate", False) and {"actor", "rollout"}.issubset(role_names))
+    hybrid = bool(getattr(config, "hybrid", False))
+    shares_actor_rollout_pg = colocate and not (getattr(config, "fully_async", False) or hybrid)
+    pg_roles = actor_rollout_pg_roles(config)
+
+    specs = []
+    for role in roles:
+        required = role in required_roles
+        raw = resource.get(role)
+        if raw is None:
+            if required:
+                errors.append(
+                    PlanError(
+                        code="missing_role",
+                        message=f"--resource is missing required role {role!r}.",
+                        role=role,
+                    )
+                )
+                specs.append(ServiceSpec(role=role, status="missing_resource", required=True))
+            continue
+
+        parsed = _parse_resource_spec(raw)
+        if parsed is None:
+            errors.append(
+                PlanError(
+                    code="resource_shape",
+                    message=f"resource entry for role {role!r} must be [num_serves, num_gpus].",
+                    role=role,
+                    value=raw,
+                )
+            )
+            specs.append(ServiceSpec(role=role, status="invalid_resource", required=required, raw=raw))
+            continue
+
+        num_serves, num_gpus = parsed
+        role_errors = []
+        if num_serves != 1:
+            role_errors.append(
+                PlanError(
+                    code="num_serves",
+                    message=f"role {role!r} requires num_serves=1, got {num_serves}.",
+                    role=role,
+                    value=raw,
+                )
+            )
+        if num_gpus < 0:
+            role_errors.append(
+                PlanError(
+                    code="gpu_count",
+                    message=f"role {role!r} requires num_gpus >= 0, got {num_gpus}.",
+                    role=role,
+                    value=raw,
+                )
+            )
+        elif num_gpus == 0 and role not in CPU_ONLY_ROLES:
+            role_errors.append(
+                PlanError(
+                    code="gpu_required",
+                    message=f"model role {role!r} requires num_gpus > 0.",
+                    role=role,
+                    value=raw,
+                )
+            )
+
+        if role_errors:
+            errors.extend(role_errors)
+            specs.append(
+                ServiceSpec(
+                    role=role,
+                    status="invalid_resource",
+                    required=required,
+                    num_serves=num_serves,
+                    num_gpus=num_gpus,
+                    raw=raw,
+                )
+            )
+            continue
+
+        specs.append(
+            ServiceSpec(
+                role=role,
+                status="planned",
+                required=required,
+                num_serves=num_serves,
+                num_gpus=num_gpus,
+                placement_group=_placement_group(
+                    role,
+                    shares_actor_rollout_pg=shares_actor_rollout_pg,
+                    actor_rollout_pg_roles=pg_roles,
+                    managed_teacher_colocate=is_managed_teacher_colocate(config),
+                ),
+            )
+        )
+
+    planned = [spec for spec in specs if spec.status == "planned"]
+    shared_gpu = max(
+        (spec.num_gpus or 0 for spec in planned if spec.placement_group == "actor_rollout_shared"),
+        default=0,
+    )
+    independent_gpu = sum(spec.num_gpus or 0 for spec in planned if spec.placement_group == "dedicated")
+
+    return ServicePlan(
+        algo_key=algo_key,
+        role_mode=role_mode,
+        candidate_roles=tuple(candidate_roles),
+        required_roles=tuple(required_roles),
+        optional_roles=tuple(optional_roles),
+        roles=tuple(roles),
+        service_specs=tuple(specs),
+        errors=tuple(errors),
+        colocate=colocate,
+        hybrid=hybrid,
+        shares_actor_rollout_pg=shares_actor_rollout_pg,
+        actor_rollout_pg_roles=tuple(pg_roles),
+        shared_gpu=shared_gpu,
+        independent_gpu=independent_gpu,
+        total_required_gpus=shared_gpu + independent_gpu,
+        service_creation=("parallel" if getattr(config, "fully_async", False) or hybrid else "serial"),
+    )
+
+
+def _resource(config: Any) -> dict[str, Any]:
+    resource = getattr(config, "resource", None)
+    return dict(resource) if isinstance(resource, Mapping) else {}
+
+
+def _parse_resource_spec(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return None
+    if len(value) != 2:
+        return None
+    num_serves, num_gpus = value
+    if type(num_serves) is not int or type(num_gpus) is not int:
+        return None
+    return num_serves, num_gpus
+
+
+def _needs_reference(config: Any) -> bool:
+    return bool(getattr(config, "use_kl_loss", False) or getattr(config, "kl_coef", 0) != 0)
+
+
+def _placement_group(
+    role: str,
+    *,
+    shares_actor_rollout_pg: bool,
+    actor_rollout_pg_roles: list[str],
+    managed_teacher_colocate: bool,
+) -> str:
+    if role in CPU_ONLY_ROLES:
+        return "none"
+    if role == "teacher" and managed_teacher_colocate:
+        return "actor_rollout_shared"
+    if shares_actor_rollout_pg and role in actor_rollout_pg_roles:
+        return "actor_rollout_shared"
+    return "dedicated"
+
+
+def _unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/relax/core/service_plan.py
+++ b/relax/core/service_plan.py
@@ -218,9 +218,13 @@ def is_managed_teacher_enabled(config: Any) -> bool:
     )
 
 
+def should_start_managed_teacher(config: Any) -> bool:
+    return is_managed_teacher_enabled(config) and not getattr(config, "debug_train_only", False)
+
+
 def is_managed_teacher_colocate(config: Any) -> bool:
     return (
-        is_managed_teacher_enabled(config)
+        should_start_managed_teacher(config)
         and getattr(config, "colocate", False)
         and not getattr(config, "hybrid", False)
         and "actor" in config.resource
@@ -238,7 +242,7 @@ def build_service_plan(config: Any) -> ServicePlan:
     if "reference" in required_roles and not _needs_reference(config):
         required_roles.remove("reference")
 
-    managed_teacher = is_managed_teacher_enabled(config)
+    managed_teacher = should_start_managed_teacher(config)
     if managed_teacher:
         candidate_roles.append("teacher")
         required_roles.append("teacher")

--- a/relax/core/service_plan.py
+++ b/relax/core/service_plan.py
@@ -121,7 +121,8 @@ class ServicePlan:
         invalid_roles = [
             error.role
             for error in self.errors
-            if error.code in {"resource_shape", "num_serves", "gpu_count", "gpu_required"} and error.role
+            if error.code in {"resource_shape", "num_serves", "gpu_count", "gpu_required", "cpu_gpu_forbidden"}
+            and error.role
         ]
         return {
             "algo_key": self.algo_key,
@@ -319,6 +320,15 @@ def build_service_plan(config: Any) -> ServicePlan:
                 PlanError(
                     code="gpu_count",
                     message=f"role {role!r} requires num_gpus >= 0, got {num_gpus}.",
+                    role=role,
+                    value=raw,
+                )
+            )
+        elif num_gpus > 0 and role in CPU_ONLY_ROLES:
+            role_errors.append(
+                PlanError(
+                    code="cpu_gpu_forbidden",
+                    message=f"CPU-only role {role!r} requires num_gpus=0, got {num_gpus}.",
                     role=role,
                     value=raw,
                 )

--- a/relax/engine/sft/bootstrap.py
+++ b/relax/engine/sft/bootstrap.py
@@ -17,6 +17,7 @@ orchestrator. Three responsibilities:
 
 from argparse import Namespace
 
+from relax.core.service_plan import resolve_algo_key
 from relax.utils.logging_utils import get_logger
 
 
@@ -33,9 +34,7 @@ def resolve_sft_algo_key(config: Namespace) -> str:
     Same priority order as ``process_role`` in ``relax.core.registry`` so the
     ROLES set and the ALGOS dict stay consistent.
     """
-    if _is_sft(config):
-        return "sft"
-    return config.advantage_estimator
+    return resolve_algo_key(config)
 
 
 def resolve_sft_num_rollout(config: Namespace) -> None:

--- a/relax/entrypoints/doctor.py
+++ b/relax/entrypoints/doctor.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import sys
+from collections.abc import Iterator
+from typing import Any
+
+from relax.utils.doctor.runner import render_json, render_text, run_doctor
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate Relax training configuration without starting Ray, SGLang, GPU workers, "
+            "or the training loop. Put training arguments after '--'."
+        )
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Output format.")
+    parser.add_argument(
+        "--strict-warnings",
+        action="store_true",
+        help="Treat warnings as errors so the command can be stricter in CI.",
+    )
+    parser.add_argument(
+        "--doctor-skip-hf-validate",
+        action="store_true",
+        help="Append --skip-hf-validate to the training args before parsing, avoiding remote HF config access.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    doctor_argv, training_argv = _split_argv(raw_argv)
+    options = build_parser().parse_args(doctor_argv)
+    if options.doctor_skip_hf_validate and "--skip-hf-validate" not in training_argv:
+        training_argv = [*training_argv, "--skip-hf-validate"]
+
+    args = None
+    parse_error = None
+    try:
+        args = parse_training_args(training_argv)
+    except SystemExit as exc:
+        parse_error = f"argparse exited with code {exc.code}"
+    except Exception as exc:  # noqa: BLE001 - all config failures should become diagnostics
+        parse_error = f"{type(exc).__name__}: {exc}"
+
+    report = run_doctor(
+        argv=training_argv,
+        args=args,
+        parse_error=parse_error,
+        strict_warnings=options.strict_warnings,
+    )
+    output = render_json(report) if options.format == "json" else render_text(report)
+    print(output)
+    return 0 if report.ok else 1
+
+
+def parse_training_args(training_argv: list[str]) -> Any:
+    # Imported lazily so `python -m relax.entrypoints.doctor --help` does not
+    # require Megatron/SGLang/Ray dependencies.
+    from relax.utils.arguments import parse_args
+
+    with _temporary_argv(["relax-doctor", *training_argv]):
+        return parse_args()
+
+
+def _split_argv(argv: list[str]) -> tuple[list[str], list[str]]:
+    if "--" in argv:
+        idx = argv.index("--")
+        return argv[:idx], argv[idx + 1 :]
+    if argv in (["-h"], ["--help"]):
+        return argv, []
+    return [], argv
+
+
+@contextlib.contextmanager
+def _temporary_argv(argv: list[str]) -> Iterator[None]:
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        yield
+    finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/relax/entrypoints/doctor.py
+++ b/relax/entrypoints/doctor.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Iterator
 from typing import Any
 
+from relax.utils.doctor.option_audit import capture_registered_options, find_unknown_options
 from relax.utils.doctor.runner import render_json, render_text, run_doctor
 
 
@@ -41,23 +42,26 @@ def main(argv: list[str] | None = None) -> int:
 
     args = None
     parse_error = None
-    try:
-        args = parse_training_args(training_argv)
-    except SystemExit as exc:
-        parse_error = f"argparse exited with code {exc.code}"
-    except Exception as exc:  # noqa: BLE001 - all config failures should become diagnostics
-        parse_error = f"{type(exc).__name__}: {exc}"
+    with capture_registered_options() as registered_options:
         try:
-            args = parse_training_args(training_argv, validate=False)
-        except SystemExit as fallback_exc:
-            parse_error = f"{parse_error}; fallback argparse exited with code {fallback_exc.code}"
-        except Exception as fallback_exc:  # noqa: BLE001 - preserve the original validation failure
-            parse_error = f"{parse_error}; fallback parse failed: {type(fallback_exc).__name__}: {fallback_exc}"
+            args = parse_training_args(training_argv)
+        except SystemExit as exc:
+            parse_error = f"argparse exited with code {exc.code}"
+        except Exception as exc:  # noqa: BLE001 - all config failures should become diagnostics
+            parse_error = f"{type(exc).__name__}: {exc}"
+            try:
+                args = parse_training_args(training_argv, validate=False)
+            except SystemExit as fallback_exc:
+                parse_error = f"{parse_error}; fallback argparse exited with code {fallback_exc.code}"
+            except Exception as fallback_exc:  # noqa: BLE001 - preserve the original validation failure
+                parse_error = f"{parse_error}; fallback parse failed: {type(fallback_exc).__name__}: {fallback_exc}"
+    unknown_options = find_unknown_options(training_argv, registered_options) if args is not None else []
 
     report = run_doctor(
         argv=training_argv,
         args=args,
         parse_error=parse_error,
+        unknown_options=unknown_options,
         strict_warnings=options.strict_warnings,
     )
     output = render_json(report) if options.format == "json" else render_text(report)

--- a/relax/entrypoints/doctor.py
+++ b/relax/entrypoints/doctor.py
@@ -47,6 +47,10 @@ def main(argv: list[str] | None = None) -> int:
         parse_error = f"argparse exited with code {exc.code}"
     except Exception as exc:  # noqa: BLE001 - all config failures should become diagnostics
         parse_error = f"{type(exc).__name__}: {exc}"
+        try:
+            args = parse_training_args(training_argv, validate=False)
+        except Exception as fallback_exc:  # noqa: BLE001 - preserve the original validation failure
+            parse_error = f"{parse_error}; fallback parse failed: {type(fallback_exc).__name__}: {fallback_exc}"
 
     report = run_doctor(
         argv=training_argv,
@@ -59,13 +63,13 @@ def main(argv: list[str] | None = None) -> int:
     return 0 if report.ok else 1
 
 
-def parse_training_args(training_argv: list[str]) -> Any:
+def parse_training_args(training_argv: list[str], *, validate: bool = True) -> Any:
     # Imported lazily so `python -m relax.entrypoints.doctor --help` does not
     # require Megatron/SGLang/Ray dependencies.
     from relax.utils.arguments import parse_args
 
     with _temporary_argv(["relax-doctor", *training_argv]):
-        return parse_args()
+        return parse_args(validate=validate)
 
 
 def _split_argv(argv: list[str]) -> tuple[list[str], list[str]]:

--- a/relax/entrypoints/doctor.py
+++ b/relax/entrypoints/doctor.py
@@ -49,6 +49,8 @@ def main(argv: list[str] | None = None) -> int:
         parse_error = f"{type(exc).__name__}: {exc}"
         try:
             args = parse_training_args(training_argv, validate=False)
+        except SystemExit as fallback_exc:
+            parse_error = f"{parse_error}; fallback argparse exited with code {fallback_exc.code}"
         except Exception as fallback_exc:  # noqa: BLE001 - preserve the original validation failure
             parse_error = f"{parse_error}; fallback parse failed: {type(fallback_exc).__name__}: {fallback_exc}"
 

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -3170,6 +3170,8 @@ def slime_validate_args(args):
         )
 
     if args.num_steps_per_rollout is not None:
+        if args.num_steps_per_rollout <= 0:
+            raise ValueError("--num-steps-per-rollout must be greater than zero.")
         global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout
         if args.global_batch_size is not None:
             assert args.global_batch_size == global_batch_size, (

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -2486,8 +2486,14 @@ def _pre_parse_mode():
     return temp_args
 
 
-def parse_args(add_custom_arguments=None):
-    # Users may call `parse_args` very early, thus we ensure logger is configured here
+def parse_args(add_custom_arguments=None, *, validate=True):
+    """Parse Relax training arguments.
+
+    ``validate=False`` is reserved for static tooling that needs the merged
+    parser namespace after normal validation has failed. It skips HF access,
+    resource-derived mutations, backend validation, and version checks.
+    Training entrypoints keep the default validated behavior.
+    """
 
     add_slime_arguments = get_slime_extra_args_provider(add_custom_arguments)
 
@@ -2510,7 +2516,8 @@ def parse_args(add_custom_arguments=None):
 
     args = megatron_parse_args(
         extra_args_provider=add_slime_arguments,
-        skip_hf_validate=pre.debug_rollout_only or pre.skip_hf_validate,
+        skip_hf_validate=pre.debug_rollout_only or pre.skip_hf_validate or not validate,
+        derive_cluster_args=validate,
     )
 
     # Merge pre-parsed args into the main namespace
@@ -2525,6 +2532,9 @@ def parse_args(add_custom_arguments=None):
     if teacher_sglang_ns is not None:
         for key, value in vars(teacher_sglang_ns).items():
             setattr(args, key, value)
+
+    if not validate:
+        return args
 
     slime_validate_args(args)
 

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -11,6 +11,7 @@ from sglang_router.launch_router import RouterArgs
 
 from relax.backends.sglang.arguments import sglang_parse_args
 from relax.backends.sglang.arguments import validate_args as sglang_validate_args
+from relax.core.service_plan import build_service_plan
 from relax.utils import device as device_utils
 from relax.utils.logging_utils import get_logger
 from relax.utils.opd.opd_utils import (
@@ -3300,3 +3301,5 @@ def slime_validate_args(args):
     if args.genrm_model_path:
         args.genrm_engine_config = args.genrm_engine_config or {}
         args.genrm_sampling_config = args.genrm_sampling_config or {}
+
+    build_service_plan(args).raise_for_errors()

--- a/relax/utils/doctor/__init__.py
+++ b/relax/utils/doctor/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from relax.utils.doctor.runner import run_doctor
+
+
+__all__ = ["run_doctor"]

--- a/relax/utils/doctor/models.py
+++ b/relax/utils/doctor/models.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 
 Severity = Literal["error", "warning", "info"]
+ConfigState = Literal["validated", "partial", "unavailable"]
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,7 @@ class DoctorContext:
     argv: list[str]
     args: Any | None
     parse_error: str | None
+    config_state: ConfigState
     config: dict[str, Any]
     topology: dict[str, Any]
     command: list[str]
@@ -43,6 +45,7 @@ class DoctorReport:
     argv: list[str]
     command: list[str]
     diagnostics: list[DiagnosticResult]
+    config_state: ConfigState
     config: dict[str, Any]
     topology: dict[str, Any]
 
@@ -52,6 +55,7 @@ class DoctorReport:
             "argv": self.argv,
             "command": self.command,
             "diagnostics": [item.to_dict() for item in self.diagnostics],
+            "config_state": self.config_state,
             "config": self.config,
             "topology": self.topology,
         }

--- a/relax/utils/doctor/models.py
+++ b/relax/utils/doctor/models.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+Severity = Literal["error", "warning", "info"]
+
+
+@dataclass(frozen=True)
+class DiagnosticResult:
+    rule_id: str
+    severity: Severity
+    message: str
+    fix: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "message": self.message,
+            "fix": self.fix,
+            "details": self.details,
+        }
+
+
+@dataclass(frozen=True)
+class DoctorContext:
+    argv: list[str]
+    args: Any | None
+    parse_error: str | None
+    config: dict[str, Any]
+    topology: dict[str, Any]
+    command: list[str]
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    ok: bool
+    argv: list[str]
+    command: list[str]
+    diagnostics: list[DiagnosticResult]
+    config: dict[str, Any]
+    topology: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "argv": self.argv,
+            "command": self.command,
+            "diagnostics": [item.to_dict() for item in self.diagnostics],
+            "config": self.config,
+            "topology": self.topology,
+        }

--- a/relax/utils/doctor/option_audit.py
+++ b/relax/utils/doctor/option_audit.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import re
 from collections.abc import Iterator
+
+
+_NEGATIVE_NUMBER_RE = re.compile(r"^-\d+$|^-\d*\.\d+$")
 
 
 @contextlib.contextmanager
@@ -34,10 +38,23 @@ def find_unknown_options(argv: list[str], registered: set[str]) -> list[str]:
 
     unknown = []
     seen = set()
+    registered_short_options = sorted(
+        (option for option in registered if option.startswith("-") and not option.startswith("--")),
+        key=len,
+        reverse=True,
+    )
     for item in argv:
-        if not item.startswith("--") or item == "--":
+        if not item.startswith("-") or item in {"-", "--"}:
             continue
-        option = item.split("=", 1)[0]
+        if item.startswith("--"):
+            option = item.split("=", 1)[0]
+        elif _NEGATIVE_NUMBER_RE.fullmatch(item):
+            continue
+        else:
+            option = next(
+                (candidate for candidate in registered_short_options if item.startswith(candidate)),
+                item.split("=", 1)[0],
+            )
         if option in registered or option in seen:
             continue
         seen.add(option)

--- a/relax/utils/doctor/option_audit.py
+++ b/relax/utils/doctor/option_audit.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+from collections.abc import Iterator
+
+
+@contextlib.contextmanager
+def capture_registered_options() -> Iterator[set[str]]:
+    """Collect option strings from every parser used during one CLI parse."""
+    registered: set[str] = set()
+    original = argparse.ArgumentParser.parse_known_args
+
+    def parse_known_args(
+        parser: argparse.ArgumentParser,
+        args: list[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> tuple[argparse.Namespace, list[str]]:
+        registered.update(parser._option_string_actions)
+        return original(parser, args=args, namespace=namespace)
+
+    argparse.ArgumentParser.parse_known_args = parse_known_args  # type: ignore[method-assign]
+    try:
+        yield registered
+    finally:
+        argparse.ArgumentParser.parse_known_args = original  # type: ignore[method-assign]
+
+
+def find_unknown_options(argv: list[str], registered: set[str]) -> list[str]:
+    if not registered:
+        return []
+
+    unknown = []
+    seen = set()
+    for item in argv:
+        if not item.startswith("--") or item == "--":
+            continue
+        option = item.split("=", 1)[0]
+        if option in registered or option in seen:
+            continue
+        seen.add(option)
+        unknown.append(option)
+    return unknown

--- a/relax/utils/doctor/rules.py
+++ b/relax/utils/doctor/rules.py
@@ -21,14 +21,22 @@ class DiagnosticRule:
     rule_id: str
     title: str
     check: RuleFn
+    supports_partial: bool = False
 
 
 _RULES: list[DiagnosticRule] = []
 
 
-def diagnostic_rule(rule_id: str, title: str) -> Callable[[RuleFn], RuleFn]:
+def diagnostic_rule(rule_id: str, title: str, *, supports_partial: bool = False) -> Callable[[RuleFn], RuleFn]:
     def decorator(func: RuleFn) -> RuleFn:
-        _RULES.append(DiagnosticRule(rule_id=rule_id, title=title, check=func))
+        _RULES.append(
+            DiagnosticRule(
+                rule_id=rule_id,
+                title=title,
+                check=func,
+                supports_partial=supports_partial,
+            )
+        )
         return func
 
     return decorator
@@ -96,7 +104,7 @@ def _dataset_paths(value: Any) -> list[str]:
     return paths
 
 
-@diagnostic_rule("CONFIG_PARSE_ERROR", "Training arguments can be parsed")
+@diagnostic_rule("CONFIG_PARSE_ERROR", "Training arguments can be parsed", supports_partial=True)
 def check_parse_error(ctx: DoctorContext) -> list[DiagnosticResult]:
     if ctx.parse_error is None:
         return []
@@ -109,7 +117,7 @@ def check_parse_error(ctx: DoctorContext) -> list[DiagnosticResult]:
     ]
 
 
-@diagnostic_rule("CONFIG_RESOURCE_REQUIRED", "Resource map is present")
+@diagnostic_rule("CONFIG_RESOURCE_REQUIRED", "Resource map is present", supports_partial=True)
 def check_resource_required(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:
@@ -125,7 +133,11 @@ def check_resource_required(ctx: DoctorContext) -> list[DiagnosticResult]:
     return []
 
 
-@diagnostic_rule("CONFIG_RESOURCE_SHAPE", "Each resource entry has one serve and non-negative GPUs")
+@diagnostic_rule(
+    "CONFIG_RESOURCE_SHAPE",
+    "Each resource entry has one serve and non-negative GPUs",
+    supports_partial=True,
+)
 def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:
@@ -201,7 +213,7 @@ def check_required_roles(ctx: DoctorContext) -> list[DiagnosticResult]:
     ]
 
 
-@diagnostic_rule("CONFIG_MODE_CONFLICT", "Training mode flags are mutually consistent")
+@diagnostic_rule("CONFIG_MODE_CONFLICT", "Training mode flags are mutually consistent", supports_partial=True)
 def check_mode_conflict(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:
@@ -217,7 +229,7 @@ def check_mode_conflict(ctx: DoctorContext) -> list[DiagnosticResult]:
     return []
 
 
-@diagnostic_rule("CONFIG_DEBUG_MODE_CONFLICT", "Debug-only modes do not conflict")
+@diagnostic_rule("CONFIG_DEBUG_MODE_CONFLICT", "Debug-only modes do not conflict", supports_partial=True)
 def check_debug_mode_conflict(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:
@@ -312,7 +324,7 @@ def check_sft_requirements(ctx: DoctorContext) -> list[DiagnosticResult]:
     return diagnostics
 
 
-@diagnostic_rule("CONFIG_BATCH_SIZE", "Batch-size fields are internally consistent")
+@diagnostic_rule("CONFIG_BATCH_SIZE", "Batch-size fields are internally consistent", supports_partial=True)
 def check_batch_size(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:
@@ -331,6 +343,16 @@ def check_batch_size(ctx: DoctorContext) -> list[DiagnosticResult]:
         )
     num_steps = getattr(args, "num_steps_per_rollout", None)
     if rollout_batch_size is not None and num_steps is not None:
+        if not _is_positive_int(num_steps):
+            diagnostics.append(
+                _result(
+                    "CONFIG_BATCH_SIZE",
+                    "num_steps_per_rollout must be a positive integer.",
+                    "Set --num-steps-per-rollout to an integer greater than zero.",
+                    details={"num_steps_per_rollout": num_steps},
+                )
+            )
+            return diagnostics
         expected = rollout_batch_size * n_samples_per_prompt // num_steps
         if global_batch_size is not None and global_batch_size != expected:
             diagnostics.append(
@@ -580,7 +602,7 @@ def check_genrm_colocate(ctx: DoctorContext) -> list[DiagnosticResult]:
     return []
 
 
-@diagnostic_rule("CONFIG_PATHS", "Local paths referenced by the config exist")
+@diagnostic_rule("CONFIG_PATHS", "Local paths referenced by the config exist", supports_partial=True)
 def check_paths(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:

--- a/relax/utils/doctor/rules.py
+++ b/relax/utils/doctor/rules.py
@@ -172,7 +172,7 @@ def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
             )
             continue
         num_serves, num_gpus = spec
-        if not isinstance(num_serves, int) or not isinstance(num_gpus, int) or num_gpus < 0:
+        if type(num_serves) is not int or type(num_gpus) is not int or num_gpus < 0:
             diagnostics.append(
                 _result(
                     "CONFIG_RESOURCE_SHAPE",

--- a/relax/utils/doctor/rules.py
+++ b/relax/utils/doctor/rules.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from relax.core.service_plan import CPU_ONLY_ROLES
 from relax.utils.doctor.models import DiagnosticResult, DoctorContext
 
 
@@ -142,6 +143,22 @@ def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
     args = _args(ctx)
     if args is None:
         return []
+    if ctx.config_state == "validated":
+        resource_errors = [
+            error
+            for error in ctx.topology.get("plan_errors", [])
+            if error.get("code") in {"resource_shape", "num_serves", "gpu_count", "gpu_required"}
+        ]
+        return [
+            _result(
+                "CONFIG_RESOURCE_SHAPE",
+                error["message"],
+                "Use [1, 0] only for CPU roles; model roles require [1, <positive num_gpus>].",
+                details=error,
+            )
+            for error in resource_errors
+        ]
+
     diagnostics = []
     for role, spec in _resource(args).items():
         if not isinstance(spec, Sequence) or isinstance(spec, (str, bytes, bytearray)) or len(spec) != 2:
@@ -161,6 +178,15 @@ def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
                     "CONFIG_RESOURCE_SHAPE",
                     f"resource entry for role {role!r} must contain integers and num_gpus >= 0.",
                     "Use integer values and keep CPU-only roles at [1, 0].",
+                    details={"role": role, "value": spec},
+                )
+            )
+        elif num_gpus == 0 and role not in CPU_ONLY_ROLES:
+            diagnostics.append(
+                _result(
+                    "CONFIG_RESOURCE_SHAPE",
+                    f"model role {role!r} requires num_gpus > 0.",
+                    "Assign at least one GPU to model roles; only CPU roles may use [1, 0].",
                     details={"role": role, "value": spec},
                 )
             )

--- a/relax/utils/doctor/rules.py
+++ b/relax/utils/doctor/rules.py
@@ -147,7 +147,7 @@ def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
         resource_errors = [
             error
             for error in ctx.topology.get("plan_errors", [])
-            if error.get("code") in {"resource_shape", "num_serves", "gpu_count", "gpu_required"}
+            if error.get("code") in {"resource_shape", "num_serves", "gpu_count", "gpu_required", "cpu_gpu_forbidden"}
         ]
         return [
             _result(
@@ -178,6 +178,15 @@ def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
                     "CONFIG_RESOURCE_SHAPE",
                     f"resource entry for role {role!r} must contain integers and num_gpus >= 0.",
                     "Use integer values and keep CPU-only roles at [1, 0].",
+                    details={"role": role, "value": spec},
+                )
+            )
+        elif num_gpus > 0 and role in CPU_ONLY_ROLES:
+            diagnostics.append(
+                _result(
+                    "CONFIG_RESOURCE_SHAPE",
+                    f"CPU-only role {role!r} requires num_gpus=0, got {num_gpus}.",
+                    "Set num_gpus to 0 for CPU-only roles.",
                     details={"role": role, "value": spec},
                 )
             )

--- a/relax/utils/doctor/rules.py
+++ b/relax/utils/doctor/rules.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import os
+import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -11,6 +13,7 @@ from relax.utils.doctor.models import DiagnosticResult, DoctorContext
 
 
 RuleFn = Callable[[DoctorContext], list[DiagnosticResult]]
+_GENERALIZED_PATH_RE = re.compile(r"^(?P<path>.*)@\[-?\d*:-?\d*\]$")
 
 
 @dataclass(frozen=True)
@@ -72,6 +75,25 @@ def _has_path(value: Any) -> bool:
 def _looks_like_dotted_import(value: str) -> bool:
     parts = value.split(".")
     return len(parts) > 1 and all(part.isidentifier() for part in parts)
+
+
+def _dataset_paths(value: Any) -> list[str]:
+    values = value if isinstance(value, (list, tuple)) else [value]
+    paths = []
+    for item in values:
+        text = str(item).strip()
+        if match := _GENERALIZED_PATH_RE.match(text):
+            text = match.group("path").strip()
+        if (text.startswith("[") and text.endswith("]")) or (text.startswith("(") and text.endswith(")")):
+            try:
+                parsed = ast.literal_eval(text)
+            except (SyntaxError, ValueError):
+                parsed = [part.strip().strip("\"'") for part in text[1:-1].split(",") if part.strip()]
+            if isinstance(parsed, (list, tuple)):
+                paths.extend(str(path).strip() for path in parsed)
+                continue
+        paths.append(text)
+    return paths
 
 
 @diagnostic_rule("CONFIG_PARSE_ERROR", "Training arguments can be parsed")
@@ -567,7 +589,6 @@ def check_paths(ctx: DoctorContext) -> list[DiagnosticResult]:
     filesystem_fields = [
         "custom_config_path",
         "eval_config",
-        "prompt_data",
     ]
     import_or_path_fields = [
         "data_source_path",
@@ -590,6 +611,19 @@ def check_paths(ctx: DoctorContext) -> list[DiagnosticResult]:
                     details={"field": field, "path": value},
                 )
             )
+    prompt_data = getattr(args, "prompt_data", None)
+    if prompt_data:
+        for path in _dataset_paths(prompt_data):
+            expanded_path = os.path.expanduser(path)
+            if not os.path.exists(expanded_path):
+                diagnostics.append(
+                    _result(
+                        "CONFIG_PATHS",
+                        f"prompt_data contains a missing path: {path!r}.",
+                        "Fix the path or mount the required dataset file or directory.",
+                        details={"field": "prompt_data", "path": path, "path_spec": prompt_data},
+                    )
+                )
     for field in import_or_path_fields:
         value = getattr(args, field, None)
         if not _has_path(value):

--- a/relax/utils/doctor/rules.py
+++ b/relax/utils/doctor/rules.py
@@ -1,0 +1,698 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from relax.utils.doctor.models import DiagnosticResult, DoctorContext
+
+
+RuleFn = Callable[[DoctorContext], list[DiagnosticResult]]
+
+
+@dataclass(frozen=True)
+class DiagnosticRule:
+    rule_id: str
+    title: str
+    check: RuleFn
+
+
+_RULES: list[DiagnosticRule] = []
+
+
+def diagnostic_rule(rule_id: str, title: str) -> Callable[[RuleFn], RuleFn]:
+    def decorator(func: RuleFn) -> RuleFn:
+        _RULES.append(DiagnosticRule(rule_id=rule_id, title=title, check=func))
+        return func
+
+    return decorator
+
+
+def get_rules() -> list[DiagnosticRule]:
+    return list(_RULES)
+
+
+def _result(
+    rule_id: str,
+    message: str,
+    fix: str,
+    *,
+    details: dict[str, Any] | None = None,
+    severity: str = "error",
+) -> DiagnosticResult:
+    return DiagnosticResult(
+        rule_id=rule_id,
+        severity=severity,  # type: ignore[arg-type]
+        message=message,
+        fix=fix,
+        details=details or {},
+    )
+
+
+def _args(ctx: DoctorContext) -> Any | None:
+    return ctx.args
+
+
+def _resource(args: Any) -> dict[str, Any]:
+    resource = getattr(args, "resource", None)
+    return resource if isinstance(resource, dict) else {}
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def _has_path(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _looks_like_dotted_import(value: str) -> bool:
+    parts = value.split(".")
+    return len(parts) > 1 and all(part.isidentifier() for part in parts)
+
+
+@diagnostic_rule("CONFIG_PARSE_ERROR", "Training arguments can be parsed")
+def check_parse_error(ctx: DoctorContext) -> list[DiagnosticResult]:
+    if ctx.parse_error is None:
+        return []
+    return [
+        _result(
+            "CONFIG_PARSE_ERROR",
+            f"failed to parse or normalize training arguments: {ctx.parse_error}",
+            "Fix the CLI arguments first. Run with the same arguments used by relax.entrypoints.train.",
+        )
+    ]
+
+
+@diagnostic_rule("CONFIG_RESOURCE_REQUIRED", "Resource map is present")
+def check_resource_required(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    if not isinstance(getattr(args, "resource", None), dict):
+        return [
+            _result(
+                "CONFIG_RESOURCE_REQUIRED",
+                "--resource is missing or is not a JSON object.",
+                'Pass --resource as JSON, for example: \'{"actor": [1, 8], "rollout": [1, 8]}\'.',
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_RESOURCE_SHAPE", "Each resource entry has one serve and non-negative GPUs")
+def check_resource_shape(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    diagnostics = []
+    for role, spec in _resource(args).items():
+        if not isinstance(spec, Sequence) or isinstance(spec, (str, bytes, bytearray)) or len(spec) != 2:
+            diagnostics.append(
+                _result(
+                    "CONFIG_RESOURCE_SHAPE",
+                    f"resource entry for role {role!r} must be [num_serves, num_gpus], got {spec!r}.",
+                    'Use a two-element integer list for every role, e.g. "actor": [1, 8].',
+                    details={"role": role, "value": spec},
+                )
+            )
+            continue
+        num_serves, num_gpus = spec
+        if not isinstance(num_serves, int) or not isinstance(num_gpus, int) or num_gpus < 0:
+            diagnostics.append(
+                _result(
+                    "CONFIG_RESOURCE_SHAPE",
+                    f"resource entry for role {role!r} must contain integers and num_gpus >= 0.",
+                    "Use integer values and keep CPU-only roles at [1, 0].",
+                    details={"role": role, "value": spec},
+                )
+            )
+        elif num_serves != 1:
+            diagnostics.append(
+                _result(
+                    "CONFIG_RESOURCE_SHAPE",
+                    f"role {role!r} has num_serves={num_serves}; Relax currently supports only one serve per role.",
+                    "Set num_serves to 1 for this role.",
+                    details={"role": role, "value": spec},
+                )
+            )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_ALGORITHM_SUPPORTED", "Algorithm key is registered")
+def check_algorithm_supported(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    algo_key = ctx.topology.get("algo_key")
+    known = set(ctx.topology.get("known_algorithms", []))
+    if algo_key not in known:
+        return [
+            _result(
+                "CONFIG_ALGORITHM_SUPPORTED",
+                f"algorithm key {algo_key!r} is not registered in the dry-run topology table.",
+                f"Use one of {sorted(known)} or add the new algorithm to the doctor topology registry.",
+                details={"algo_key": algo_key, "known_algorithms": sorted(known)},
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_REQUIRED_ROLES", "Required roles are present in resource map")
+def check_required_roles(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    missing = list(ctx.topology.get("missing_resource_roles", []))
+    if not missing:
+        return []
+    return [
+        _result(
+            "CONFIG_REQUIRED_ROLES",
+            f"--resource is missing required role(s): {missing}.",
+            "Add all planned roles to --resource, or change the training mode so those roles are not required.",
+            details={"missing_roles": missing, "planned_roles": ctx.topology.get("roles", [])},
+        )
+    ]
+
+
+@diagnostic_rule("CONFIG_MODE_CONFLICT", "Training mode flags are mutually consistent")
+def check_mode_conflict(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    if getattr(args, "fully_async", False) and getattr(args, "colocate", False) and not getattr(args, "hybrid", False):
+        return [
+            _result(
+                "CONFIG_MODE_CONFLICT",
+                "--fully-async and --colocate cannot be combined directly.",
+                "Use --hybrid for the supported hybrid mode, or remove one of --fully-async / --colocate.",
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_DEBUG_MODE_CONFLICT", "Debug-only modes do not conflict")
+def check_debug_mode_conflict(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    if getattr(args, "debug_rollout_only", False) and getattr(args, "debug_train_only", False):
+        return [
+            _result(
+                "CONFIG_DEBUG_MODE_CONFLICT",
+                "--debug-rollout-only and --debug-train-only are both enabled.",
+                "Pick only one debug mode.",
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_PPO_TOPOLOGY", "PPO topology is supported")
+def check_ppo_topology(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or getattr(args, "advantage_estimator", None) != "ppo":
+        return []
+    diagnostics = []
+    resource = _resource(args)
+    if "critic" not in resource:
+        diagnostics.append(
+            _result(
+                "CONFIG_PPO_TOPOLOGY",
+                "--advantage-estimator ppo requires a 'critic' entry in --resource.",
+                'Add "critic": [1, <num_gpus>] to --resource.',
+            )
+        )
+    if getattr(args, "fully_async", False) or getattr(args, "hybrid", False):
+        diagnostics.append(
+            _result(
+                "CONFIG_PPO_TOPOLOGY",
+                "PPO does not currently support --fully-async or --hybrid.",
+                "Run PPO in synchronous colocate mode.",
+            )
+        )
+    if getattr(args, "colocate", False) and getattr(args, "max_staleness", 0) != 0:
+        diagnostics.append(
+            _result(
+                "CONFIG_PPO_TOPOLOGY",
+                "Synchronous colocate PPO requires --max-staleness 0.",
+                "Set --max-staleness 0 for PPO colocate training.",
+            )
+        )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_SFT_REQUIREMENTS", "SFT-specific options are complete")
+def check_sft_requirements(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or getattr(args, "loss_type", None) != "sft":
+        return []
+    diagnostics = []
+    if not getattr(args, "custom_dataset_class_path", None) and not getattr(args, "prompt_data", None):
+        diagnostics.append(
+            _result(
+                "CONFIG_SFT_REQUIREMENTS",
+                "--loss-type sft requires --prompt-data unless --custom-dataset-class-path is set.",
+                "Set --prompt-data to an SFT dataset path, or provide --custom-dataset-class-path.",
+            )
+        )
+    if not getattr(args, "use_dynamic_batch_size", False):
+        diagnostics.append(
+            _result(
+                "CONFIG_SFT_REQUIREMENTS",
+                "--loss-type sft requires --use-dynamic-batch-size.",
+                "Enable --use-dynamic-batch-size and set --max-tokens-per-gpu.",
+            )
+        )
+    if getattr(args, "sft_oversize_strategy", None) == "custom" and not getattr(
+        args, "sft_oversize_custom_function_path", None
+    ):
+        diagnostics.append(
+            _result(
+                "CONFIG_SFT_REQUIREMENTS",
+                "--sft-oversize-strategy custom requires --sft-oversize-custom-function-path.",
+                "Provide the custom oversize function path or use a built-in strategy.",
+            )
+        )
+    if getattr(args, "sft_predict_interval", None) is not None:
+        has_eval_source = bool(getattr(args, "eval_prompt_data", None)) or getattr(args, "eval_size", None) is not None
+        if not getattr(args, "save", None) or not has_eval_source:
+            diagnostics.append(
+                _result(
+                    "CONFIG_SFT_REQUIREMENTS",
+                    "--sft-predict-interval requires --save and an eval source.",
+                    "Set --save and either --eval-prompt-data or --eval-size.",
+                )
+            )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_BATCH_SIZE", "Batch-size fields are internally consistent")
+def check_batch_size(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    diagnostics = []
+    rollout_batch_size = getattr(args, "rollout_batch_size", None)
+    global_batch_size = getattr(args, "global_batch_size", None)
+    n_samples_per_prompt = getattr(args, "n_samples_per_prompt", 1)
+    if rollout_batch_size is None and global_batch_size is None:
+        diagnostics.append(
+            _result(
+                "CONFIG_BATCH_SIZE",
+                "Either --rollout-batch-size or --global-batch-size must be set.",
+                "Set --rollout-batch-size directly, or set --global-batch-size with --n-samples-per-prompt.",
+            )
+        )
+    num_steps = getattr(args, "num_steps_per_rollout", None)
+    if rollout_batch_size is not None and num_steps is not None:
+        expected = rollout_batch_size * n_samples_per_prompt // num_steps
+        if global_batch_size is not None and global_batch_size != expected:
+            diagnostics.append(
+                _result(
+                    "CONFIG_BATCH_SIZE",
+                    f"global_batch_size={global_batch_size} does not match rollout batch formula {expected}.",
+                    "Set global_batch_size = rollout_batch_size * n_samples_per_prompt // num_steps_per_rollout.",
+                    details={"expected_global_batch_size": expected},
+                )
+            )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_ROLLOUT_COUNT", "Rollout count is bounded")
+def check_rollout_count(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    if getattr(args, "num_epoch", None) is None and getattr(args, "num_rollout", None) is None:
+        return [
+            _result(
+                "CONFIG_ROLLOUT_COUNT",
+                "Neither --num-rollout nor --num-epoch is set.",
+                "Set at least one of --num-rollout or --num-epoch.",
+            )
+        ]
+    if getattr(args, "num_epoch", None) is not None and getattr(args, "loss_type", None) != "sft":
+        if not getattr(args, "rollout_global_dataset", True):
+            return [
+                _result(
+                    "CONFIG_ROLLOUT_COUNT",
+                    "--num-epoch requires rollout_global_dataset for RL training.",
+                    "Remove --disable-rollout-global-dataset or use --num-rollout.",
+                )
+            ]
+    return []
+
+
+@diagnostic_rule("CONFIG_OVERSAMPLING", "Over-sampling batch size is valid")
+def check_oversampling(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    rollout_batch_size = getattr(args, "rollout_batch_size", None)
+    over_sampling_batch_size = getattr(args, "over_sampling_batch_size", None)
+    if rollout_batch_size is None or over_sampling_batch_size is None:
+        return []
+    if over_sampling_batch_size < rollout_batch_size:
+        return [
+            _result(
+                "CONFIG_OVERSAMPLING",
+                "over_sampling_batch_size must be greater than or equal to rollout_batch_size.",
+                "Increase --over-sampling-batch-size or lower --rollout-batch-size.",
+                details={
+                    "over_sampling_batch_size": over_sampling_batch_size,
+                    "rollout_batch_size": rollout_batch_size,
+                },
+            )
+        ]
+    if (
+        over_sampling_batch_size > rollout_batch_size
+        and not getattr(args, "fully_async", False)
+        and not getattr(args, "partial_rollout", False)
+    ):
+        return [
+            _result(
+                "CONFIG_OVERSAMPLING",
+                "over-sampled surplus will be discarded without fully_async or partial_rollout.",
+                "Enable --fully-async / --partial-rollout, or set over_sampling_batch_size == rollout_batch_size.",
+                severity="warning",
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_DYNAMIC_BATCH", "Dynamic batch size has token budget")
+def check_dynamic_batch(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or not getattr(args, "use_dynamic_batch_size", False):
+        return []
+    if getattr(args, "max_tokens_per_gpu", None) is None:
+        return [
+            _result(
+                "CONFIG_DYNAMIC_BATCH",
+                "--use-dynamic-batch-size requires --max-tokens-per-gpu.",
+                "Set --max-tokens-per-gpu to the per-GPU token budget.",
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_CONTEXT_LENGTH", "Context-length settings can fit the token budget")
+def check_context_length(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    diagnostics = []
+    max_context = getattr(args, "rollout_max_context_len", None)
+    max_prompt = getattr(args, "rollout_max_prompt_len", None)
+    if max_context is not None and max_prompt is not None and max_prompt > max_context - 1:
+        diagnostics.append(
+            _result(
+                "CONFIG_CONTEXT_LENGTH",
+                "rollout_max_prompt_len must leave at least one token for generation.",
+                "Set rollout_max_prompt_len <= rollout_max_context_len - 1.",
+                details={"rollout_max_prompt_len": max_prompt, "rollout_max_context_len": max_context},
+            )
+        )
+    if getattr(args, "use_dynamic_batch_size", False) and max_context is not None:
+        token_budget = getattr(args, "max_tokens_per_gpu", None)
+        cp_size = getattr(args, "context_parallel_size", 1)
+        if (
+            token_budget is not None
+            and token_budget * cp_size < max_context
+            and not getattr(args, "dynamic_context_parallel", False)
+        ):
+            diagnostics.append(
+                _result(
+                    "CONFIG_CONTEXT_LENGTH",
+                    "max_tokens_per_gpu * context_parallel_size is smaller than rollout_max_context_len.",
+                    "Increase --max-tokens-per-gpu / --context-parallel-size, or reduce rollout_max_context_len.",
+                    details={"token_budget": token_budget * cp_size, "rollout_max_context_len": max_context},
+                )
+            )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_SGLANG_PARALLEL", "SGLang parallelism is internally consistent")
+def check_sglang_parallel(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or getattr(args, "debug_train_only", False):
+        return []
+    diagnostics = []
+    pp_size = getattr(args, "sglang_pp_size", getattr(args, "sglang_pipeline_parallel_size", 1))
+    rollout_num_gpus_per_engine = getattr(args, "rollout_num_gpus_per_engine", 1)
+    if pp_size and rollout_num_gpus_per_engine % pp_size != 0:
+        diagnostics.append(
+            _result(
+                "CONFIG_SGLANG_PARALLEL",
+                "rollout_num_gpus_per_engine must be divisible by SGLang pipeline parallel size.",
+                "Adjust --rollout-num-gpus-per-engine or --sglang-pipeline-parallel-size.",
+                details={"rollout_num_gpus_per_engine": rollout_num_gpus_per_engine, "sglang_pp_size": pp_size},
+            )
+        )
+    if getattr(args, "sglang_data_parallel_size", 1) > 1 and not getattr(args, "sglang_enable_dp_attention", False):
+        diagnostics.append(
+            _result(
+                "CONFIG_SGLANG_PARALLEL",
+                "sglang_data_parallel_size > 1 requires --sglang-enable-dp-attention.",
+                "Enable --sglang-enable-dp-attention or set data parallel size to 1.",
+            )
+        )
+    if getattr(args, "prefill_num_servers", None) is not None and getattr(args, "rollout_external", False):
+        diagnostics.append(
+            _result(
+                "CONFIG_SGLANG_PARALLEL",
+                "prefill_num_servers cannot be set when rollout_external is set.",
+                "Remove --prefill-num-servers or disable external rollout.",
+            )
+        )
+    if getattr(args, "sglang_config", None) is not None and getattr(args, "prefill_num_servers", None) is not None:
+        diagnostics.append(
+            _result(
+                "CONFIG_SGLANG_PARALLEL",
+                "sglang_config and prefill_num_servers are mutually exclusive.",
+                "Use engine_groups in the SGLang YAML config instead of --prefill-num-servers.",
+            )
+        )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_EVAL", "Evaluation configuration is complete")
+def check_eval(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    diagnostics = []
+    if getattr(args, "loss_type", None) == "sft" and getattr(args, "eval_config", None) is not None:
+        diagnostics.append(
+            _result(
+                "CONFIG_EVAL",
+                "--loss-type sft uses --eval-prompt-data for eval; --eval-config is not supported.",
+                "Replace --eval-config with --eval-prompt-data for SFT.",
+            )
+        )
+    if getattr(args, "eval_size", None) is not None and getattr(args, "loss_type", None) != "sft":
+        diagnostics.append(
+            _result(
+                "CONFIG_EVAL",
+                "--eval-size is only meaningful under --loss-type sft.",
+                "Use --eval-config / --eval-prompt-data for RL eval, or switch to SFT.",
+            )
+        )
+    if getattr(args, "eval_interval", None) is not None and getattr(args, "loss_type", None) != "sft":
+        if not getattr(args, "eval_datasets", None) and not getattr(args, "eval_prompt_data", None):
+            diagnostics.append(
+                _result(
+                    "CONFIG_EVAL",
+                    "Evaluation datasets must be configured when eval_interval is set.",
+                    "Provide --eval-config or --eval-prompt-data.",
+                )
+            )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_SAVE", "Save-related options have required paths")
+def check_save(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    if getattr(args, "save_interval", None) is not None and not getattr(args, "save", None):
+        return [
+            _result(
+                "CONFIG_SAVE",
+                "--save is required when --save-interval is set.",
+                "Set --save to the checkpoint output directory, or remove --save-interval.",
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_GENRM_COLOCATE", "GenRM colocate GPU split is valid")
+def check_genrm_colocate(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or not getattr(args, "colocate", False) or not getattr(args, "genrm_model_path", None):
+        return []
+    rollout_g = getattr(args, "rollout_num_gpus", None)
+    genrm_g = getattr(args, "genrm_num_gpus", 1)
+    actor_total = getattr(args, "actor_num_gpus_per_node", 1) * getattr(args, "actor_num_nodes", 1)
+    if rollout_g is None:
+        return [
+            _result(
+                "CONFIG_GENRM_COLOCATE",
+                "When GenRM is enabled in colocated mode, --rollout-num-gpus must be set.",
+                "Set --rollout-num-gpus and --genrm-num-gpus so they split or share actor GPUs.",
+            )
+        ]
+    if not (rollout_g + genrm_g == actor_total or (rollout_g == actor_total and genrm_g == actor_total)):
+        return [
+            _result(
+                "CONFIG_GENRM_COLOCATE",
+                "Invalid GenRM colocate GPU allocation.",
+                "Use split allocation rollout + genrm == actor total, or shared allocation rollout == genrm == actor total.",
+                details={"rollout_num_gpus": rollout_g, "genrm_num_gpus": genrm_g, "actor_total_gpus": actor_total},
+            )
+        ]
+    return []
+
+
+@diagnostic_rule("CONFIG_PATHS", "Local paths referenced by the config exist")
+def check_paths(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None:
+        return []
+    diagnostics = []
+    filesystem_fields = [
+        "custom_config_path",
+        "eval_config",
+        "prompt_data",
+    ]
+    import_or_path_fields = [
+        "data_source_path",
+        "rollout_function_path",
+        "eval_function_path",
+        "custom_reward_function_path",
+        "custom_dataset_class_path",
+    ]
+    for field in filesystem_fields:
+        value = getattr(args, field, None)
+        if not _has_path(value):
+            continue
+        path = os.path.expanduser(value)
+        if not os.path.exists(path):
+            diagnostics.append(
+                _result(
+                    "CONFIG_PATHS",
+                    f"{field} points to a missing path: {value!r}.",
+                    "Fix the path or mount the required data/config file.",
+                    details={"field": field, "path": value},
+                )
+            )
+    for field in import_or_path_fields:
+        value = getattr(args, field, None)
+        if not _has_path(value):
+            continue
+        if _looks_like_dotted_import(value):
+            # Dotted import paths are resolved at runtime; do not treat them as filesystem paths.
+            continue
+        path = os.path.expanduser(value)
+        if not os.path.exists(path):
+            diagnostics.append(
+                _result(
+                    "CONFIG_PATHS",
+                    f"{field} points to a missing path: {value!r}.",
+                    "Fix the path, mount the required data/config file, or use a valid Python dotted import path.",
+                    details={"field": field, "path": value},
+                )
+            )
+    ref_load = getattr(args, "ref_load", None)
+    if (
+        (getattr(args, "kl_coef", 0) != 0 or getattr(args, "use_kl_loss", False))
+        and ref_load
+        and not os.path.exists(os.path.expanduser(ref_load))
+    ):
+        diagnostics.append(
+            _result(
+                "CONFIG_PATHS",
+                f"ref_load {ref_load!r} does not exist while KL is enabled.",
+                "Set --ref-load to an existing checkpoint path or disable KL.",
+                details={"field": "ref_load", "path": ref_load},
+            )
+        )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_LORA", "LoRA options are compatible")
+def check_lora(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or getattr(args, "lora_rank", 0) <= 0:
+        return []
+    diagnostics = []
+    if getattr(args, "lora_merge_mode", False) and getattr(args, "lora_adapter_mode", False):
+        diagnostics.append(
+            _result(
+                "CONFIG_LORA",
+                "--lora-merge-mode and --lora-adapter-mode are mutually exclusive.",
+                "Pick one LoRA rollout path.",
+            )
+        )
+    if getattr(args, "lora_adapter_mode", False) and getattr(args, "sglang_dp_size", 1) != 1:
+        diagnostics.append(
+            _result(
+                "CONFIG_LORA",
+                "--lora-adapter-mode requires --sglang-dp-size 1.",
+                "Set SGLang DP size to 1 or use LoRA merge mode.",
+            )
+        )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_QKV_FORMAT", "QKV format is compatible with batching mode")
+def check_qkv_format(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or getattr(args, "qkv_format", None) != "bshd":
+        return []
+    diagnostics = []
+    if getattr(args, "train_backend", "megatron") != "megatron":
+        diagnostics.append(
+            _result(
+                "CONFIG_QKV_FORMAT",
+                "bshd format is only supported for megatron backend.",
+                "Use --train-backend megatron or switch qkv_format.",
+            )
+        )
+    if getattr(args, "use_dynamic_batch_size", False):
+        diagnostics.append(
+            _result(
+                "CONFIG_QKV_FORMAT",
+                "Dynamic batch size is not supported for bshd format.",
+                "Disable --use-dynamic-batch-size and set --micro-batch-size.",
+            )
+        )
+    return diagnostics
+
+
+@diagnostic_rule("CONFIG_ROTATE_CKPT", "Rotating checkpoints has required options")
+def check_rotate_ckpt(ctx: DoctorContext) -> list[DiagnosticResult]:
+    args = _args(ctx)
+    if args is None or not getattr(args, "rotate_ckpt", False):
+        return []
+    missing = []
+    if not getattr(args, "save", None):
+        missing.append("--save")
+    if getattr(args, "save_interval", None) is None:
+        missing.append("--save-interval")
+    if not getattr(args, "async_save", False):
+        missing.append("--async-save")
+    if not missing:
+        return []
+    return [
+        _result(
+            "CONFIG_ROTATE_CKPT",
+            f"--rotate-ckpt is missing required option(s): {missing}.",
+            "Set all required checkpoint rotation options or disable --rotate-ckpt.",
+            details={"missing": missing},
+        )
+    ]

--- a/relax/utils/doctor/runner.py
+++ b/relax/utils/doctor/runner.py
@@ -27,15 +27,17 @@ def run_doctor(
     parse_error: str | None = None,
     strict_warnings: bool = False,
 ) -> DoctorReport:
-    safe_argv, argv_secrets = sanitize_argv(argv)
+    config_state = "unavailable" if args is None else ("partial" if parse_error is not None else "validated")
     config, config_secrets = sanitize_config(serialize_config(args))
-    secret_values = argv_secrets | config_secrets
+    safe_argv, argv_secrets = sanitize_argv(argv, known_secrets=config_secrets)
+    secret_values = config_secrets | argv_secrets
     safe_parse_error = sanitize_text(parse_error, secret_values)
-    topology = build_topology_plan(args)
+    topology = build_topology_plan(args) if config_state == "validated" else {}
     context = DoctorContext(
         argv=safe_argv,
         args=args,
         parse_error=safe_parse_error,
+        config_state=config_state,
         config=config,
         topology=topology,
         command=build_expected_command(safe_argv),
@@ -43,11 +45,20 @@ def run_doctor(
 
     diagnostics: list[DiagnosticResult] = []
     for rule in get_rules():
-        diagnostics.extend(rule.check(context))
-
-    targeted_errors = any(item.severity == "error" and item.rule_id != "CONFIG_PARSE_ERROR" for item in diagnostics)
-    if targeted_errors:
-        diagnostics = [item for item in diagnostics if item.rule_id != "CONFIG_PARSE_ERROR"]
+        if config_state != "validated" and not rule.supports_partial:
+            continue
+        try:
+            diagnostics.extend(rule.check(context))
+        except Exception as exc:  # noqa: BLE001 - reports must remain structured for malformed input
+            diagnostics.append(
+                DiagnosticResult(
+                    rule_id="DOCTOR_RULE_EXECUTION_ERROR",
+                    severity="error",
+                    message=f"diagnostic rule {rule.rule_id} failed: {type(exc).__name__}: {exc}",
+                    fix="Fix the reported input first; if the failure persists, report the rule id to Relax maintainers.",
+                    details={"failed_rule_id": rule.rule_id},
+                )
+            )
 
     diagnostics = [
         DiagnosticResult(
@@ -78,6 +89,7 @@ def run_doctor(
         argv=safe_argv,
         command=context.command,
         diagnostics=diagnostics,
+        config_state=config_state,
         config=config,
         topology=topology,
     )
@@ -118,7 +130,11 @@ def render_text(report: DoctorReport) -> str:
             "Role topology:",
             _indent_json(report.topology),
             "",
-            "Final merged config:",
+            {
+                "validated": "Final merged config:",
+                "partial": "Partial parsed config:",
+                "unavailable": "Config unavailable:",
+            }[report.config_state],
             _indent_json(report.config),
         ]
     )

--- a/relax/utils/doctor/runner.py
+++ b/relax/utils/doctor/runner.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from relax.utils.doctor.models import DiagnosticResult, DoctorContext, DoctorReport
+from relax.utils.doctor.rules import get_rules
+from relax.utils.doctor.topology import build_topology_plan, serialize_config
+
+
+def build_expected_command(argv: list[str]) -> list[str]:
+    return ["python", "-m", "relax.entrypoints.train", *argv]
+
+
+def run_doctor(
+    *,
+    argv: list[str],
+    args: Any | None,
+    parse_error: str | None = None,
+    strict_warnings: bool = False,
+) -> DoctorReport:
+    config = serialize_config(args)
+    topology = build_topology_plan(args)
+    context = DoctorContext(
+        argv=argv,
+        args=args,
+        parse_error=parse_error,
+        config=config,
+        topology=topology,
+        command=build_expected_command(argv),
+    )
+
+    diagnostics: list[DiagnosticResult] = []
+    for rule in get_rules():
+        diagnostics.extend(rule.check(context))
+
+    if strict_warnings:
+        diagnostics = [
+            DiagnosticResult(
+                rule_id=item.rule_id,
+                severity="error" if item.severity == "warning" else item.severity,
+                message=item.message,
+                fix=item.fix,
+                details=item.details,
+            )
+            for item in diagnostics
+        ]
+
+    ok = not any(item.severity == "error" for item in diagnostics)
+    return DoctorReport(
+        ok=ok,
+        argv=argv,
+        command=context.command,
+        diagnostics=diagnostics,
+        config=config,
+        topology=topology,
+    )
+
+
+def render_json(report: DoctorReport) -> str:
+    return json.dumps(report.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def render_text(report: DoctorReport) -> str:
+    lines = [
+        "Relax Config Doctor",
+        f"Status: {'PASS' if report.ok else 'FAIL'}",
+        "",
+        "Expected launch command:",
+        "  " + " ".join(_shell_quote(item) for item in report.command),
+        "",
+        "Diagnostics:",
+    ]
+    if not report.diagnostics:
+        lines.append("  No errors or warnings.")
+    else:
+        for item in report.diagnostics:
+            lines.extend(
+                [
+                    f"  [{item.severity.upper()}] {item.rule_id}",
+                    f"    {item.message}",
+                    f"    Fix: {item.fix}",
+                ]
+            )
+            if item.details:
+                details = json.dumps(item.details, ensure_ascii=False, sort_keys=True)
+                lines.append(f"    Details: {details}")
+
+    lines.extend(
+        [
+            "",
+            "Role topology:",
+            _indent_json(report.topology),
+            "",
+            "Final merged config:",
+            _indent_json(report.config),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _indent_json(value: Any) -> str:
+    payload = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+    return "\n".join("  " + line for line in payload.splitlines())
+
+
+def _shell_quote(value: str) -> str:
+    if not value:
+        return "''"
+    safe = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_+-=.,/:@%")
+    if all(ch in safe for ch in value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"

--- a/relax/utils/doctor/runner.py
+++ b/relax/utils/doctor/runner.py
@@ -7,6 +7,12 @@ from typing import Any
 
 from relax.utils.doctor.models import DiagnosticResult, DoctorContext, DoctorReport
 from relax.utils.doctor.rules import get_rules
+from relax.utils.doctor.sanitizer import (
+    sanitize_argv,
+    sanitize_config,
+    sanitize_details,
+    sanitize_text,
+)
 from relax.utils.doctor.topology import build_topology_plan, serialize_config
 
 
@@ -21,15 +27,18 @@ def run_doctor(
     parse_error: str | None = None,
     strict_warnings: bool = False,
 ) -> DoctorReport:
-    config = serialize_config(args)
+    safe_argv, argv_secrets = sanitize_argv(argv)
+    config, config_secrets = sanitize_config(serialize_config(args))
+    secret_values = argv_secrets | config_secrets
+    safe_parse_error = sanitize_text(parse_error, secret_values)
     topology = build_topology_plan(args)
     context = DoctorContext(
-        argv=argv,
+        argv=safe_argv,
         args=args,
-        parse_error=parse_error,
+        parse_error=safe_parse_error,
         config=config,
         topology=topology,
-        command=build_expected_command(argv),
+        command=build_expected_command(safe_argv),
     )
 
     diagnostics: list[DiagnosticResult] = []
@@ -39,6 +48,17 @@ def run_doctor(
     targeted_errors = any(item.severity == "error" and item.rule_id != "CONFIG_PARSE_ERROR" for item in diagnostics)
     if targeted_errors:
         diagnostics = [item for item in diagnostics if item.rule_id != "CONFIG_PARSE_ERROR"]
+
+    diagnostics = [
+        DiagnosticResult(
+            rule_id=item.rule_id,
+            severity=item.severity,
+            message=sanitize_text(item.message, secret_values) or "",
+            fix=sanitize_text(item.fix, secret_values) or "",
+            details=sanitize_details(item.details, secret_values),
+        )
+        for item in diagnostics
+    ]
 
     if strict_warnings:
         diagnostics = [
@@ -55,7 +75,7 @@ def run_doctor(
     ok = not any(item.severity == "error" for item in diagnostics)
     return DoctorReport(
         ok=ok,
-        argv=argv,
+        argv=safe_argv,
         command=context.command,
         diagnostics=diagnostics,
         config=config,

--- a/relax/utils/doctor/runner.py
+++ b/relax/utils/doctor/runner.py
@@ -25,6 +25,7 @@ def run_doctor(
     argv: list[str],
     args: Any | None,
     parse_error: str | None = None,
+    unknown_options: list[str] | None = None,
     strict_warnings: bool = False,
 ) -> DoctorReport:
     config_state = "unavailable" if args is None else ("partial" if parse_error is not None else "validated")
@@ -44,6 +45,16 @@ def run_doctor(
     )
 
     diagnostics: list[DiagnosticResult] = []
+    if unknown_options:
+        diagnostics.append(
+            DiagnosticResult(
+                rule_id="CONFIG_UNKNOWN_ARGUMENT",
+                severity="error",
+                message=f"unknown command-line option(s): {unknown_options}.",
+                fix="Fix misspelled options or remove flags that are not registered by Relax, Megatron, or SGLang.",
+                details={"unknown_options": unknown_options},
+            )
+        )
     for rule in get_rules():
         if config_state != "validated" and not rule.supports_partial:
             continue

--- a/relax/utils/doctor/runner.py
+++ b/relax/utils/doctor/runner.py
@@ -36,6 +36,10 @@ def run_doctor(
     for rule in get_rules():
         diagnostics.extend(rule.check(context))
 
+    targeted_errors = any(item.severity == "error" and item.rule_id != "CONFIG_PARSE_ERROR" for item in diagnostics)
+    if targeted_errors:
+        diagnostics = [item for item in diagnostics if item.rule_id != "CONFIG_PARSE_ERROR"]
+
     if strict_warnings:
         diagnostics = [
             DiagnosticResult(

--- a/relax/utils/doctor/sanitizer.py
+++ b/relax/utils/doctor/sanitizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -22,12 +23,15 @@ _SENSITIVE_NAMES = {
     "private_key",
     "secret",
     "token",
+    "wandb_key",
 }
 
+_STRUCTURED_SECRET_OPTIONS = {"train_env_vars"}
 
-def sanitize_argv(argv: list[str]) -> tuple[list[str], set[str]]:
+
+def sanitize_argv(argv: list[str], *, known_secrets: set[str] | None = None) -> tuple[list[str], set[str]]:
     sanitized = []
-    secret_values: set[str] = set()
+    secret_values = set(known_secrets or ())
     index = 0
     while index < len(argv):
         item = argv[index]
@@ -48,21 +52,28 @@ def sanitize_argv(argv: list[str]) -> tuple[list[str], set[str]]:
                 sanitized.append(f"{option}={REDACTED}")
                 if value:
                     secret_values.add(value)
+            elif _normalize_name(option) in _STRUCTURED_SECRET_OPTIONS:
+                sanitized.append(f"{option}={_sanitize_json_mapping(value, secret_values)}")
             else:
                 sanitized.append(item)
             index += 1
             continue
 
         sanitized.append(item)
-        if item.startswith("--") and is_sensitive_name(item) and index + 1 < len(argv):
+        if item.startswith("--") and index + 1 < len(argv):
             value = argv[index + 1]
-            sanitized.append(REDACTED)
-            if value:
-                secret_values.add(value)
-            index += 2
-            continue
+            if is_sensitive_name(item):
+                sanitized.append(REDACTED)
+                if value:
+                    secret_values.add(value)
+                index += 2
+                continue
+            if _normalize_name(item) in _STRUCTURED_SECRET_OPTIONS:
+                sanitized.append(_sanitize_json_mapping(value, secret_values))
+                index += 2
+                continue
         index += 1
-    return sanitized, secret_values
+    return [sanitize_text(item, secret_values) or "" for item in sanitized], secret_values
 
 
 def sanitize_config(config: dict[str, Any]) -> tuple[dict[str, Any], set[str]]:
@@ -87,13 +98,28 @@ def sanitize_details(value: Any, secret_values: set[str]) -> Any:
 
 
 def is_sensitive_name(name: str) -> bool:
-    normalized = name.lstrip("-").replace("-", "_").lower()
+    normalized = _normalize_name(name)
     if normalized in _SENSITIVE_NAMES:
         return True
     parts = normalized.split("_")
     if any(part in {"password", "passwd", "secret", "token", "credential", "credentials"} for part in parts):
         return True
     return "api" in parts and "key" in parts or "private" in parts and "key" in parts
+
+
+def _normalize_name(name: str) -> str:
+    return name.lstrip("-").replace("-", "_").lower()
+
+
+def _sanitize_json_mapping(value: str, secret_values: set[str]) -> str:
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return sanitize_text(value, secret_values) or ""
+    if not isinstance(parsed, Mapping):
+        return sanitize_text(value, secret_values) or ""
+    sanitized = _sanitize_value(parsed, secret_values=secret_values)
+    return json.dumps(sanitized, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
 
 
 def _sanitize_value(value: Any, *, secret_values: set[str], key: str | None = None) -> Any:

--- a/relax/utils/doctor/sanitizer.py
+++ b/relax/utils/doctor/sanitizer.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+REDACTED = "<redacted>"
+
+_SENSITIVE_NAMES = {
+    "agent_env",
+    "api_key",
+    "apikey",
+    "auth_token",
+    "authorization",
+    "credential",
+    "credentials",
+    "notify_urls",
+    "password",
+    "passwd",
+    "private_key",
+    "secret",
+    "token",
+}
+
+
+def sanitize_argv(argv: list[str]) -> tuple[list[str], set[str]]:
+    sanitized = []
+    secret_values: set[str] = set()
+    index = 0
+    while index < len(argv):
+        item = argv[index]
+        if item == "--agent-env":
+            sanitized.append(item)
+            index += 1
+            while index < len(argv) and not argv[index].startswith("--"):
+                sanitized_item, secret = _sanitize_env_item(argv[index])
+                sanitized.append(sanitized_item)
+                if secret:
+                    secret_values.add(secret)
+                index += 1
+            continue
+
+        if item.startswith("--") and "=" in item:
+            option, value = item.split("=", 1)
+            if is_sensitive_name(option):
+                sanitized.append(f"{option}={REDACTED}")
+                if value:
+                    secret_values.add(value)
+            else:
+                sanitized.append(item)
+            index += 1
+            continue
+
+        sanitized.append(item)
+        if item.startswith("--") and is_sensitive_name(item) and index + 1 < len(argv):
+            value = argv[index + 1]
+            sanitized.append(REDACTED)
+            if value:
+                secret_values.add(value)
+            index += 2
+            continue
+        index += 1
+    return sanitized, secret_values
+
+
+def sanitize_config(config: dict[str, Any]) -> tuple[dict[str, Any], set[str]]:
+    secret_values: set[str] = set()
+    sanitized = _sanitize_value(config, secret_values=secret_values)
+    return sanitized, secret_values
+
+
+def sanitize_text(value: str | None, secret_values: set[str]) -> str | None:
+    if value is None:
+        return None
+    sanitized = value
+    for secret in sorted(secret_values, key=len, reverse=True):
+        if secret:
+            sanitized = sanitized.replace(secret, REDACTED)
+    return sanitized
+
+
+def sanitize_details(value: Any, secret_values: set[str]) -> Any:
+    sanitized = _sanitize_value(value, secret_values=set())
+    return _replace_secret_literals(sanitized, secret_values)
+
+
+def is_sensitive_name(name: str) -> bool:
+    normalized = name.lstrip("-").replace("-", "_").lower()
+    if normalized in _SENSITIVE_NAMES:
+        return True
+    parts = normalized.split("_")
+    if any(part in {"password", "passwd", "secret", "token", "credential", "credentials"} for part in parts):
+        return True
+    return "api" in parts and "key" in parts or "private" in parts and "key" in parts
+
+
+def _sanitize_value(value: Any, *, secret_values: set[str], key: str | None = None) -> Any:
+    if key == "agent_env":
+        sanitized_items = []
+        for item in value or []:
+            sanitized_item, secret = _sanitize_env_item(str(item))
+            sanitized_items.append(sanitized_item)
+            if secret:
+                secret_values.add(secret)
+        return sanitized_items
+    if key is not None and is_sensitive_name(key):
+        _collect_scalar_secrets(value, secret_values)
+        return REDACTED
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): _sanitize_value(item_value, secret_values=secret_values, key=str(item_key))
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_sanitize_value(item, secret_values=secret_values) for item in value]
+    return value
+
+
+def _sanitize_env_item(item: str) -> tuple[str, str | None]:
+    if "=" not in item:
+        return REDACTED, item or None
+    key, value = item.split("=", 1)
+    return f"{key}={REDACTED}", value or None
+
+
+def _collect_scalar_secrets(value: Any, secret_values: set[str]) -> None:
+    if isinstance(value, Mapping):
+        for item in value.values():
+            _collect_scalar_secrets(item, secret_values)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            _collect_scalar_secrets(item, secret_values)
+    elif value is not None:
+        secret_values.add(str(value))
+
+
+def _replace_secret_literals(value: Any, secret_values: set[str]) -> Any:
+    if isinstance(value, str):
+        return sanitize_text(value, secret_values)
+    if isinstance(value, Mapping):
+        return {key: _replace_secret_literals(item, secret_values) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_replace_secret_literals(item, secret_values) for item in value]
+    return value

--- a/relax/utils/doctor/sanitizer.py
+++ b/relax/utils/doctor/sanitizer.py
@@ -115,9 +115,14 @@ def _sanitize_json_mapping(value: str, secret_values: set[str]) -> str:
     try:
         parsed = json.loads(value)
     except (TypeError, ValueError):
-        return sanitize_text(value, secret_values) or ""
+        if value:
+            secret_values.add(value)
+        return REDACTED
     if not isinstance(parsed, Mapping):
-        return sanitize_text(value, secret_values) or ""
+        _collect_scalar_secrets(parsed, secret_values)
+        if value:
+            secret_values.add(value)
+        return REDACTED
     sanitized = _sanitize_value(parsed, secret_values=secret_values)
     return json.dumps(sanitized, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
 
@@ -131,6 +136,9 @@ def _sanitize_value(value: Any, *, secret_values: set[str], key: str | None = No
             if secret:
                 secret_values.add(secret)
         return sanitized_items
+    if key is not None and _normalize_name(key) in _STRUCTURED_SECRET_OPTIONS and not isinstance(value, Mapping):
+        _collect_scalar_secrets(value, secret_values)
+        return REDACTED
     if key is not None and is_sensitive_name(key):
         _collect_scalar_secrets(value, secret_values)
         return REDACTED

--- a/relax/utils/doctor/topology.py
+++ b/relax/utils/doctor/topology.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+_SCALAR_TYPES = (str, int, float, bool, type(None))
+
+_RL_ALGOS = {"grpo", "gspo", "sapo", "cispo"}
+_PPO_ALGO = "ppo"
+_SFT_ALGO = "sft"
+KNOWN_ALGOS = sorted([*_RL_ALGOS, _PPO_ALGO, _SFT_ALGO])
+
+
+def serialize_config(args: Any | None) -> dict[str, Any]:
+    if args is None:
+        return {}
+    values = vars(args) if hasattr(args, "__dict__") else {}
+    return {key: _to_jsonable(value) for key, value in sorted(values.items())}
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, _SCALAR_TYPES):
+        return value
+    if isinstance(value, Mapping):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_to_jsonable(item) for item in value]
+    return repr(value)
+
+
+def resolve_algo_key(args: Any) -> str:
+    if getattr(args, "loss_type", None) == _SFT_ALGO:
+        return _SFT_ALGO
+    return str(getattr(args, "advantage_estimator", "grpo"))
+
+
+def expected_base_roles(args: Any) -> list[str]:
+    if getattr(args, "debug_rollout_only", False):
+        return ["rollout"]
+    if getattr(args, "debug_train_only", False):
+        return ["actor"]
+    if getattr(args, "loss_type", None) == _SFT_ALGO:
+        return ["sft", "actor"]
+
+    algo_key = resolve_algo_key(args)
+    if algo_key == _PPO_ALGO:
+        if getattr(args, "fully_async", False):
+            roles = ["actor", "critic", "rollout", "advantages", "reference"]
+            if not getattr(args, "true_on_policy_mode", False):
+                roles.append("actor_fwd")
+            return roles
+        return ["actor", "critic", "rollout"]
+
+    if getattr(args, "hybrid", False):
+        return ["actor", "rollout"]
+    if getattr(args, "fully_async", False):
+        roles = ["actor", "rollout", "advantages", "reference"]
+        if not getattr(args, "true_on_policy_mode", False):
+            roles.append("actor_fwd")
+        return roles
+    return ["actor", "rollout"]
+
+
+def optional_roles(args: Any) -> list[str]:
+    roles: list[str] = []
+    if getattr(args, "genrm_model_path", None):
+        roles.append("genrm")
+    if getattr(args, "loss_type", None) == _SFT_ALGO and getattr(args, "sft_predict_interval", None) is not None:
+        roles.append("rollout")
+    return roles
+
+
+def actor_rollout_pg_roles(args: Any) -> list[str]:
+    roles = ["actor", "rollout", "genrm"]
+    resource = _resource(args)
+    if resolve_algo_key(args) == _PPO_ALGO and resource.get("critic") == resource.get("actor"):
+        roles.append("critic")
+    return roles
+
+
+def build_topology_plan(args: Any | None) -> dict[str, Any]:
+    if args is None:
+        return {}
+
+    resource = _resource(args)
+    algo_key = resolve_algo_key(args)
+    base_roles = expected_base_roles(args)
+    extras = optional_roles(args)
+    roles = _unique(base_roles + extras)
+    role_names = set(roles)
+    colocate = bool(getattr(args, "colocate", False) and {"actor", "rollout"}.issubset(role_names))
+    pg_roles = actor_rollout_pg_roles(args)
+
+    role_entries = []
+    missing_roles = []
+    invalid_resources = []
+    for role in roles:
+        spec = resource.get(role)
+        if spec is None:
+            missing_roles.append(role)
+            role_entries.append({"role": role, "status": "missing_resource"})
+            continue
+        parsed = _parse_resource_spec(spec)
+        if parsed is None:
+            invalid_resources.append(role)
+            role_entries.append({"role": role, "status": "invalid_resource", "raw": spec})
+            continue
+        num_serves, num_gpus = parsed
+        role_entries.append(
+            {
+                "role": role,
+                "status": "planned",
+                "num_serves": num_serves,
+                "num_gpus": num_gpus,
+                "placement_group": _placement_group_for_role(role, colocate, pg_roles, args),
+            }
+        )
+
+    resource_summary = _resource_summary(role_entries, colocate, pg_roles)
+    data_system = _data_system_plan(args)
+    startup = {
+        "service_creation": "parallel" if getattr(args, "fully_async", False) else "serial",
+        "will_start_ray": False,
+        "will_start_sglang": False,
+        "will_start_training_workers": False,
+    }
+    return {
+        "algo_key": algo_key,
+        "known_algorithms": KNOWN_ALGOS,
+        "base_roles": base_roles,
+        "optional_roles": extras,
+        "roles": roles,
+        "role_plan": role_entries,
+        "missing_resource_roles": missing_roles,
+        "invalid_resource_roles": invalid_resources,
+        "colocate": colocate,
+        "hybrid": bool(getattr(args, "hybrid", False)),
+        "actor_rollout_pg_roles": pg_roles,
+        "resource_summary": resource_summary,
+        "data_system": data_system,
+        "startup": startup,
+    }
+
+
+def _resource(args: Any) -> dict[str, Any]:
+    resource = getattr(args, "resource", None)
+    return resource if isinstance(resource, dict) else {}
+
+
+def _parse_resource_spec(spec: Any) -> tuple[int, int] | None:
+    if not isinstance(spec, Sequence) or isinstance(spec, (str, bytes, bytearray)):
+        return None
+    if len(spec) != 2:
+        return None
+    num_serves, num_gpus = spec
+    if not isinstance(num_serves, int) or not isinstance(num_gpus, int):
+        return None
+    return num_serves, num_gpus
+
+
+def _placement_group_for_role(role: str, colocate: bool, pg_roles: list[str], args: Any) -> str:
+    if colocate and not getattr(args, "hybrid", False) and role in pg_roles:
+        return "actor_rollout_shared"
+    if role in {"advantages", "sft"}:
+        return "none"
+    return "dedicated"
+
+
+def _resource_summary(role_entries: list[dict[str, Any]], colocate: bool, pg_roles: list[str]) -> dict[str, Any]:
+    planned = [entry for entry in role_entries if entry.get("status") == "planned"]
+    if colocate:
+        shared_gpu = max((entry["num_gpus"] for entry in planned if entry["role"] in pg_roles), default=0)
+        independent_gpu = sum(entry["num_gpus"] for entry in planned if entry["role"] not in pg_roles)
+        total_required = shared_gpu + independent_gpu
+    else:
+        shared_gpu = 0
+        independent_gpu = sum(entry["num_gpus"] for entry in planned)
+        total_required = independent_gpu
+    return {
+        "shared_gpu": shared_gpu,
+        "independent_gpu": independent_gpu,
+        "total_required_gpus": total_required,
+        "role_gpus": {entry["role"]: entry["num_gpus"] for entry in planned},
+    }
+
+
+def _data_system_plan(args: Any) -> dict[str, Any]:
+    rollout_batch_size = getattr(args, "rollout_batch_size", None)
+    over_sampling_batch_size = getattr(args, "over_sampling_batch_size", None) or rollout_batch_size
+    batch_size_for_capacity = (
+        over_sampling_batch_size
+        if getattr(args, "partial_rollout", False) and getattr(args, "use_dynamic_global_batch_size", False)
+        else rollout_batch_size
+    )
+    if getattr(args, "fully_async", False) and getattr(args, "use_dynamic_batch_size", False):
+        sampler = "StreamingTokenBudgetSampler"
+    elif resolve_algo_key(args) == _SFT_ALGO or getattr(args, "balance_data", False):
+        sampler = "SeqlenBalancedSampler"
+    else:
+        sampler = "GRPOGroupNSampler"
+
+    storage_size = None
+    if batch_size_for_capacity is not None:
+        storage_size = (
+            batch_size_for_capacity
+            * (getattr(args, "max_staleness", 0) + 1)
+            * getattr(args, "n_samples_per_prompt", 1)
+        )
+    return {
+        "sampler": sampler,
+        "batch_size_for_capacity": batch_size_for_capacity,
+        "total_storage_size": storage_size,
+        "num_data_storage_units": getattr(args, "num_data_storage_units", None),
+    }
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/relax/utils/doctor/topology.py
+++ b/relax/utils/doctor/topology.py
@@ -37,7 +37,7 @@ def resolve_algo_key(args: Any) -> str:
     return str(getattr(args, "advantage_estimator", "grpo"))
 
 
-def expected_base_roles(args: Any) -> list[str]:
+def candidate_base_roles(args: Any) -> list[str]:
     if getattr(args, "debug_rollout_only", False):
         return ["rollout"]
     if getattr(args, "debug_train_only", False):
@@ -49,7 +49,7 @@ def expected_base_roles(args: Any) -> list[str]:
     if algo_key == _PPO_ALGO:
         if getattr(args, "fully_async", False):
             roles = ["actor", "critic", "rollout", "advantages", "reference"]
-            if not getattr(args, "true_on_policy_mode", False):
+            if not _is_effective_true_on_policy(args):
                 roles.append("actor_fwd")
             return roles
         return ["actor", "critic", "rollout"]
@@ -58,10 +58,31 @@ def expected_base_roles(args: Any) -> list[str]:
         return ["actor", "rollout"]
     if getattr(args, "fully_async", False):
         roles = ["actor", "rollout", "advantages", "reference"]
-        if not getattr(args, "true_on_policy_mode", False):
+        if not _is_effective_true_on_policy(args):
             roles.append("actor_fwd")
         return roles
     return ["actor", "rollout"]
+
+
+def required_base_roles(args: Any) -> list[str]:
+    candidates = candidate_base_roles(args)
+    if getattr(args, "debug_rollout_only", False) or getattr(args, "debug_train_only", False):
+        return candidates
+    if getattr(args, "loss_type", None) == _SFT_ALGO:
+        return candidates
+    if resolve_algo_key(args) == _PPO_ALGO:
+        return ["actor", "critic", "rollout"]
+    if getattr(args, "hybrid", False):
+        return ["actor", "rollout"]
+    if not getattr(args, "fully_async", False):
+        return ["actor", "rollout"]
+
+    roles = ["actor", "rollout", "advantages"]
+    if _needs_reference(args):
+        roles.append("reference")
+    if not _is_effective_true_on_policy(args):
+        roles.append("actor_fwd")
+    return roles
 
 
 def optional_roles(args: Any) -> list[str]:
@@ -87,11 +108,14 @@ def build_topology_plan(args: Any | None) -> dict[str, Any]:
 
     resource = _resource(args)
     algo_key = resolve_algo_key(args)
-    base_roles = expected_base_roles(args)
+    candidates = candidate_base_roles(args)
+    required_roles = required_base_roles(args)
     extras = optional_roles(args)
-    roles = _unique(base_roles + extras)
+    required_roles = _unique(required_roles + extras)
+    roles = _unique([role for role in candidates if role in resource or role in required_roles] + extras)
     role_names = set(roles)
     colocate = bool(getattr(args, "colocate", False) and {"actor", "rollout"}.issubset(role_names))
+    shares_actor_rollout_pg = colocate and not (getattr(args, "fully_async", False) or getattr(args, "hybrid", False))
     pg_roles = actor_rollout_pg_roles(args)
 
     role_entries = []
@@ -100,8 +124,9 @@ def build_topology_plan(args: Any | None) -> dict[str, Any]:
     for role in roles:
         spec = resource.get(role)
         if spec is None:
-            missing_roles.append(role)
-            role_entries.append({"role": role, "status": "missing_resource"})
+            if role in required_roles:
+                missing_roles.append(role)
+                role_entries.append({"role": role, "status": "missing_resource"})
             continue
         parsed = _parse_resource_spec(spec)
         if parsed is None:
@@ -115,14 +140,16 @@ def build_topology_plan(args: Any | None) -> dict[str, Any]:
                 "status": "planned",
                 "num_serves": num_serves,
                 "num_gpus": num_gpus,
-                "placement_group": _placement_group_for_role(role, colocate, pg_roles, args),
+                "placement_group": _placement_group_for_role(role, shares_actor_rollout_pg, pg_roles),
             }
         )
 
-    resource_summary = _resource_summary(role_entries, colocate, pg_roles)
+    resource_summary = _resource_summary(role_entries, shares_actor_rollout_pg, pg_roles)
     data_system = _data_system_plan(args)
     startup = {
-        "service_creation": "parallel" if getattr(args, "fully_async", False) else "serial",
+        "service_creation": (
+            "parallel" if getattr(args, "fully_async", False) or getattr(args, "hybrid", False) else "serial"
+        ),
         "will_start_ray": False,
         "will_start_sglang": False,
         "will_start_training_workers": False,
@@ -130,7 +157,8 @@ def build_topology_plan(args: Any | None) -> dict[str, Any]:
     return {
         "algo_key": algo_key,
         "known_algorithms": KNOWN_ALGOS,
-        "base_roles": base_roles,
+        "candidate_roles": candidates,
+        "required_roles": required_roles,
         "optional_roles": extras,
         "roles": roles,
         "role_plan": role_entries,
@@ -138,6 +166,7 @@ def build_topology_plan(args: Any | None) -> dict[str, Any]:
         "invalid_resource_roles": invalid_resources,
         "colocate": colocate,
         "hybrid": bool(getattr(args, "hybrid", False)),
+        "shares_actor_rollout_pg": shares_actor_rollout_pg,
         "actor_rollout_pg_roles": pg_roles,
         "resource_summary": resource_summary,
         "data_system": data_system,
@@ -161,17 +190,19 @@ def _parse_resource_spec(spec: Any) -> tuple[int, int] | None:
     return num_serves, num_gpus
 
 
-def _placement_group_for_role(role: str, colocate: bool, pg_roles: list[str], args: Any) -> str:
-    if colocate and not getattr(args, "hybrid", False) and role in pg_roles:
+def _placement_group_for_role(role: str, shares_actor_rollout_pg: bool, pg_roles: list[str]) -> str:
+    if shares_actor_rollout_pg and role in pg_roles:
         return "actor_rollout_shared"
     if role in {"advantages", "sft"}:
         return "none"
     return "dedicated"
 
 
-def _resource_summary(role_entries: list[dict[str, Any]], colocate: bool, pg_roles: list[str]) -> dict[str, Any]:
+def _resource_summary(
+    role_entries: list[dict[str, Any]], shares_actor_rollout_pg: bool, pg_roles: list[str]
+) -> dict[str, Any]:
     planned = [entry for entry in role_entries if entry.get("status") == "planned"]
-    if colocate:
+    if shares_actor_rollout_pg:
         shared_gpu = max((entry["num_gpus"] for entry in planned if entry["role"] in pg_roles), default=0)
         independent_gpu = sum(entry["num_gpus"] for entry in planned if entry["role"] not in pg_roles)
         total_required = shared_gpu + independent_gpu
@@ -185,6 +216,25 @@ def _resource_summary(role_entries: list[dict[str, Any]], colocate: bool, pg_rol
         "total_required_gpus": total_required,
         "role_gpus": {entry["role"]: entry["num_gpus"] for entry in planned},
     }
+
+
+def _needs_reference(args: Any) -> bool:
+    return bool(getattr(args, "use_kl_loss", False) or getattr(args, "kl_coef", 0) != 0)
+
+
+def _is_effective_true_on_policy(args: Any) -> bool:
+    if getattr(args, "true_on_policy_mode", False):
+        return True
+    if not getattr(args, "fully_async", False):
+        return False
+    rollout_batch_size = getattr(args, "rollout_batch_size", None)
+    global_batch_size = getattr(args, "global_batch_size", None)
+    n_samples_per_prompt = getattr(args, "n_samples_per_prompt", 1)
+    return (
+        rollout_batch_size is not None
+        and global_batch_size is not None
+        and rollout_batch_size * n_samples_per_prompt == global_batch_size
+    )
 
 
 def _data_system_plan(args: Any) -> dict[str, Any]:

--- a/relax/utils/doctor/topology.py
+++ b/relax/utils/doctor/topology.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from relax.core.service_plan import build_service_plan, resolve_algo_key
+
 
 _SCALAR_TYPES = (str, int, float, bool, type(None))
-
-_RL_ALGOS = {"grpo", "gspo", "sapo", "cispo"}
-_PPO_ALGO = "ppo"
-_SFT_ALGO = "sft"
-KNOWN_ALGOS = sorted([*_RL_ALGOS, _PPO_ALGO, _SFT_ALGO])
 
 
 def serialize_config(args: Any | None) -> dict[str, Any]:
@@ -31,210 +28,13 @@ def _to_jsonable(value: Any) -> Any:
     return repr(value)
 
 
-def resolve_algo_key(args: Any) -> str:
-    if getattr(args, "loss_type", None) == _SFT_ALGO:
-        return _SFT_ALGO
-    return str(getattr(args, "advantage_estimator", "grpo"))
-
-
-def candidate_base_roles(args: Any) -> list[str]:
-    if getattr(args, "debug_rollout_only", False):
-        return ["rollout"]
-    if getattr(args, "debug_train_only", False):
-        return ["actor"]
-    if getattr(args, "loss_type", None) == _SFT_ALGO:
-        return ["sft", "actor"]
-
-    algo_key = resolve_algo_key(args)
-    if algo_key == _PPO_ALGO:
-        if getattr(args, "fully_async", False):
-            roles = ["actor", "critic", "rollout", "advantages", "reference"]
-            if not _is_effective_true_on_policy(args):
-                roles.append("actor_fwd")
-            return roles
-        return ["actor", "critic", "rollout"]
-
-    if getattr(args, "hybrid", False):
-        return ["actor", "rollout"]
-    if getattr(args, "fully_async", False):
-        roles = ["actor", "rollout", "advantages", "reference"]
-        if not _is_effective_true_on_policy(args):
-            roles.append("actor_fwd")
-        return roles
-    return ["actor", "rollout"]
-
-
-def required_base_roles(args: Any) -> list[str]:
-    candidates = candidate_base_roles(args)
-    if getattr(args, "debug_rollout_only", False) or getattr(args, "debug_train_only", False):
-        return candidates
-    if getattr(args, "loss_type", None) == _SFT_ALGO:
-        return candidates
-    if resolve_algo_key(args) == _PPO_ALGO:
-        return ["actor", "critic", "rollout"]
-    if getattr(args, "hybrid", False):
-        return ["actor", "rollout"]
-    if not getattr(args, "fully_async", False):
-        return ["actor", "rollout"]
-
-    roles = ["actor", "rollout", "advantages"]
-    if _needs_reference(args):
-        roles.append("reference")
-    if not _is_effective_true_on_policy(args):
-        roles.append("actor_fwd")
-    return roles
-
-
-def optional_roles(args: Any) -> list[str]:
-    roles: list[str] = []
-    if getattr(args, "genrm_model_path", None):
-        roles.append("genrm")
-    if getattr(args, "loss_type", None) == _SFT_ALGO and getattr(args, "sft_predict_interval", None) is not None:
-        roles.append("rollout")
-    return roles
-
-
-def actor_rollout_pg_roles(args: Any) -> list[str]:
-    roles = ["actor", "rollout", "genrm"]
-    resource = _resource(args)
-    if resolve_algo_key(args) == _PPO_ALGO and resource.get("critic") == resource.get("actor"):
-        roles.append("critic")
-    return roles
-
-
 def build_topology_plan(args: Any | None) -> dict[str, Any]:
     if args is None:
         return {}
 
-    resource = _resource(args)
-    algo_key = resolve_algo_key(args)
-    candidates = candidate_base_roles(args)
-    required_roles = required_base_roles(args)
-    extras = optional_roles(args)
-    required_roles = _unique(required_roles + extras)
-    roles = _unique([role for role in candidates if role in resource or role in required_roles] + extras)
-    role_names = set(roles)
-    colocate = bool(getattr(args, "colocate", False) and {"actor", "rollout"}.issubset(role_names))
-    shares_actor_rollout_pg = colocate and not (getattr(args, "fully_async", False) or getattr(args, "hybrid", False))
-    pg_roles = actor_rollout_pg_roles(args)
-
-    role_entries = []
-    missing_roles = []
-    invalid_resources = []
-    for role in roles:
-        spec = resource.get(role)
-        if spec is None:
-            if role in required_roles:
-                missing_roles.append(role)
-                role_entries.append({"role": role, "status": "missing_resource"})
-            continue
-        parsed = _parse_resource_spec(spec)
-        if parsed is None:
-            invalid_resources.append(role)
-            role_entries.append({"role": role, "status": "invalid_resource", "raw": spec})
-            continue
-        num_serves, num_gpus = parsed
-        role_entries.append(
-            {
-                "role": role,
-                "status": "planned",
-                "num_serves": num_serves,
-                "num_gpus": num_gpus,
-                "placement_group": _placement_group_for_role(role, shares_actor_rollout_pg, pg_roles),
-            }
-        )
-
-    resource_summary = _resource_summary(role_entries, shares_actor_rollout_pg, pg_roles)
-    data_system = _data_system_plan(args)
-    startup = {
-        "service_creation": (
-            "parallel" if getattr(args, "fully_async", False) or getattr(args, "hybrid", False) else "serial"
-        ),
-        "will_start_ray": False,
-        "will_start_sglang": False,
-        "will_start_training_workers": False,
-    }
-    return {
-        "algo_key": algo_key,
-        "known_algorithms": KNOWN_ALGOS,
-        "candidate_roles": candidates,
-        "required_roles": required_roles,
-        "optional_roles": extras,
-        "roles": roles,
-        "role_plan": role_entries,
-        "missing_resource_roles": missing_roles,
-        "invalid_resource_roles": invalid_resources,
-        "colocate": colocate,
-        "hybrid": bool(getattr(args, "hybrid", False)),
-        "shares_actor_rollout_pg": shares_actor_rollout_pg,
-        "actor_rollout_pg_roles": pg_roles,
-        "resource_summary": resource_summary,
-        "data_system": data_system,
-        "startup": startup,
-    }
-
-
-def _resource(args: Any) -> dict[str, Any]:
-    resource = getattr(args, "resource", None)
-    return resource if isinstance(resource, dict) else {}
-
-
-def _parse_resource_spec(spec: Any) -> tuple[int, int] | None:
-    if not isinstance(spec, Sequence) or isinstance(spec, (str, bytes, bytearray)):
-        return None
-    if len(spec) != 2:
-        return None
-    num_serves, num_gpus = spec
-    if not isinstance(num_serves, int) or not isinstance(num_gpus, int):
-        return None
-    return num_serves, num_gpus
-
-
-def _placement_group_for_role(role: str, shares_actor_rollout_pg: bool, pg_roles: list[str]) -> str:
-    if shares_actor_rollout_pg and role in pg_roles:
-        return "actor_rollout_shared"
-    if role in {"advantages", "sft"}:
-        return "none"
-    return "dedicated"
-
-
-def _resource_summary(
-    role_entries: list[dict[str, Any]], shares_actor_rollout_pg: bool, pg_roles: list[str]
-) -> dict[str, Any]:
-    planned = [entry for entry in role_entries if entry.get("status") == "planned"]
-    if shares_actor_rollout_pg:
-        shared_gpu = max((entry["num_gpus"] for entry in planned if entry["role"] in pg_roles), default=0)
-        independent_gpu = sum(entry["num_gpus"] for entry in planned if entry["role"] not in pg_roles)
-        total_required = shared_gpu + independent_gpu
-    else:
-        shared_gpu = 0
-        independent_gpu = sum(entry["num_gpus"] for entry in planned)
-        total_required = independent_gpu
-    return {
-        "shared_gpu": shared_gpu,
-        "independent_gpu": independent_gpu,
-        "total_required_gpus": total_required,
-        "role_gpus": {entry["role"]: entry["num_gpus"] for entry in planned},
-    }
-
-
-def _needs_reference(args: Any) -> bool:
-    return bool(getattr(args, "use_kl_loss", False) or getattr(args, "kl_coef", 0) != 0)
-
-
-def _is_effective_true_on_policy(args: Any) -> bool:
-    if getattr(args, "true_on_policy_mode", False):
-        return True
-    if not getattr(args, "fully_async", False):
-        return False
-    rollout_batch_size = getattr(args, "rollout_batch_size", None)
-    global_batch_size = getattr(args, "global_batch_size", None)
-    n_samples_per_prompt = getattr(args, "n_samples_per_prompt", 1)
-    return (
-        rollout_batch_size is not None
-        and global_batch_size is not None
-        and rollout_batch_size * n_samples_per_prompt == global_batch_size
-    )
+    topology = build_service_plan(args).to_dict()
+    topology["data_system"] = _data_system_plan(args)
+    return topology
 
 
 def _data_system_plan(args: Any) -> dict[str, Any]:
@@ -247,7 +47,7 @@ def _data_system_plan(args: Any) -> dict[str, Any]:
     )
     if getattr(args, "fully_async", False) and getattr(args, "use_dynamic_batch_size", False):
         sampler = "StreamingTokenBudgetSampler"
-    elif resolve_algo_key(args) == _SFT_ALGO or getattr(args, "balance_data", False):
+    elif resolve_algo_key(args) == "sft" or getattr(args, "balance_data", False):
         sampler = "SeqlenBalancedSampler"
     else:
         sampler = "GRPOGroupNSampler"
@@ -265,14 +65,3 @@ def _data_system_plan(args: Any) -> dict[str, Any]:
         "total_storage_size": storage_size,
         "num_data_storage_units": getattr(args, "num_data_storage_units", None),
     }
-
-
-def _unique(values: list[str]) -> list[str]:
-    seen = set()
-    result = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        result.append(value)
-    return result

--- a/relax/utils/opd/opd_utils.py
+++ b/relax/utils/opd/opd_utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import torch
 import torch.distributed as dist
 
+from relax.core.service_plan import is_managed_teacher_colocate, is_managed_teacher_enabled
 from relax.utils.logging_utils import get_logger
 from relax.utils.opd import opd_opsd_worker
 
@@ -62,26 +63,11 @@ _SGLANG_PASSTHROUGH_SKIP_ARGS = (
 
 
 def is_managed_opd_teacher_enabled(args: Any) -> bool:
-    return (
-        getattr(args, "use_opd", False)
-        and getattr(args, "opd_type", None) == "sglang"
-        and (
-            getattr(args, "teacher_hf_checkpoint", None) is not None
-            or getattr(args, "opd_teacher_routes", None) is not None
-        )
-        and getattr(args, "resource", None) is not None
-        and "teacher" in args.resource
-    )
+    return is_managed_teacher_enabled(args)
 
 
 def is_managed_opd_teacher_colocate(args: Any) -> bool:
-    return (
-        is_managed_opd_teacher_enabled(args)
-        and getattr(args, "colocate", False)
-        and not getattr(args, "hybrid", False)
-        and "actor" in args.resource
-        and "rollout" in args.resource
-    )
+    return is_managed_teacher_colocate(args)
 
 
 def _mirror_teacher_sglang_server_args(parser: Any) -> None:

--- a/relax/utils/opd/opd_utils.py
+++ b/relax/utils/opd/opd_utils.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, Any, Callable
 import torch
 import torch.distributed as dist
 
-from relax.core.service_plan import is_managed_teacher_colocate, is_managed_teacher_enabled
+from relax.core.service_plan import (
+    is_managed_teacher_colocate,
+    is_managed_teacher_enabled,
+    should_start_managed_teacher,
+)
 from relax.utils.logging_utils import get_logger
 from relax.utils.opd import opd_opsd_worker
 
@@ -175,7 +179,7 @@ def create_managed_opd_teacher_manager(
 
 
 def maybe_start_managed_opd_teacher(args: Any, *, runtime_env: dict | None = None) -> tuple[Any, Any]:
-    if not is_managed_opd_teacher_enabled(args) or getattr(args, "debug_train_only", False):
+    if not should_start_managed_teacher(args):
         return None, None
 
     # ── Multi-teacher (MOPD) path: --opd-teacher-routes ────────────────────

--- a/tests/core/test_service_plan.py
+++ b/tests/core/test_service_plan.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from types import SimpleNamespace
+
+from relax.core.service_plan import build_service_plan
+
+
+def _config(**overrides) -> SimpleNamespace:
+    values = {
+        "loss_type": "policy_loss",
+        "advantage_estimator": "grpo",
+        "debug_rollout_only": False,
+        "debug_train_only": False,
+        "fully_async": False,
+        "hybrid": False,
+        "true_on_policy_mode": False,
+        "colocate": True,
+        "use_kl_loss": False,
+        "kl_coef": 0.0,
+        "genrm_model_path": None,
+        "sft_predict_interval": None,
+        "use_opd": False,
+        "opd_type": "sglang",
+        "teacher_hf_checkpoint": None,
+        "opd_teacher_routes": None,
+        "resource": {"actor": [1, 8], "rollout": [1, 8]},
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_service_plan_matches_sync_and_hybrid_placement():
+    sync_plan = build_service_plan(_config())
+    hybrid_plan = build_service_plan(_config(hybrid=True, fully_async=True))
+
+    assert sync_plan.roles == ("actor", "rollout")
+    assert sync_plan.shares_actor_rollout_pg is True
+    assert sync_plan.total_required_gpus == 8
+
+    assert hybrid_plan.roles == ("actor", "rollout")
+    assert hybrid_plan.shares_actor_rollout_pg is False
+    assert hybrid_plan.total_required_gpus == 16
+
+
+def test_service_plan_resolves_fully_async_conditional_roles():
+    resources = {
+        "actor": [1, 4],
+        "rollout": [1, 4],
+        "advantages": [1, 0],
+        "actor_fwd": [1, 2],
+    }
+    plan = build_service_plan(_config(fully_async=True, colocate=False, resource=resources))
+
+    assert plan.required_roles == ("actor", "rollout", "advantages", "actor_fwd")
+    assert "reference" not in plan.roles
+    assert plan.total_required_gpus == 10
+
+    kl_plan = build_service_plan(
+        _config(
+            fully_async=True,
+            colocate=False,
+            use_kl_loss=True,
+            resource=resources,
+        )
+    )
+    assert "reference" in kl_plan.required_roles
+    assert any(error.code == "missing_role" and error.role == "reference" for error in kl_plan.errors)
+
+
+def test_service_plan_keeps_explicit_optional_reference():
+    plan = build_service_plan(
+        _config(
+            fully_async=True,
+            colocate=False,
+            resource={
+                "actor": [1, 4],
+                "rollout": [1, 4],
+                "advantages": [1, 0],
+                "actor_fwd": [1, 2],
+                "reference": [1, 2],
+            },
+        )
+    )
+
+    assert "reference" not in plan.required_roles
+    assert "reference" in plan.roles
+    assert not plan.errors
+
+
+def test_service_plan_allows_only_cpu_roles_to_use_zero_gpus():
+    plan = build_service_plan(
+        _config(
+            fully_async=True,
+            colocate=False,
+            resource={
+                "actor": [1, 0],
+                "rollout": [1, 4],
+                "advantages": [1, 0],
+                "actor_fwd": [1, 2],
+            },
+        )
+    )
+
+    assert any(error.code == "gpu_required" and error.role == "actor" for error in plan.errors)
+    assert not any(error.code == "gpu_required" and error.role == "advantages" for error in plan.errors)
+
+
+def test_service_plan_handles_sft_and_debug_modes():
+    sft_plan = build_service_plan(
+        _config(
+            loss_type="sft",
+            resource={"sft": [1, 0], "actor": [1, 8]},
+        )
+    )
+    rollout_only_plan = build_service_plan(
+        _config(
+            debug_rollout_only=True,
+            resource={"rollout": [1, 4]},
+        )
+    )
+
+    assert sft_plan.roles == ("sft", "actor")
+    assert sft_plan.total_required_gpus == 8
+    assert rollout_only_plan.roles == ("rollout",)
+    assert rollout_only_plan.total_required_gpus == 4
+
+
+def test_service_plan_accounts_for_managed_teacher_placement():
+    shared = build_service_plan(
+        _config(
+            use_opd=True,
+            teacher_hf_checkpoint="/teacher",
+            resource={"actor": [1, 8], "rollout": [1, 4], "teacher": [1, 4]},
+        )
+    )
+    dedicated = build_service_plan(
+        _config(
+            colocate=False,
+            use_opd=True,
+            teacher_hf_checkpoint="/teacher",
+            resource={"actor": [1, 4], "rollout": [1, 4], "teacher": [1, 2]},
+        )
+    )
+
+    shared_teacher = next(spec for spec in shared.planned_specs if spec.role == "teacher")
+    dedicated_teacher = next(spec for spec in dedicated.planned_specs if spec.role == "teacher")
+    assert shared_teacher.placement_group == "actor_rollout_shared"
+    assert shared.total_required_gpus == 8
+    assert dedicated_teacher.placement_group == "dedicated"
+    assert dedicated.total_required_gpus == 10

--- a/tests/core/test_service_plan.py
+++ b/tests/core/test_service_plan.py
@@ -120,6 +120,30 @@ def test_service_plan_allows_only_cpu_roles_to_use_zero_gpus():
     assert not any(error.code == "gpu_required" and error.role == "advantages" for error in plan.errors)
 
 
+def test_service_plan_rejects_gpu_allocations_for_cpu_only_roles():
+    advantages_plan = build_service_plan(
+        _config(
+            fully_async=True,
+            colocate=False,
+            resource={
+                "actor": [1, 4],
+                "rollout": [1, 4],
+                "advantages": [1, 1],
+                "actor_fwd": [1, 2],
+            },
+        )
+    )
+    sft_plan = build_service_plan(
+        _config(
+            loss_type="sft",
+            resource={"sft": [1, 1], "actor": [1, 8]},
+        )
+    )
+
+    assert any(error.code == "cpu_gpu_forbidden" and error.role == "advantages" for error in advantages_plan.errors)
+    assert any(error.code == "cpu_gpu_forbidden" and error.role == "sft" for error in sft_plan.errors)
+
+
 def test_service_plan_handles_sft_and_debug_modes():
     sft_plan = build_service_plan(
         _config(

--- a/tests/core/test_service_plan.py
+++ b/tests/core/test_service_plan.py
@@ -42,6 +42,21 @@ def test_service_plan_matches_sync_and_hybrid_placement():
     assert hybrid_plan.total_required_gpus == 16
 
 
+def test_service_plan_sizes_shared_pg_for_largest_role():
+    plan = build_service_plan(
+        _config(
+            resource={
+                "actor": [1, 4],
+                "rollout": [1, 8],
+            }
+        )
+    )
+
+    assert plan.shares_actor_rollout_pg is True
+    assert plan.shared_gpu == 8
+    assert plan.total_required_gpus == 8
+
+
 def test_service_plan_resolves_fully_async_conditional_roles():
     resources = {
         "actor": [1, 4],

--- a/tests/core/test_service_plan.py
+++ b/tests/core/test_service_plan.py
@@ -163,3 +163,30 @@ def test_service_plan_accounts_for_managed_teacher_placement():
     assert shared.total_required_gpus == 8
     assert dedicated_teacher.placement_group == "dedicated"
     assert dedicated.total_required_gpus == 10
+
+
+def test_service_plan_matches_managed_teacher_debug_runtime_modes():
+    train_only = build_service_plan(
+        _config(
+            debug_train_only=True,
+            use_opd=True,
+            teacher_hf_checkpoint="/teacher",
+            resource={"actor": [1, 8], "teacher": [1, 8]},
+        )
+    )
+    rollout_only = build_service_plan(
+        _config(
+            debug_rollout_only=True,
+            colocate=False,
+            use_opd=True,
+            teacher_hf_checkpoint="/teacher",
+            resource={"rollout": [1, 4], "teacher": [1, 2]},
+        )
+    )
+
+    assert train_only.roles == ("actor",)
+    assert train_only.total_required_gpus == 8
+    assert all(spec.role != "teacher" for spec in train_only.service_specs)
+
+    assert rollout_only.roles == ("rollout", "teacher")
+    assert rollout_only.total_required_gpus == 6

--- a/tests/distributed/ray/test_opd_teacher_controller_colocate.py
+++ b/tests/distributed/ray/test_opd_teacher_controller_colocate.py
@@ -59,3 +59,24 @@ def test_managed_teacher_colocate_uses_full_shared_pg(monkeypatch):
         "runtime_env": {"env_vars": {"A": "B"}},
     }
     assert config.opd_teacher_url == "http://teacher/generate"
+
+
+def test_managed_teacher_runtime_skips_debug_train_only(monkeypatch):
+    from relax.utils.opd import opd_utils
+
+    def fail_if_started(*_args, **_kwargs):
+        raise AssertionError("teacher manager must not start")
+
+    monkeypatch.setattr(opd_utils, "create_managed_opd_teacher_manager", fail_if_started)
+    config = Namespace(
+        use_opd=True,
+        opd_type="sglang",
+        colocate=False,
+        hybrid=False,
+        debug_train_only=True,
+        resource={"actor": [1, 8], "teacher": [1, 8]},
+        teacher_hf_checkpoint="/teacher",
+        opd_teacher_routes=None,
+    )
+
+    assert opd_utils.maybe_start_managed_opd_teacher(config) == (None, None)

--- a/tests/doctor/fixtures/error_cases.json
+++ b/tests/doctor/fixtures/error_cases.json
@@ -1,0 +1,120 @@
+[
+  {
+    "name": "missing_resource",
+    "expected_rule": "CONFIG_RESOURCE_REQUIRED",
+    "config": {"resource": null}
+  },
+  {
+    "name": "invalid_resource_shape",
+    "expected_rule": "CONFIG_RESOURCE_SHAPE",
+    "config": {"resource": {"actor": [2, 8], "rollout": [1, 8]}}
+  },
+  {
+    "name": "unsupported_algorithm",
+    "expected_rule": "CONFIG_ALGORITHM_SUPPORTED",
+    "config": {"advantage_estimator": "unknown_algo"}
+  },
+  {
+    "name": "missing_required_role",
+    "expected_rule": "CONFIG_REQUIRED_ROLES",
+    "config": {"resource": {"actor": [1, 8]}}
+  },
+  {
+    "name": "mode_conflict",
+    "expected_rule": "CONFIG_MODE_CONFLICT",
+    "config": {"fully_async": true, "colocate": true, "hybrid": false}
+  },
+  {
+    "name": "debug_mode_conflict",
+    "expected_rule": "CONFIG_DEBUG_MODE_CONFLICT",
+    "config": {"debug_rollout_only": true, "debug_train_only": true}
+  },
+  {
+    "name": "ppo_missing_critic",
+    "expected_rule": "CONFIG_PPO_TOPOLOGY",
+    "config": {"advantage_estimator": "ppo", "resource": {"actor": [1, 8], "rollout": [1, 8]}}
+  },
+  {
+    "name": "sft_missing_prompt_data",
+    "expected_rule": "CONFIG_SFT_REQUIREMENTS",
+    "config": {"loss_type": "sft", "resource": {"sft": [1, 0], "actor": [1, 8]}, "prompt_data": null}
+  },
+  {
+    "name": "missing_batch_size",
+    "expected_rule": "CONFIG_BATCH_SIZE",
+    "config": {"rollout_batch_size": null, "global_batch_size": null}
+  },
+  {
+    "name": "missing_rollout_count",
+    "expected_rule": "CONFIG_ROLLOUT_COUNT",
+    "config": {"num_rollout": null, "num_epoch": null}
+  },
+  {
+    "name": "bad_oversampling",
+    "expected_rule": "CONFIG_OVERSAMPLING",
+    "config": {"over_sampling_batch_size": 2, "rollout_batch_size": 4}
+  },
+  {
+    "name": "dynamic_batch_without_budget",
+    "expected_rule": "CONFIG_DYNAMIC_BATCH",
+    "config": {"use_dynamic_batch_size": true, "max_tokens_per_gpu": null}
+  },
+  {
+    "name": "context_budget_too_small",
+    "expected_rule": "CONFIG_CONTEXT_LENGTH",
+    "config": {
+      "use_dynamic_batch_size": true,
+      "max_tokens_per_gpu": 1024,
+      "context_parallel_size": 1,
+      "rollout_max_context_len": 2048
+    }
+  },
+  {
+    "name": "sglang_bad_parallel",
+    "expected_rule": "CONFIG_SGLANG_PARALLEL",
+    "config": {"rollout_num_gpus_per_engine": 3, "sglang_pp_size": 2}
+  },
+  {
+    "name": "eval_interval_missing_dataset",
+    "expected_rule": "CONFIG_EVAL",
+    "config": {"eval_interval": 10, "eval_datasets": null, "eval_prompt_data": null}
+  },
+  {
+    "name": "save_interval_without_save",
+    "expected_rule": "CONFIG_SAVE",
+    "config": {"save_interval": 10, "save": null}
+  },
+  {
+    "name": "genrm_bad_split",
+    "expected_rule": "CONFIG_GENRM_COLOCATE",
+    "config": {
+      "genrm_model_path": "/tmp/genrm",
+      "colocate": true,
+      "rollout_num_gpus": 3,
+      "genrm_num_gpus": 3,
+      "actor_num_gpus_per_node": 8,
+      "actor_num_nodes": 1,
+      "resource": {"actor": [1, 8], "rollout": [1, 3], "genrm": [1, 3]}
+    }
+  },
+  {
+    "name": "missing_local_path",
+    "expected_rule": "CONFIG_PATHS",
+    "config": {"prompt_data": "./tests/doctor/fixtures/not_exists.jsonl"}
+  },
+  {
+    "name": "lora_conflict",
+    "expected_rule": "CONFIG_LORA",
+    "config": {"lora_rank": 8, "lora_merge_mode": true, "lora_adapter_mode": true}
+  },
+  {
+    "name": "qkv_dynamic_batch",
+    "expected_rule": "CONFIG_QKV_FORMAT",
+    "config": {"qkv_format": "bshd", "use_dynamic_batch_size": true}
+  },
+  {
+    "name": "rotate_ckpt_missing_options",
+    "expected_rule": "CONFIG_ROTATE_CKPT",
+    "config": {"rotate_ckpt": true, "save": null, "save_interval": null, "async_save": false}
+  }
+]

--- a/tests/doctor/fixtures/error_cases.json
+++ b/tests/doctor/fixtures/error_cases.json
@@ -2,62 +2,128 @@
   {
     "name": "missing_resource",
     "expected_rule": "CONFIG_RESOURCE_REQUIRED",
-    "config": {"resource": null}
+    "config": {
+      "resource": null
+    }
   },
   {
     "name": "invalid_resource_shape",
     "expected_rule": "CONFIG_RESOURCE_SHAPE",
-    "config": {"resource": {"actor": [2, 8], "rollout": [1, 8]}}
+    "config": {
+      "resource": {
+        "actor": [
+          2,
+          8
+        ],
+        "rollout": [
+          1,
+          8
+        ]
+      }
+    }
   },
   {
     "name": "unsupported_algorithm",
     "expected_rule": "CONFIG_ALGORITHM_SUPPORTED",
-    "config": {"advantage_estimator": "unknown_algo"}
+    "config": {
+      "advantage_estimator": "unknown_algo"
+    }
   },
   {
     "name": "missing_required_role",
     "expected_rule": "CONFIG_REQUIRED_ROLES",
-    "config": {"resource": {"actor": [1, 8]}}
+    "config": {
+      "resource": {
+        "actor": [
+          1,
+          8
+        ]
+      }
+    }
   },
   {
     "name": "mode_conflict",
     "expected_rule": "CONFIG_MODE_CONFLICT",
-    "config": {"fully_async": true, "colocate": true, "hybrid": false}
+    "config": {
+      "fully_async": true,
+      "colocate": true,
+      "hybrid": false
+    }
   },
   {
     "name": "debug_mode_conflict",
     "expected_rule": "CONFIG_DEBUG_MODE_CONFLICT",
-    "config": {"debug_rollout_only": true, "debug_train_only": true}
+    "config": {
+      "debug_rollout_only": true,
+      "debug_train_only": true
+    }
   },
   {
     "name": "ppo_missing_critic",
     "expected_rule": "CONFIG_PPO_TOPOLOGY",
-    "config": {"advantage_estimator": "ppo", "resource": {"actor": [1, 8], "rollout": [1, 8]}}
+    "config": {
+      "advantage_estimator": "ppo",
+      "resource": {
+        "actor": [
+          1,
+          8
+        ],
+        "rollout": [
+          1,
+          8
+        ]
+      }
+    }
   },
   {
     "name": "sft_missing_prompt_data",
     "expected_rule": "CONFIG_SFT_REQUIREMENTS",
-    "config": {"loss_type": "sft", "resource": {"sft": [1, 0], "actor": [1, 8]}, "prompt_data": null}
+    "config": {
+      "loss_type": "sft",
+      "resource": {
+        "sft": [
+          1,
+          0
+        ],
+        "actor": [
+          1,
+          8
+        ]
+      },
+      "prompt_data": null
+    }
   },
   {
     "name": "missing_batch_size",
     "expected_rule": "CONFIG_BATCH_SIZE",
-    "config": {"rollout_batch_size": null, "global_batch_size": null}
+    "config": {
+      "rollout_batch_size": null,
+      "global_batch_size": null
+    }
   },
   {
     "name": "missing_rollout_count",
     "expected_rule": "CONFIG_ROLLOUT_COUNT",
-    "config": {"num_rollout": null, "num_epoch": null}
+    "config": {
+      "num_rollout": null,
+      "num_epoch": null
+    }
   },
   {
     "name": "bad_oversampling",
     "expected_rule": "CONFIG_OVERSAMPLING",
-    "config": {"over_sampling_batch_size": 2, "rollout_batch_size": 4}
+    "config": {
+      "over_sampling_batch_size": 2,
+      "rollout_batch_size": 4
+    }
   },
   {
     "name": "dynamic_batch_without_budget",
     "expected_rule": "CONFIG_DYNAMIC_BATCH",
-    "config": {"use_dynamic_batch_size": true, "max_tokens_per_gpu": null}
+    "config": {
+      "use_dynamic_batch_size": true,
+      "max_tokens_per_gpu": null
+    }
   },
   {
     "name": "context_budget_too_small",
@@ -72,17 +138,27 @@
   {
     "name": "sglang_bad_parallel",
     "expected_rule": "CONFIG_SGLANG_PARALLEL",
-    "config": {"rollout_num_gpus_per_engine": 3, "sglang_pp_size": 2}
+    "config": {
+      "rollout_num_gpus_per_engine": 3,
+      "sglang_pp_size": 2
+    }
   },
   {
     "name": "eval_interval_missing_dataset",
     "expected_rule": "CONFIG_EVAL",
-    "config": {"eval_interval": 10, "eval_datasets": null, "eval_prompt_data": null}
+    "config": {
+      "eval_interval": 10,
+      "eval_datasets": null,
+      "eval_prompt_data": null
+    }
   },
   {
     "name": "save_interval_without_save",
     "expected_rule": "CONFIG_SAVE",
-    "config": {"save_interval": 10, "save": null}
+    "config": {
+      "save_interval": 10,
+      "save": null
+    }
   },
   {
     "name": "genrm_bad_split",
@@ -94,27 +170,54 @@
       "genrm_num_gpus": 3,
       "actor_num_gpus_per_node": 8,
       "actor_num_nodes": 1,
-      "resource": {"actor": [1, 8], "rollout": [1, 3], "genrm": [1, 3]}
+      "resource": {
+        "actor": [
+          1,
+          8
+        ],
+        "rollout": [
+          1,
+          3
+        ],
+        "genrm": [
+          1,
+          3
+        ]
+      }
     }
   },
   {
     "name": "missing_local_path",
     "expected_rule": "CONFIG_PATHS",
-    "config": {"prompt_data": "./tests/doctor/fixtures/not_exists.jsonl"}
+    "config": {
+      "prompt_data": "./tests/doctor/fixtures/not_exists.jsonl"
+    }
   },
   {
     "name": "lora_conflict",
     "expected_rule": "CONFIG_LORA",
-    "config": {"lora_rank": 8, "lora_merge_mode": true, "lora_adapter_mode": true}
+    "config": {
+      "lora_rank": 8,
+      "lora_merge_mode": true,
+      "lora_adapter_mode": true
+    }
   },
   {
     "name": "qkv_dynamic_batch",
     "expected_rule": "CONFIG_QKV_FORMAT",
-    "config": {"qkv_format": "bshd", "use_dynamic_batch_size": true}
+    "config": {
+      "qkv_format": "bshd",
+      "use_dynamic_batch_size": true
+    }
   },
   {
     "name": "rotate_ckpt_missing_options",
     "expected_rule": "CONFIG_ROTATE_CKPT",
-    "config": {"rotate_ckpt": true, "save": null, "save_interval": null, "async_save": false}
+    "config": {
+      "rotate_ckpt": true,
+      "save": null,
+      "save_interval": null,
+      "async_save": false
+    }
   }
 ]

--- a/tests/doctor/fixtures/error_cases.json
+++ b/tests/doctor/fixtures/error_cases.json
@@ -211,6 +211,29 @@
     }
   },
   {
+    "name": "zero_num_steps_per_rollout",
+    "expected_rule": "CONFIG_BATCH_SIZE",
+    "config": {
+      "num_steps_per_rollout": 0
+    }
+  },
+  {
+    "name": "zero_gpu_model_role",
+    "expected_rule": "CONFIG_RESOURCE_SHAPE",
+    "config": {
+      "resource": {
+        "actor": [
+          1,
+          0
+        ],
+        "rollout": [
+          1,
+          8
+        ]
+      }
+    }
+  },
+  {
     "name": "rotate_ckpt_missing_options",
     "expected_rule": "CONFIG_ROTATE_CKPT",
     "config": {

--- a/tests/doctor/test_doctor_entrypoint.py
+++ b/tests/doctor/test_doctor_entrypoint.py
@@ -220,3 +220,24 @@ def test_entrypoint_rejects_option_not_registered_by_any_parser(monkeypatch, cap
     assert '"--does-not-exist"' in output
     assert '"--num-rollout"' not in output.split('"unknown_options":', 1)[1].split("]", 1)[0]
     assert '"--backend-option"' not in output.split('"unknown_options":', 1)[1].split("]", 1)[0]
+
+
+def test_entrypoint_rejects_unknown_short_option_without_flagging_negative_value(monkeypatch, capsys):
+    def fake_parse_training_args(argv, *, validate=True):
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("--rollout-top-k", type=int)
+        parser.add_argument("-k", type=int)
+        parser.parse_known_args(argv)
+        return _args()
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(["--format", "json", "--", "--rollout-top-k", "-1", "-k8", "-x"])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert '"rule_id": "CONFIG_UNKNOWN_ARGUMENT"' in output
+    unknown_options = output.split('"unknown_options":', 1)[1].split("]", 1)[0]
+    assert '"-x"' in unknown_options
+    assert '"-1"' not in unknown_options
+    assert '"-k"' not in unknown_options

--- a/tests/doctor/test_doctor_entrypoint.py
+++ b/tests/doctor/test_doctor_entrypoint.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
+import argparse
 from types import SimpleNamespace
 
 from relax.entrypoints import doctor
@@ -164,3 +165,39 @@ def test_doctor_skip_hf_validate_is_forwarded(monkeypatch):
     assert doctor.main(["--doctor-skip-hf-validate", "--", "--num-rollout", "1"]) == 0
     assert captured["argv"] == ["--num-rollout", "1", "--skip-hf-validate"]
     assert captured["validate"] is True
+
+
+def test_entrypoint_rejects_option_not_registered_by_any_parser(monkeypatch, capsys):
+    def fake_parse_training_args(argv, *, validate=True):
+        relax_parser = argparse.ArgumentParser(add_help=False)
+        relax_parser.add_argument("--num-rollout")
+        relax_parser.parse_known_args(argv)
+
+        backend_parser = argparse.ArgumentParser(add_help=False)
+        backend_parser.add_argument("--backend-option")
+        backend_parser.parse_known_args(argv)
+        return _args()
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(
+        [
+            "--format",
+            "json",
+            "--",
+            "--num-rollout",
+            "1",
+            "--backend-option",
+            "enabled",
+            "--does-not-exist",
+            "123",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert '"rule_id": "CONFIG_UNKNOWN_ARGUMENT"' in output
+    assert '"unknown_options": [' in output
+    assert '"--does-not-exist"' in output
+    assert '"--num-rollout"' not in output.split('"unknown_options":', 1)[1].split("]", 1)[0]
+    assert '"--backend-option"' not in output.split('"unknown_options":', 1)[1].split("]", 1)[0]

--- a/tests/doctor/test_doctor_entrypoint.py
+++ b/tests/doctor/test_doctor_entrypoint.py
@@ -152,6 +152,25 @@ def test_partial_fallback_skips_rules_that_require_normalized_config(monkeypatch
     assert "CONFIG_ALGORITHM_SUPPORTED" not in output
 
 
+def test_partial_fallback_reports_zero_gpu_model_role(monkeypatch, capsys):
+    def fake_parse_training_args(_argv, *, validate=True):
+        if validate:
+            raise ValueError("resource role 'actor' requires num_gpus > 0")
+        args = _args()
+        args.resource = {"actor": [1, 0], "rollout": [1, 8]}
+        return args
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(["--format", "json", "--", "--resource", '{"actor": [1, 0], "rollout": [1, 8]}'])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert '"rule_id": "CONFIG_PARSE_ERROR"' in output
+    assert '"rule_id": "CONFIG_RESOURCE_SHAPE"' in output
+    assert "requires num_gpus > 0" in output
+
+
 def test_doctor_skip_hf_validate_is_forwarded(monkeypatch):
     captured = {}
 

--- a/tests/doctor/test_doctor_entrypoint.py
+++ b/tests/doctor/test_doctor_entrypoint.py
@@ -128,7 +128,27 @@ def test_entrypoint_falls_back_to_targeted_rules_after_validation_error(monkeypa
     assert code == 1
     assert calls == [True, False]
     assert '"rule_id": "CONFIG_MODE_CONFLICT"' in output
-    assert "CONFIG_PARSE_ERROR" not in output
+    assert '"rule_id": "CONFIG_PARSE_ERROR"' in output
+    assert '"config_state": "partial"' in output
+    assert '"topology": {}' in output
+
+
+def test_partial_fallback_skips_rules_that_require_normalized_config(monkeypatch, capsys):
+    def fake_parse_training_args(_argv, *, validate=True):
+        if validate:
+            raise ValueError("validation stopped before normalization")
+        args = _args()
+        args.advantage_estimator = "unknown"
+        return args
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(["--format", "json", "--", "--advantage-estimator", "unknown"])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert '"rule_id": "CONFIG_PARSE_ERROR"' in output
+    assert "CONFIG_ALGORITHM_SUPPORTED" not in output
 
 
 def test_doctor_skip_hf_validate_is_forwarded(monkeypatch):

--- a/tests/doctor/test_doctor_entrypoint.py
+++ b/tests/doctor/test_doctor_entrypoint.py
@@ -96,7 +96,7 @@ def test_entrypoint_returns_zero_for_valid_config(monkeypatch, capsys):
 
 
 def test_entrypoint_returns_nonzero_for_parse_error(monkeypatch, capsys):
-    def fake_parse_training_args(_argv):
+    def fake_parse_training_args(_argv, *, validate=True):
         raise ValueError("bad config")
 
     monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
@@ -108,14 +108,39 @@ def test_entrypoint_returns_nonzero_for_parse_error(monkeypatch, capsys):
     assert "CONFIG_PARSE_ERROR" in output
 
 
+def test_entrypoint_falls_back_to_targeted_rules_after_validation_error(monkeypatch, capsys):
+    calls = []
+
+    def fake_parse_training_args(_argv, *, validate=True):
+        calls.append(validate)
+        if validate:
+            raise ValueError("--fully-async and --colocate cannot be combined directly")
+        args = _args()
+        args.fully_async = True
+        args.colocate = True
+        return args
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(["--format", "json", "--", "--fully-async", "--colocate"])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert calls == [True, False]
+    assert '"rule_id": "CONFIG_MODE_CONFLICT"' in output
+    assert "CONFIG_PARSE_ERROR" not in output
+
+
 def test_doctor_skip_hf_validate_is_forwarded(monkeypatch):
     captured = {}
 
-    def fake_parse_training_args(argv):
+    def fake_parse_training_args(argv, *, validate=True):
         captured["argv"] = argv
+        captured["validate"] = validate
         return _args()
 
     monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
 
     assert doctor.main(["--doctor-skip-hf-validate", "--", "--num-rollout", "1"]) == 0
     assert captured["argv"] == ["--num-rollout", "1", "--skip-hf-validate"]
+    assert captured["validate"] is True

--- a/tests/doctor/test_doctor_entrypoint.py
+++ b/tests/doctor/test_doctor_entrypoint.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from types import SimpleNamespace
+
+from relax.entrypoints import doctor
+
+
+def _args() -> SimpleNamespace:
+    return SimpleNamespace(
+        advantage_estimator="grpo",
+        loss_type="policy_loss",
+        resource={"actor": [1, 8], "rollout": [1, 8]},
+        debug_rollout_only=False,
+        debug_train_only=False,
+        fully_async=False,
+        colocate=True,
+        hybrid=False,
+        true_on_policy_mode=False,
+        max_staleness=0,
+        rollout_batch_size=4,
+        global_batch_size=32,
+        n_samples_per_prompt=8,
+        num_steps_per_rollout=None,
+        num_rollout=1,
+        num_epoch=None,
+        rollout_global_dataset=True,
+        over_sampling_batch_size=4,
+        partial_rollout=False,
+        use_dynamic_global_batch_size=False,
+        use_dynamic_batch_size=False,
+        max_tokens_per_gpu=None,
+        context_parallel_size=1,
+        dynamic_context_parallel=False,
+        rollout_max_context_len=2048,
+        rollout_max_prompt_len=1024,
+        num_data_storage_units=1,
+        balance_data=False,
+        sglang_pp_size=1,
+        rollout_num_gpus_per_engine=1,
+        sglang_data_parallel_size=1,
+        sglang_enable_dp_attention=False,
+        prefill_num_servers=None,
+        rollout_external=False,
+        sglang_config=None,
+        eval_interval=None,
+        eval_config=None,
+        eval_prompt_data=None,
+        eval_datasets=None,
+        eval_size=None,
+        save_interval=None,
+        save="./outputs/doctor-ok",
+        sft_predict_interval=None,
+        custom_dataset_class_path=None,
+        prompt_data=None,
+        sft_oversize_strategy="drop",
+        sft_oversize_custom_function_path=None,
+        genrm_model_path=None,
+        genrm_num_gpus=1,
+        actor_num_gpus_per_node=8,
+        actor_num_nodes=1,
+        rollout_num_gpus=8,
+        lora_rank=0,
+        lora_merge_mode=False,
+        lora_adapter_mode=False,
+        sglang_dp_size=1,
+        qkv_format="thd",
+        train_backend="megatron",
+        rotate_ckpt=False,
+        async_save=False,
+        data_source_path="relax.engine.rollout.data_source.RolloutDataSourceWithBuffer",
+        rollout_function_path="relax.engine.rollout.sglang_rollout.generate_rollout",
+        eval_function_path="relax.engine.rollout.sglang_rollout.generate_rollout",
+        custom_config_path=None,
+        custom_reward_function_path=None,
+        kl_coef=0.0,
+        use_kl_loss=False,
+        ref_load=None,
+    )
+
+
+def test_entrypoint_returns_zero_for_valid_config(monkeypatch, capsys):
+    captured = {}
+
+    def fake_parse_training_args(argv):
+        captured["argv"] = argv
+        return _args()
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(["--format", "json", "--", "--num-rollout", "1"])
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert captured["argv"] == ["--num-rollout", "1"]
+    assert '"ok": true' in output
+
+
+def test_entrypoint_returns_nonzero_for_parse_error(monkeypatch, capsys):
+    def fake_parse_training_args(_argv):
+        raise ValueError("bad config")
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    code = doctor.main(["--", "--bad"])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "CONFIG_PARSE_ERROR" in output
+
+
+def test_doctor_skip_hf_validate_is_forwarded(monkeypatch):
+    captured = {}
+
+    def fake_parse_training_args(argv):
+        captured["argv"] = argv
+        return _args()
+
+    monkeypatch.setattr(doctor, "parse_training_args", fake_parse_training_args)
+
+    assert doctor.main(["--doctor-skip-hf-validate", "--", "--num-rollout", "1"]) == 0
+    assert captured["argv"] == ["--num-rollout", "1", "--skip-hf-validate"]

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -128,6 +128,25 @@ def test_hybrid_resource_preview_uses_dedicated_actor_and_rollout_gpus():
     assert {item["placement_group"] for item in report.topology["role_plan"]} == {"dedicated"}
 
 
+def test_debug_train_only_topology_excludes_managed_teacher():
+    args = _namespace(
+        {
+            "debug_train_only": True,
+            "use_opd": True,
+            "opd_type": "sglang",
+            "teacher_hf_checkpoint": "/teacher",
+            "resource": {"actor": [1, 8], "teacher": [1, 8]},
+        }
+    )
+
+    report = run_doctor(argv=[], args=args)
+
+    assert report.ok
+    assert report.topology["roles"] == ["actor"]
+    assert report.topology["resource_summary"]["total_required_gpus"] == 8
+    assert all(spec["role"] != "teacher" for spec in report.topology["role_plan"])
+
+
 def test_model_roles_reject_zero_gpu_resources():
     report = run_doctor(
         argv=[],

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -263,3 +263,63 @@ def test_text_and_json_reports_include_required_sections():
     assert json_report["command"] == ["python", "-m", "relax.entrypoints.train", "--num-rollout", "1"]
     assert "topology" in json_report
     assert "config" in json_report
+
+
+def test_report_redacts_agent_env_and_sensitive_options():
+    api_value = "api-value"
+    region_value = "region-value"
+    sglang_value = "server-value"
+    args = _namespace(
+        {
+            "agent_env": [f"OPENAI_API_KEY={api_value}", f"REGION={region_value}"],
+            "sglang_api_key": sglang_value,
+            "reward_key": "score",
+        }
+    )
+    report = run_doctor(
+        argv=[
+            "--agent-env",
+            f"OPENAI_API_KEY={api_value}",
+            f"REGION={region_value}",
+            "--sglang-api-key",
+            sglang_value,
+            "--reward-key",
+            "score",
+        ],
+        args=args,
+    )
+
+    text_report = render_text(report)
+    json_report = render_json(report)
+
+    for sensitive_value in (api_value, region_value, sglang_value):
+        assert sensitive_value not in text_report
+        assert sensitive_value not in json_report
+    assert report.config["agent_env"] == ["OPENAI_API_KEY=<redacted>", "REGION=<redacted>"]
+    assert report.config["sglang_api_key"] == "<redacted>"
+    assert report.config["reward_key"] == "score"
+    assert report.argv == [
+        "--agent-env",
+        "OPENAI_API_KEY=<redacted>",
+        "REGION=<redacted>",
+        "--sglang-api-key",
+        "<redacted>",
+        "--reward-key",
+        "score",
+    ]
+    assert report.command[-2:] == ["--reward-key", "score"]
+
+
+def test_parse_error_redacts_secret_from_raw_argv():
+    secret = "malformed-agent-secret"
+
+    report = run_doctor(
+        argv=["--agent-env", f"TOKEN={secret}", "--bad-flag"],
+        args=None,
+        parse_error=f"invalid agent env TOKEN={secret}",
+    )
+    output = render_json(report)
+
+    assert not report.ok
+    assert secret not in output
+    assert "TOKEN=<redacted>" in output

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -197,6 +197,38 @@ def test_fully_async_keeps_explicit_optional_reference_in_plan():
     assert "reference" in report.topology["roles"]
 
 
+def test_generalized_prompt_data_paths_are_checked_individually(tmp_path):
+    first = tmp_path / "first.jsonl"
+    second = tmp_path / "second.jsonl"
+    first.write_text("{}\n")
+    second.write_text("{}\n")
+    args = _namespace({"prompt_data": f"[{first},{second}]@[0:100]"})
+
+    report = run_doctor(argv=[], args=args)
+
+    assert report.ok
+    assert "CONFIG_PATHS" not in _rule_ids(report)
+
+
+def test_generalized_prompt_data_reports_only_missing_physical_path(tmp_path):
+    existing = tmp_path / "existing.jsonl"
+    missing = tmp_path / "missing.jsonl"
+    existing.write_text("{}\n")
+    path_spec = f"[{existing},{missing}]@[1:5]"
+    args = _namespace({"prompt_data": path_spec})
+
+    report = run_doctor(argv=[], args=args)
+
+    path_diagnostics = [item for item in report.diagnostics if item.rule_id == "CONFIG_PATHS"]
+    assert not report.ok
+    assert len(path_diagnostics) == 1
+    assert path_diagnostics[0].details == {
+        "field": "prompt_data",
+        "path": str(missing),
+        "path_spec": path_spec,
+    }
+
+
 @pytest.mark.parametrize("case", json.loads(FIXTURES.read_text()))
 def test_error_case_library_maps_to_rule(case):
     report = run_doctor(argv=[], args=_namespace(case["config"]))

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -128,6 +128,19 @@ def test_hybrid_resource_preview_uses_dedicated_actor_and_rollout_gpus():
     assert {item["placement_group"] for item in report.topology["role_plan"]} == {"dedicated"}
 
 
+def test_model_roles_reject_zero_gpu_resources():
+    report = run_doctor(
+        argv=[],
+        args=_namespace({"resource": {"actor": [1, 0], "rollout": [1, 8]}}),
+    )
+
+    assert not report.ok
+    assert "CONFIG_RESOURCE_SHAPE" in _rule_ids(report)
+    diagnostic = next(item for item in report.diagnostics if item.rule_id == "CONFIG_RESOURCE_SHAPE")
+    assert diagnostic.details["code"] == "gpu_required"
+    assert diagnostic.details["role"] == "actor"
+
+
 def test_fully_async_without_kl_does_not_require_reference():
     args = _namespace(
         {

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from relax.utils.doctor import runner as doctor_runner
 from relax.utils.doctor.runner import render_json, render_text, run_doctor
 
 
@@ -241,6 +242,7 @@ def test_parse_error_is_reported_as_ci_failure():
     report = run_doctor(argv=["--bad-flag"], args=None, parse_error="argparse exited with code 2")
 
     assert not report.ok
+    assert report.config_state == "unavailable"
     assert "CONFIG_PARSE_ERROR" in _rule_ids(report)
 
 
@@ -261,6 +263,7 @@ def test_text_and_json_reports_include_required_sections():
     assert "Role topology" in text_report
     assert "Final merged config" in text_report
     assert json_report["command"] == ["python", "-m", "relax.entrypoints.train", "--num-rollout", "1"]
+    assert json_report["config_state"] == "validated"
     assert "topology" in json_report
     assert "config" in json_report
 
@@ -323,3 +326,69 @@ def test_parse_error_redacts_secret_from_raw_argv():
     assert not report.ok
     assert secret not in output
     assert "TOKEN=<redacted>" in output
+
+
+def test_report_redacts_structured_train_env_and_wandb_key():
+    train_secret = "train-value"
+    wandb_secret = "wandb-value"
+    args = _namespace(
+        {
+            "train_env_vars": {"OPENAI_API_KEY": train_secret},
+            "wandb_key": wandb_secret,
+        }
+    )
+
+    report = run_doctor(
+        argv=[
+            "--train-env-vars",
+            f'{{"OPENAI_API_KEY":"{train_secret}"}}',
+            "--wandb-key",
+            wandb_secret,
+        ],
+        args=args,
+    )
+    output = render_json(report)
+
+    assert train_secret not in output
+    assert wandb_secret not in output
+    assert report.argv == [
+        "--train-env-vars",
+        '{"OPENAI_API_KEY":"<redacted>"}',
+        "--wandb-key",
+        "<redacted>",
+    ]
+    assert report.command[-4:] == report.argv
+    assert report.config["train_env_vars"] == {"OPENAI_API_KEY": "<redacted>"}
+    assert report.config["wandb_key"] == "<redacted>"
+
+
+def test_zero_num_steps_returns_structured_batch_diagnostic():
+    report = run_doctor(argv=[], args=_namespace({"num_steps_per_rollout": 0}))
+
+    assert not report.ok
+    assert "CONFIG_BATCH_SIZE" in _rule_ids(report)
+    diagnostic = next(item for item in report.diagnostics if item.rule_id == "CONFIG_BATCH_SIZE")
+    assert diagnostic.details == {"num_steps_per_rollout": 0}
+
+
+def test_rule_exception_is_converted_to_structured_diagnostic(monkeypatch):
+    def broken_rule(_context):
+        raise RuntimeError("broken rule")
+
+    monkeypatch.setattr(
+        doctor_runner,
+        "get_rules",
+        lambda: [
+            SimpleNamespace(
+                rule_id="BROKEN_RULE",
+                supports_partial=True,
+                check=broken_rule,
+            )
+        ],
+    )
+
+    report = run_doctor(argv=[], args=_namespace())
+
+    assert not report.ok
+    assert [item.rule_id for item in report.diagnostics] == ["DOCTOR_RULE_EXECUTION_ERROR"]
+    assert report.diagnostics[0].details == {"failed_rule_id": "BROKEN_RULE"}

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -160,6 +160,30 @@ def test_model_roles_reject_zero_gpu_resources():
     assert diagnostic.details["role"] == "actor"
 
 
+@pytest.mark.parametrize("parse_error", (None, "service plan rejected GPU allocation for a CPU-only role"))
+def test_cpu_only_roles_reject_positive_gpu_resources(parse_error):
+    report = run_doctor(
+        argv=[],
+        args=_namespace(
+            {
+                "fully_async": True,
+                "colocate": False,
+                "resource": {
+                    "actor": [1, 4],
+                    "rollout": [1, 4],
+                    "advantages": [1, 1],
+                    "actor_fwd": [1, 2],
+                },
+            }
+        ),
+        parse_error=parse_error,
+    )
+
+    resource_diagnostics = [item for item in report.diagnostics if item.rule_id == "CONFIG_RESOURCE_SHAPE"]
+    assert len(resource_diagnostics) == 1
+    assert "CPU-only role 'advantages' requires num_gpus=0" in resource_diagnostics[0].message
+
+
 @pytest.mark.parametrize(
     "actor_resource",
     (

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from relax.utils.doctor.runner import render_json, render_text, run_doctor
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "error_cases.json"
+
+
+def _base_config() -> dict:
+    return {
+        "advantage_estimator": "grpo",
+        "loss_type": "policy_loss",
+        "resource": {"actor": [1, 8], "rollout": [1, 8]},
+        "debug_rollout_only": False,
+        "debug_train_only": False,
+        "fully_async": False,
+        "colocate": True,
+        "hybrid": False,
+        "true_on_policy_mode": False,
+        "max_staleness": 0,
+        "rollout_batch_size": 4,
+        "global_batch_size": 32,
+        "n_samples_per_prompt": 8,
+        "num_steps_per_rollout": None,
+        "num_rollout": 1,
+        "num_epoch": None,
+        "rollout_global_dataset": True,
+        "over_sampling_batch_size": 4,
+        "partial_rollout": False,
+        "use_dynamic_global_batch_size": False,
+        "use_dynamic_batch_size": False,
+        "max_tokens_per_gpu": None,
+        "context_parallel_size": 1,
+        "dynamic_context_parallel": False,
+        "rollout_max_context_len": 2048,
+        "rollout_max_prompt_len": 1024,
+        "num_data_storage_units": 1,
+        "balance_data": False,
+        "sglang_pp_size": 1,
+        "sglang_pipeline_parallel_size": 1,
+        "rollout_num_gpus_per_engine": 1,
+        "sglang_data_parallel_size": 1,
+        "sglang_enable_dp_attention": False,
+        "prefill_num_servers": None,
+        "rollout_external": False,
+        "sglang_config": None,
+        "eval_interval": None,
+        "eval_config": None,
+        "eval_prompt_data": None,
+        "eval_datasets": None,
+        "eval_size": None,
+        "save_interval": None,
+        "save": "./outputs/doctor-ok",
+        "sft_predict_interval": None,
+        "custom_dataset_class_path": None,
+        "prompt_data": None,
+        "sft_oversize_strategy": "drop",
+        "sft_oversize_custom_function_path": None,
+        "genrm_model_path": None,
+        "genrm_num_gpus": 1,
+        "actor_num_gpus_per_node": 8,
+        "actor_num_nodes": 1,
+        "rollout_num_gpus": 8,
+        "lora_rank": 0,
+        "lora_merge_mode": False,
+        "lora_adapter_mode": False,
+        "sglang_dp_size": 1,
+        "qkv_format": "thd",
+        "train_backend": "megatron",
+        "rotate_ckpt": False,
+        "async_save": False,
+        "data_source_path": "relax.engine.rollout.data_source.RolloutDataSourceWithBuffer",
+        "rollout_function_path": "relax.engine.rollout.sglang_rollout.generate_rollout",
+        "eval_function_path": "relax.engine.rollout.sglang_rollout.generate_rollout",
+        "custom_config_path": None,
+        "custom_reward_function_path": None,
+        "kl_coef": 0.0,
+        "use_kl_loss": False,
+        "ref_load": None,
+    }
+
+
+def _namespace(overrides: dict | None = None) -> SimpleNamespace:
+    config = _base_config()
+    if overrides:
+        config.update(overrides)
+    return SimpleNamespace(**config)
+
+
+def _rule_ids(report) -> set[str]:
+    return {item.rule_id for item in report.diagnostics}
+
+
+def test_doctor_passes_for_minimal_colocate_config():
+    report = run_doctor(argv=["--resource", '{"actor": [1, 8], "rollout": [1, 8]}'], args=_namespace())
+
+    assert report.ok
+    assert not report.diagnostics
+    assert report.command[:3] == ["python", "-m", "relax.entrypoints.train"]
+    assert report.topology["resource_summary"]["total_required_gpus"] == 8
+    assert report.topology["data_system"]["sampler"] == "GRPOGroupNSampler"
+
+
+@pytest.mark.parametrize("case", json.loads(FIXTURES.read_text()))
+def test_error_case_library_maps_to_rule(case):
+    report = run_doctor(argv=[], args=_namespace(case["config"]))
+
+    assert case["expected_rule"] in _rule_ids(report), case["name"]
+    assert not report.ok
+
+
+def test_parse_error_is_reported_as_ci_failure():
+    report = run_doctor(argv=["--bad-flag"], args=None, parse_error="argparse exited with code 2")
+
+    assert not report.ok
+    assert "CONFIG_PARSE_ERROR" in _rule_ids(report)
+
+
+def test_strict_warnings_promotes_warning_to_error():
+    args = _namespace({"over_sampling_batch_size": 8, "fully_async": False, "partial_rollout": False})
+    report = run_doctor(argv=[], args=args, strict_warnings=True)
+
+    assert not report.ok
+    assert any(item.rule_id == "CONFIG_OVERSAMPLING" and item.severity == "error" for item in report.diagnostics)
+
+
+def test_text_and_json_reports_include_required_sections():
+    report = run_doctor(argv=["--num-rollout", "1"], args=_namespace())
+    text_report = render_text(report)
+    json_report = json.loads(render_json(report))
+
+    assert "Expected launch command" in text_report
+    assert "Role topology" in text_report
+    assert "Final merged config" in text_report
+    assert json_report["command"] == ["python", "-m", "relax.entrypoints.train", "--num-rollout", "1"]
+    assert "topology" in json_report
+    assert "config" in json_report

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -141,6 +141,32 @@ def test_model_roles_reject_zero_gpu_resources():
     assert diagnostic.details["role"] == "actor"
 
 
+@pytest.mark.parametrize(
+    "actor_resource",
+    (
+        [True, 8],
+        [False, 8],
+        [1, True],
+        [1, False],
+    ),
+)
+def test_partial_resource_shape_rejects_boolean_values(actor_resource):
+    report = run_doctor(
+        argv=[],
+        args=_namespace({"resource": {"actor": actor_resource, "rollout": [1, 8]}}),
+        parse_error="service plan rejected a non-integer resource value",
+    )
+
+    resource_diagnostics = [item for item in report.diagnostics if item.rule_id == "CONFIG_RESOURCE_SHAPE"]
+    assert report.config_state == "partial"
+    assert len(resource_diagnostics) == 1
+    assert "must contain integers" in resource_diagnostics[0].message
+    assert resource_diagnostics[0].details == {
+        "role": "actor",
+        "value": actor_resource,
+    }
+
+
 def test_fully_async_without_kl_does_not_require_reference():
     args = _namespace(
         {

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -401,6 +401,43 @@ def test_report_redacts_structured_train_env_and_wandb_key():
     assert report.config["wandb_key"] == "<redacted>"
 
 
+def test_report_redacts_malformed_structured_train_env_without_config():
+    secret = "malformed-train-value"
+    malformed = f'{{"OPENAI_API_KEY":"{secret}"'
+
+    report = run_doctor(
+        argv=["--train-env-vars", malformed],
+        args=None,
+        parse_error=f"invalid train env: {malformed}",
+    )
+
+    for output in (render_json(report), render_text(report)):
+        assert secret not in output
+        assert malformed not in output
+    assert report.argv == ["--train-env-vars", "<redacted>"]
+    assert report.command[-2:] == report.argv
+
+
+def test_report_redacts_non_mapping_train_env_in_partial_config():
+    secret = "partial-train-value"
+    raw_value = f'["{secret}"]'
+    args = _namespace({"train_env_vars": [secret]})
+
+    report = run_doctor(
+        argv=["--train-env-vars", raw_value],
+        args=args,
+        parse_error=f"train_env_vars must be a mapping: {secret}",
+    )
+
+    for output in (render_json(report), render_text(report)):
+        assert secret not in output
+        assert raw_value not in output
+    assert report.config_state == "partial"
+    assert report.config["train_env_vars"] == "<redacted>"
+    assert report.argv == ["--train-env-vars", "<redacted>"]
+    assert report.command[-2:] == report.argv
+
+
 def test_zero_num_steps_returns_structured_batch_diagnostic():
     report = run_doctor(argv=[], args=_namespace({"num_steps_per_rollout": 0}))
 

--- a/tests/doctor/test_doctor_rules.py
+++ b/tests/doctor/test_doctor_rules.py
@@ -107,6 +107,96 @@ def test_doctor_passes_for_minimal_colocate_config():
     assert report.topology["data_system"]["sampler"] == "GRPOGroupNSampler"
 
 
+def test_hybrid_resource_preview_uses_dedicated_actor_and_rollout_gpus():
+    args = _namespace(
+        {
+            "resource": {"actor": [1, 8], "rollout": [1, 8]},
+            "hybrid": True,
+            "fully_async": True,
+            "colocate": True,
+        }
+    )
+
+    report = run_doctor(argv=[], args=args)
+
+    assert report.ok
+    assert report.topology["colocate"] is True
+    assert report.topology["shares_actor_rollout_pg"] is False
+    assert report.topology["resource_summary"]["shared_gpu"] == 0
+    assert report.topology["resource_summary"]["total_required_gpus"] == 16
+    assert {item["placement_group"] for item in report.topology["role_plan"]} == {"dedicated"}
+
+
+def test_fully_async_without_kl_does_not_require_reference():
+    args = _namespace(
+        {
+            "resource": {
+                "actor": [1, 4],
+                "rollout": [1, 4],
+                "advantages": [1, 0],
+                "actor_fwd": [1, 2],
+            },
+            "fully_async": True,
+            "colocate": False,
+            "global_batch_size": 16,
+        }
+    )
+
+    report = run_doctor(argv=[], args=args)
+
+    assert report.ok
+    assert "reference" not in report.topology["required_roles"]
+    assert "reference" not in report.topology["missing_resource_roles"]
+    assert "reference" not in report.topology["roles"]
+
+
+def test_fully_async_with_kl_requires_reference():
+    args = _namespace(
+        {
+            "resource": {
+                "actor": [1, 4],
+                "rollout": [1, 4],
+                "advantages": [1, 0],
+                "actor_fwd": [1, 2],
+            },
+            "fully_async": True,
+            "colocate": False,
+            "global_batch_size": 16,
+            "use_kl_loss": True,
+        }
+    )
+
+    report = run_doctor(argv=[], args=args)
+
+    assert not report.ok
+    assert "reference" in report.topology["required_roles"]
+    assert "reference" in report.topology["missing_resource_roles"]
+    assert "CONFIG_REQUIRED_ROLES" in _rule_ids(report)
+
+
+def test_fully_async_keeps_explicit_optional_reference_in_plan():
+    args = _namespace(
+        {
+            "resource": {
+                "actor": [1, 4],
+                "rollout": [1, 4],
+                "advantages": [1, 0],
+                "actor_fwd": [1, 2],
+                "reference": [1, 2],
+            },
+            "fully_async": True,
+            "colocate": False,
+            "global_batch_size": 16,
+        }
+    )
+
+    report = run_doctor(argv=[], args=args)
+
+    assert report.ok
+    assert "reference" not in report.topology["required_roles"]
+    assert "reference" in report.topology["roles"]
+
+
 @pytest.mark.parametrize("case", json.loads(FIXTURES.read_text()))
 def test_error_case_library_maps_to_rule(case):
     report = run_doctor(argv=[], args=_namespace(case["config"]))

--- a/tests/utils/test_arguments_opd_teacher_colocate.py
+++ b/tests/utils/test_arguments_opd_teacher_colocate.py
@@ -239,3 +239,11 @@ def test_arguments_rejects_non_positive_num_steps_per_rollout(arguments_module):
 
     with pytest.raises(ValueError, match="num-steps-per-rollout must be greater than zero"):
         arguments_module.slime_validate_args(args)
+
+
+def test_arguments_rejects_zero_gpu_model_role(arguments_module):
+    args = _opd_args()
+    args.resource["rollout"] = [1, 0]
+
+    with pytest.raises(ValueError, match="model role 'rollout' requires num_gpus > 0"):
+        arguments_module.slime_validate_args(args)

--- a/tests/utils/test_arguments_opd_teacher_colocate.py
+++ b/tests/utils/test_arguments_opd_teacher_colocate.py
@@ -231,3 +231,11 @@ def test_arguments_dynamic_context_parallel_rejects_sft_eval(arguments_module):
 
     with pytest.raises(ValueError, match="this combination can hang and has not been fixed"):
         arguments_module.slime_validate_args(args)
+
+
+def test_arguments_rejects_non_positive_num_steps_per_rollout(arguments_module):
+    args = _opd_args()
+    args.num_steps_per_rollout = 0
+
+    with pytest.raises(ValueError, match="num-steps-per-rollout must be greater than zero"):
+        arguments_module.slime_validate_args(args)

--- a/tests/utils/test_arguments_opd_teacher_colocate.py
+++ b/tests/utils/test_arguments_opd_teacher_colocate.py
@@ -56,6 +56,43 @@ def test_recompute_loss_function_use_reentrant_option(arguments_module, argv, ex
     assert args.recompute_loss_function_use_reentrant is expected
 
 
+def test_parse_only_mode_returns_namespace_before_validation(arguments_module, monkeypatch):
+    captured = {}
+
+    def fake_megatron_parse_args(extra_args_provider, skip_hf_validate=False, derive_cluster_args=True):
+        captured["skip_hf_validate"] = skip_hf_validate
+        captured["derive_cluster_args"] = derive_cluster_args
+        parser = argparse.ArgumentParser()
+        extra_args_provider(parser)
+        return parser.parse_args()
+
+    megatron_arguments = ModuleType("relax.backends.megatron.arguments")
+    megatron_arguments.megatron_parse_args = fake_megatron_parse_args
+    megatron_arguments.validate_args = lambda args: args
+    monkeypatch.setitem(sys.modules, "relax.backends.megatron.arguments", megatron_arguments)
+    monkeypatch.setattr(arguments_module, "sglang_parse_args", lambda: None)
+    monkeypatch.setattr(arguments_module, "teacher_sglang_parse_args", lambda: None)
+    arguments_module.RouterArgs = SimpleNamespace(add_cli_args=lambda parser, **_kwargs: parser)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "relax-doctor",
+            "--resource",
+            '{"actor": [1, 4], "rollout": [1, 4]}',
+            "--fully-async",
+            "--colocate",
+        ],
+    )
+
+    args = arguments_module.parse_args(validate=False)
+
+    assert args.fully_async is True
+    assert args.colocate is True
+    assert args.resource == {"actor": [1, 4], "rollout": [1, 4]}
+    assert captured == {"skip_hf_validate": True, "derive_cluster_args": False}
+
+
 def _opd_args() -> SimpleNamespace:
     return SimpleNamespace(
         loss_type="grpo",


### PR DESCRIPTION
Task issue: https://github.com/redai-infra/Relax/issues/86

## What

Add a Config Doctor dry-run entrypoint for 【No.35】.

`python -m relax.entrypoints.doctor` validates configuration without starting Ray, Ray Serve, SGLang, GPU workers, or a training loop. It reports config state, structured diagnostics, the normalized configuration, the shared runtime service plan, GPU demand, and the expected launch command.

## Why

Relates to #86.

Task 35 requires a CI-friendly preflight command that catches malformed resources, incompatible modes, missing role producers, invalid batch sizing, unknown options, missing paths, and topology conflicts before GPU allocation.

## How

- Add text/JSON Doctor output and non-zero CI exit codes.
- Keep full validation failures visible while restricting fallback namespaces to partial-safe checks.
- Audit options registered by the actual Relax, Megatron, SGLang, and teacher parsers.
- Redact sensitive values across argv, expected commands, config, parse errors, and diagnostic details.
- Add `relax/core/service_plan.py` as the shared source for runtime and Doctor role/resource planning.
- Cover more than 15 error classes with unit tests and an error-case fixture library.
- Add Chinese and English usage documentation.

## Review Follow-up

The second maintainer review is addressed in four atomic commits:

1. `b117299` keeps the original validation failure, marks fallback config as partial, skips normalized-only rules, converts rule exceptions to diagnostics, and fixes `--train-env-vars` / `--wandb-key` redaction.
2. `88cb695` audits unknown options across the real parser registrations and rejects non-positive `num_steps_per_rollout` before division.
3. `823fbec` extracts a side-effect-free shared service plan used by Controller and Doctor, covers managed teacher/SFT/debug/Hybrid placement, and rejects zero-GPU model roles while retaining CPU roles.
4. `df2d77b` updates the guides and error fixture library for the final behavior.

## Testing

Run from the repository root with the project environment activated.

```bash
python -m pre_commit run --all-files
```

Result: `Passed`.

```bash
python -m pytest -q tests/doctor
```

Result: `46 passed`.

```bash
python -m pytest -q tests/doctor tests/core tests/utils/test_arguments_opd_teacher_colocate.py tests/distributed/ray/test_teacher_sglang_overrides.py
```

Result: `66 passed, 6 skipped`.

```bash
python -m ruff check relax tests/doctor tests/core/test_service_plan.py tests/utils/test_arguments_opd_teacher_colocate.py
python -m ruff format --check relax tests/doctor tests/core/test_service_plan.py tests/utils/test_arguments_opd_teacher_colocate.py
```

Result: `Passed`.

- [x] Full pre-commit passes
- [x] Doctor, shared-plan, Controller-adjacent, and parser tests pass
- [x] Review regression tests added
- [x] Chinese and English documentation updated

## Type of Change

- New feature: Config Doctor dry-run entrypoint.
- Bug fixes: safe fallback, unknown argument handling, resource validation, and report redaction.
- Refactor: shared Controller/Doctor service planning.
- Documentation update: Chinese and English usage guides.

## Screenshots / Logs

No screenshots. Reproducible commands and results are included above.