### PR TITLE
perf(colocate): add bidirectional GPU weight handoff

### DIFF
--- a/docker/patch/megatron/20260506-85bced0ae.patch
+++ b/docker/patch/megatron/20260506-85bced0ae.patch
@@ -443,7 +443,7 @@ index 19de0ed52..d957e0f1e 100644
                      output_layer=self.output_layer,
                      output_weight=output_weight,
 diff --git a/megatron/core/optimizer/distrib_optimizer.py b/megatron/core/optimizer/distrib_optimizer.py
-index 4430a8c84..084389b27 100644
+index 4430a8c84a..f270a19615 100644
 --- a/megatron/core/optimizer/distrib_optimizer.py
 +++ b/megatron/core/optimizer/distrib_optimizer.py
 @@ -706,6 +706,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
@@ -464,6 +464,25 @@ index 4430a8c84..084389b27 100644
                              assert tensors[key].shape == (gbuf_local_end - gbuf_local_start,), (
                                  tensors[key].shape,
                                  gbuf_local_start,
+@@ -2823,6 +2827,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+         if self._state_offloader is not None:
+             self._state_offloader.offload()
+ 
++    def enable_state_offload(self):
++        """Lazily enable the existing asynchronous state offloader.
++
++        RL runtimes use this when optimizer state only needs to leave the GPU
++        at phase boundaries.  It intentionally does not change
++        ``config.offload_optimizer_states`` or the per-training-step policy.
++        """
++        if self._state_offloader is None:
++            self._state_offloader = OptimizerStateOffloader(self)
++        if self.optimizer.state:
++            self._state_offloader.mark_optimizer_states_initialized()
++
+     def reload_offloaded_states(self):
+         """Start async reload of offloaded states."""
+         if self._state_offloader is not None:
 diff --git a/megatron/core/parallel_state.py b/megatron/core/parallel_state.py
 index 863b5d55d..6c81e6e5f 100644
 --- a/megatron/core/parallel_state.py
@@ -893,17 +912,19 @@ index 62f6e4426..c25969b3b 100644
      )
      group.add_argument(
 diff --git a/megatron/training/training.py b/megatron/training/training.py
-index a0817e834..7cd094dc5 100644
+index a0817e834a..2befd84303 100644
 --- a/megatron/training/training.py
 +++ b/megatron/training/training.py
-@@ -222,7 +222,9 @@ from megatron.training.utils import (
+@@ -222,7 +222,11 @@ from megatron.training.utils import (
  try:
      from torch_memory_saver import torch_memory_saver
  
 -    torch_memory_saver.hook_mode = "torch"
-+    # NOTE(wuhuan): keep the default hook mode; forcing "torch" triggers
-+    # 'torch.AcceleratorError: CUDA error: invalid argument' on weight updates.
-+    # torch_memory_saver.hook_mode = "torch"
++    # A preloaded TMS allocator is required for pauseable CUDA graphs in
++    # colocated inference. Fall back to the torch hook only for standalone
++    # launches that did not preload that allocator.
++    if "torch_memory_saver" not in os.getenv("LD_PRELOAD", ""):
++        torch_memory_saver.hook_mode = "torch"
      HAVE_TORCH_MEMORY_SAVER = True
  except ImportError:
      HAVE_TORCH_MEMORY_SAVER = False

--- a/docker/patch/sglang/v0.5.12.post1.patch
+++ b/docker/patch/sglang/v0.5.12.post1.patch
@@ -791,10 +791,18 @@ index 1dde8bed80..729a5e6fe3 100644
          """Get weights by parameter name."""
          obj = GetWeightsByNameReqInput(name=name, truncate_size=truncate_size)
 diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
-index 80081fc579..cec2c57f18 100644
+index 80081fc579..50b06d5a41 100644
 --- a/python/sglang/srt/entrypoints/http_server.py
 +++ b/python/sglang/srt/entrypoints/http_server.py
-@@ -127,6 +127,7 @@ from sglang.srt.managers.io_struct import (
+@@ -118,6 +118,7 @@ from sglang.srt.managers.io_struct import (
+     DestroyWeightsUpdateGroupReqInput,
+     DumperControlReqInput,
+     EmbeddingReqInput,
++    ExportWeightsToTensorReqInput,
+     GenerateReqInput,
+     GetWeightsByNameReqInput,
+     InitWeightsSendGroupForRemoteInstanceReqInput,
+@@ -127,6 +128,7 @@ from sglang.srt.managers.io_struct import (
      OpenSessionReqInput,
      ParseFunctionCallReq,
      PauseGenerationReqInput,
@@ -802,7 +810,7 @@ index 80081fc579..cec2c57f18 100644
      ProfileReqInput,
      ReleaseMemoryOccupationReqInput,
      ResumeMemoryOccupationReqInput,
-@@ -611,10 +612,8 @@ async def model_info():
+@@ -611,10 +613,8 @@ async def model_info():
  @app.get("/weight_version")
  async def weight_version():
      """Get the current weight version."""
@@ -815,7 +823,7 @@ index 80081fc579..cec2c57f18 100644
  
  
  @app.get("/get_server_info")
-@@ -631,9 +630,19 @@ async def get_server_info():
+@@ -631,9 +631,19 @@ async def get_server_info():
  async def server_info():
      """Get the server information."""
      # Returns internal states per DP.
@@ -838,7 +846,35 @@ index 80081fc579..cec2c57f18 100644
  
      # server_args.model_config is not serializable but should be excluded by asdict.
      return {
-@@ -1222,6 +1231,23 @@ async def update_weights_from_ipc(obj: UpdateWeightsFromIPCReqInput, request: Re
+@@ -1186,6 +1196,27 @@ async def update_weights_from_tensor(
+     )
+ 
+ 
++@app.post("/export_weights_to_tensor")
++@auth_level(AuthLevel.ADMIN_OPTIONAL)
++async def export_weights_to_tensor(
++    obj: ExportWeightsToTensorReqInput, request: Request
++):
++    """Export live model parameters as same-node CUDA IPC handles."""
++    result = await _global_state.tokenizer_manager.export_weights_to_tensor(
++        obj, request
++    )
++    content = {
++        "success": result.success,
++        "message": result.message,
++        "serialized_named_tensors": result.serialized_named_tensors,
++        "metadata": result.metadata,
++        "weight_version": _global_state.tokenizer_manager.server_args.weight_version,
++    }
++    return ORJSONResponse(
++        content, status_code=200 if result.success else HTTPStatus.BAD_REQUEST
++    )
++
++
+ @app.post("/update_weights_from_distributed")
+ @auth_level(AuthLevel.ADMIN_OPTIONAL)
+ async def update_weights_from_distributed(
+@@ -1222,6 +1253,23 @@ async def update_weights_from_ipc(obj: UpdateWeightsFromIPCReqInput, request: Re
          return ORJSONResponse(content, status_code=HTTPStatus.BAD_REQUEST)
  
  
@@ -953,7 +989,7 @@ index f3c2c295d2..b99f7fcbe3 100644
              if enable_dual_stream:
                  current_stream = torch.cuda.current_stream()
 diff --git a/python/sglang/srt/layers/layernorm.py b/python/sglang/srt/layers/layernorm.py
-index e9c9e7b..d07e8ed 100644
+index e9c9e7be8c..d07e8edfea 100644
 --- a/python/sglang/srt/layers/layernorm.py
 +++ b/python/sglang/srt/layers/layernorm.py
 @@ -561,7 +561,9 @@ class GemmaRMSNorm(MultiPlatformOp):
@@ -1150,7 +1186,7 @@ index 0ac18784c3..bbc94f7a49 100644
              is_k_full=self.is_k_full,
              routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
 diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
-index 293335f646..51e56694ad 100644
+index 293335f646..d05103fee3 100644
 --- a/python/sglang/srt/managers/io_struct.py
 +++ b/python/sglang/srt/managers/io_struct.py
 @@ -1407,6 +1407,8 @@ class PauseContinueBroadcast:
@@ -1213,7 +1249,28 @@ index 293335f646..51e56694ad 100644
      # Whether to call torch.cuda.empty_cache() during flush
      torch_empty_cache: bool = False
  
-@@ -1638,6 +1677,18 @@ class ResumeMemoryOccupationReqOutput(BaseReq):
+@@ -1491,6 +1530,20 @@ class UpdateWeightsFromTensorReqOutput(BaseReq):
+     message: str
+ 
+ 
++@dataclass
++class ExportWeightsToTensorReqInput(BaseReq):
++    names: List[str]
++    load_format: str = "hf"
++
++
++@dataclass
++class ExportWeightsToTensorReqOutput(BaseReq):
++    success: bool
++    message: str
++    serialized_named_tensors: Optional[str] = None
++    metadata: Optional[List[Dict[str, Any]]] = None
++
++
+ @dataclass
+ class InitWeightsSendGroupForRemoteInstanceReqInput(BaseReq):
+     # The master address
+@@ -1638,6 +1691,18 @@ class ResumeMemoryOccupationReqOutput(BaseReq):
      pass
  
  
@@ -1249,10 +1306,18 @@ index feecc54416..28b189cc59 100755
                  break
  
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index 143054cd6e..40e05e2453 100644
+index 143054cd6e..35e8416aa2 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -124,6 +124,7 @@ from sglang.srt.managers.io_struct import (
+@@ -105,6 +105,7 @@ from sglang.srt.managers.io_struct import (
+     ExpertDistributionReq,
+     ExpertDistributionReqOutput,
+     ExpertDistributionReqType,
++    ExportWeightsToTensorReqInput,
+     FlushCacheReqInput,
+     FlushCacheReqOutput,
+     FreezeGCReq,
+@@ -124,6 +125,7 @@ from sglang.srt.managers.io_struct import (
      LoadLoRAAdapterReqOutput,
      OpenSessionReqInput,
      PauseGenerationReqInput,
@@ -1260,15 +1325,17 @@ index 143054cd6e..40e05e2453 100644
      ProfileReq,
      ReleaseMemoryOccupationReqInput,
      RemoveExternalCorpusReqInput,
-@@ -1452,6 +1453,7 @@ class Scheduler(
+@@ -1451,7 +1453,9 @@ class Scheduler(
+                     self.update_weights_from_distributed,
                  ),
                  (UpdateWeightsFromTensorReqInput, self.update_weights_from_tensor),
++                (ExportWeightsToTensorReqInput, self.export_weights_to_tensor),
                  (UpdateWeightsFromIPCReqInput, self.update_weights_from_ipc),
 +                (PostProcessWeightsReqInput, self.post_process_weights),
                  (GetWeightsByNameReqInput, self.get_weights_by_name),
                  (ReleaseMemoryOccupationReqInput, self.release_memory_occupation),
                  (ResumeMemoryOccupationReqInput, self.resume_memory_occupation),
-@@ -3649,9 +3651,16 @@ class Scheduler(
+@@ -3649,9 +3653,16 @@ class Scheduler(
                  recv_req.abort_all or req.rid.startswith(recv_req.rid)
              ):
                  # Abort method 3: set `to_finish`
@@ -1313,10 +1380,10 @@ index c02ed7997d..61733c4127 100644
                      if self.profile_in_progress:
                          # force trace flush
 diff --git a/python/sglang/srt/managers/scheduler_update_weights_mixin.py b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
-index f2daf644de..534d1b2f01 100644
+index f2daf644de..bb2fe882e0 100644
 --- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
 +++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
-@@ -12,6 +12,7 @@ from sglang.srt.constants import (
+@@ -12,15 +12,20 @@ from sglang.srt.constants import (
      GPU_MEMORY_TYPE_KV_CACHE,
      GPU_MEMORY_TYPE_WEIGHTS,
  )
@@ -1324,7 +1391,11 @@ index f2daf644de..534d1b2f01 100644
  from sglang.srt.managers.io_struct import (
      CheckWeightsReqInput,
      CheckWeightsReqOutput,
-@@ -21,6 +22,8 @@ from sglang.srt.managers.io_struct import (
+     DestroyWeightsUpdateGroupReqInput,
+     DestroyWeightsUpdateGroupReqOutput,
++    ExportWeightsToTensorReqInput,
++    ExportWeightsToTensorReqOutput,
+     GetWeightsByNameReqInput,
      GetWeightsByNameReqOutput,
      InitWeightsUpdateGroupReqInput,
      InitWeightsUpdateGroupReqOutput,
@@ -1333,7 +1404,35 @@ index f2daf644de..534d1b2f01 100644
      ReleaseMemoryOccupationReqInput,
      ReleaseMemoryOccupationReqOutput,
      ResumeMemoryOccupationReqInput,
-@@ -120,6 +123,11 @@ class SchedulerUpdateWeightsMixin:
+@@ -105,6 +110,27 @@ class SchedulerUpdateWeightsMixin:
+         torch.distributed.barrier(group=self.tp_cpu_group)
+         return UpdateWeightsFromTensorReqOutput(success, message)
+ 
++    def export_weights_to_tensor(
++        self: Scheduler, recv_req: ExportWeightsToTensorReqInput
++    ):
++        if not self.is_fully_idle():
++            return ExportWeightsToTensorReqOutput(
++                success=False,
++                message="Weight export requires an idle scheduler",
++            )
++        if GPU_MEMORY_TYPE_WEIGHTS in self.offload_tags:
++            return ExportWeightsToTensorReqOutput(
++                success=False,
++                message="Weight export requires resident model weights",
++            )
++        success, message, serialized, metadata = self.tp_worker.export_weights_to_tensor(recv_req)
++        return ExportWeightsToTensorReqOutput(
++            success=success,
++            message=message,
++            serialized_named_tensors=serialized,
++            metadata=metadata,
++        )
++
+     def update_weights_from_ipc(
+         self: Scheduler, recv_req: UpdateWeightsFromIPCReqInput
+     ):
+@@ -120,6 +146,11 @@ class SchedulerUpdateWeightsMixin:
          torch.distributed.barrier(group=self.tp_cpu_group)
          return UpdateWeightsFromIPCReqOutput(success, message)
  
@@ -1345,7 +1444,7 @@ index f2daf644de..534d1b2f01 100644
      def get_weights_by_name(self: Scheduler, recv_req: GetWeightsByNameReqInput):
          parameter = self.tp_worker.get_weights_by_name(recv_req)
          return GetWeightsByNameReqOutput(parameter)
-@@ -143,6 +151,15 @@ class SchedulerUpdateWeightsMixin:
+@@ -143,6 +174,15 @@ class SchedulerUpdateWeightsMixin:
              self.memory_saver_adapter.pause(GPU_MEMORY_TYPE_KV_CACHE)
              self.flush_cache()
  
@@ -1361,7 +1460,7 @@ index f2daf644de..534d1b2f01 100644
          if GPU_MEMORY_TYPE_WEIGHTS in tags:
              self.stashed_model_static_state = _export_static_state(
                  self.tp_worker.model_runner.model
-@@ -183,6 +200,15 @@ class SchedulerUpdateWeightsMixin:
+@@ -183,6 +223,15 @@ class SchedulerUpdateWeightsMixin:
          if GPU_MEMORY_TYPE_KV_CACHE in tags:
              self.memory_saver_adapter.resume(GPU_MEMORY_TYPE_KV_CACHE)
  
@@ -1378,10 +1477,19 @@ index f2daf644de..534d1b2f01 100644
  
      def check_weights(self: Scheduler, recv_req: CheckWeightsReqInput):
 diff --git a/python/sglang/srt/managers/tokenizer_control_mixin.py b/python/sglang/srt/managers/tokenizer_control_mixin.py
-index 05382e073e..7eea220be6 100644
+index 05382e073e..1c702cb65b 100644
 --- a/python/sglang/srt/managers/tokenizer_control_mixin.py
 +++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
-@@ -76,6 +76,8 @@ from sglang.srt.managers.io_struct import (
+@@ -35,6 +35,8 @@ from sglang.srt.managers.io_struct import (
+     ExpertDistributionReq,
+     ExpertDistributionReqOutput,
+     ExpertDistributionReqType,
++    ExportWeightsToTensorReqInput,
++    ExportWeightsToTensorReqOutput,
+     FlushCacheReqInput,
+     FlushCacheReqOutput,
+     GetInternalStateReq,
+@@ -76,6 +78,8 @@ from sglang.srt.managers.io_struct import (
      UpdateWeightsFromDistributedReqOutput,
      UpdateWeightsFromIPCReqInput,
      UpdateWeightsFromIPCReqOutput,
@@ -1390,15 +1498,38 @@ index 05382e073e..7eea220be6 100644
      UpdateWeightsFromTensorReqInput,
      UpdateWeightsFromTensorReqOutput,
  )
-@@ -102,6 +104,7 @@ _COMMUNICATOR_SPECS = [
+@@ -101,7 +105,9 @@ _COMMUNICATOR_SPECS = [
+     ),
      ("send_weights_to_remote_instance", SendWeightsToRemoteInstanceReqOutput),
      ("update_weights_from_tensor", UpdateWeightsFromTensorReqOutput),
++    ("export_weights_to_tensor", ExportWeightsToTensorReqOutput),
      ("update_weights_from_ipc", UpdateWeightsFromIPCReqOutput),
 +    ("post_process_weights", PostProcessWeightsReqOutput),
      ("get_weights_by_name", GetWeightsByNameReqOutput),
      ("release_memory_occupation", ReleaseMemoryOccupationReqOutput),
      ("resume_memory_occupation", ResumeMemoryOccupationReqOutput),
-@@ -531,6 +534,17 @@ class TokenizerControlMixin:
+@@ -496,6 +502,20 @@ class TokenizerControlMixin:
+ 
+         return success, message
+ 
++    async def export_weights_to_tensor(
++        self: TokenizerManager,
++        obj: ExportWeightsToTensorReqInput,
++        request: Optional[fastapi.Request] = None,
++    ) -> ExportWeightsToTensorReqOutput:
++        self.auto_create_handle_loop()
++        if self.server_args.dp_size != 1:
++            raise ValueError("Weight export currently requires SGLang DP=1")
++        async with self.model_update_lock.writer_lock:
++            results = await self.export_weights_to_tensor_communicator(obj)
++        if len(results) != 1:
++            raise RuntimeError(f"Expected one weight export result, got {len(results)}")
++        return results[0]
++
+     async def update_weights_from_ipc(
+         self: TokenizerManager,
+         obj: UpdateWeightsFromIPCReqInput,
+@@ -531,6 +551,17 @@ class TokenizerControlMixin:
  
          return success, message
  
@@ -1490,10 +1621,16 @@ index 6375a1d8b7..3fc175e1af 100644
          if state.finished:
              # Get detailed cache breakdown if available
 diff --git a/python/sglang/srt/managers/tp_worker.py b/python/sglang/srt/managers/tp_worker.py
-index 60e105d939..6a37a8200c 100644
+index 60e105d939..1468e40792 100644
 --- a/python/sglang/srt/managers/tp_worker.py
 +++ b/python/sglang/srt/managers/tp_worker.py
-@@ -29,6 +29,7 @@ from sglang.srt.managers.io_struct import (
+@@ -24,11 +24,13 @@ import torch
+ from sglang.srt.distributed import get_pp_group, get_world_group
+ from sglang.srt.managers.io_struct import (
+     DestroyWeightsUpdateGroupReqInput,
++    ExportWeightsToTensorReqInput,
+     GetWeightsByNameReqInput,
+     InitWeightsSendGroupForRemoteInstanceReqInput,
      InitWeightsUpdateGroupReqInput,
      LoadLoRAAdapterFromTensorsReqInput,
      LoadLoRAAdapterReqInput,
@@ -1501,7 +1638,7 @@ index 60e105d939..6a37a8200c 100644
      SendWeightsToRemoteInstanceReqInput,
      UnloadLoRAAdapterReqInput,
      UpdateWeightFromDiskReqInput,
-@@ -97,6 +98,7 @@ class BaseTpWorker(ABC):
+@@ -97,6 +99,7 @@ class BaseTpWorker(ABC):
          success, message = self.model_runner.update_weights_from_disk(
              recv_req.model_path,
              recv_req.load_format,
@@ -1509,7 +1646,7 @@ index 60e105d939..6a37a8200c 100644
              recapture_cuda_graph=recv_req.recapture_cuda_graph,
          )
          return success, message
-@@ -152,6 +154,7 @@ class BaseTpWorker(ABC):
+@@ -152,6 +155,7 @@ class BaseTpWorker(ABC):
              recv_req.shapes,
              recv_req.group_name,
              recv_req.load_format,
@@ -1517,7 +1654,18 @@ index 60e105d939..6a37a8200c 100644
          )
          return success, message
  
-@@ -171,6 +174,11 @@ class BaseTpWorker(ABC):
+@@ -166,11 +170,22 @@ class BaseTpWorker(ABC):
+         )
+         return success, message
+ 
++    def export_weights_to_tensor(self, recv_req: ExportWeightsToTensorReqInput):
++        return self.model_runner.export_weights_to_tensor(
++            names=recv_req.names,
++            load_format=recv_req.load_format,
++        )
++
+     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
+         """Update weights from IPC for checkpoint-engine integration."""
          success, message = self.model_runner.update_weights_from_ipc(recv_req)
          return success, message
  
@@ -1688,7 +1836,7 @@ index 5f8a256f66..5eff30ef96 100644
          return DecLockRefResult(delta=delta)
  
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index eff3a5615a..5b1eec9953 100644
+index eff3a5615a..fcae7e19e4 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
 @@ -20,7 +20,9 @@ import datetime
@@ -1944,7 +2092,56 @@ index eff3a5615a..5b1eec9953 100644
      def update_weights_from_tensor(
          self,
          named_tensors: List[Tuple[str, Union[torch.Tensor, "LocalSerializedTensor"]]],
-@@ -3346,11 +3526,18 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -2098,6 +2278,48 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+             raise NotImplementedError(f"Unknown load_format={load_format}")
+         return True, "Success"
+ 
++    def export_weights_to_tensor(self, names: List[str], load_format: str = "hf"):
++        """Serialize a partial group of model weights for same-node CUDA IPC."""
++        if load_format != "hf":
++            return False, f"Unsupported export format: {load_format}", None, None
++        if self.tp_size != 1:
++            return False, "Weight export currently requires SGLang TP=1", None, None
++        exporter = getattr(self.model, "export_weights_to_hf_views", None)
++        if exporter is None:
++            return False, f"{type(self.model).__name__} does not support HF-view export", None, None
++
++        try:
++            from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
++
++            monkey_patch_torch_reductions()
++            source_views = exporter(names)
++            # TMS uses CUDA VMM for releasable model weights, while PyTorch's
++            # standard IPC reducer only supports ordinary CUDA allocations.
++            # Model loading has already left the tagged TMS region here, so a
++            # normal clone uses PyTorch's default CUDA pool.  The caller sends
++            # bounded Bridge-task groups, keeping this D2D staging short-lived
++            # and avoiding both full-model staging and host traffic.
++            named_tensors = [
++                (name, tensor.contiguous().clone())
++                for name, tensor in source_views
++            ]
++            if [name for name, _ in named_tensors] != names:
++                raise RuntimeError("Exporter returned weights in an unexpected order")
++            metadata = [
++                {
++                    "name": name,
++                    "shape": list(tensor.shape),
++                    "dtype": str(tensor.dtype).removeprefix("torch."),
++                    "numel": tensor.numel(),
++                }
++                for name, tensor in named_tensors
++            ]
++            serialized = MultiprocessingSerializer.serialize(named_tensors, output_str=True)
++            return True, "Success", serialized, metadata
++        except Exception as exc:
++            logger.exception("Failed to export model weights as CUDA IPC views")
++            return False, str(exc), None, None
++
+     def _update_weights_from_flattened_bucket(
+         self,
+         flattened_tensor_bucket_dict,
+@@ -3346,11 +3568,18 @@ class ModelRunner(ModelRunnerKVCacheMixin):
          output.expert_distribution_metrics = recorder_outputs.get("metrics")
  
          no_copy_to_cpu = not self.server_args.disable_overlap_schedule
@@ -1964,7 +2161,7 @@ index eff3a5615a..5b1eec9953 100644
                  no_copy_to_cpu=no_copy_to_cpu,
              )
  
-@@ -3358,7 +3545,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3358,7 +3587,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
              output.indexer_topk_output = indexer_capturer.on_forward_end(
                  forward_batch=forward_batch,
                  can_run_graph=output.can_run_graph,
@@ -1973,7 +2170,7 @@ index eff3a5615a..5b1eec9953 100644
                  no_copy_to_cpu=no_copy_to_cpu,
              )
  
-@@ -3641,6 +3828,161 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3641,6 +3870,161 @@ class ModelRunner(ModelRunnerKVCacheMixin):
              )
          return output
  
@@ -2413,7 +2610,7 @@ index 832ee74dd0..69b296fcb3 100644
      def get_model_config_for_expert_location(cls, config: KimiK25Config):
          text_config = config.text_config
 diff --git a/python/sglang/srt/models/qwen3_vl.py b/python/sglang/srt/models/qwen3_vl.py
-index 1b6c185bcb..58ad9c7803 100644
+index 1b6c185bcb..fb5895f44c 100644
 --- a/python/sglang/srt/models/qwen3_vl.py
 +++ b/python/sglang/srt/models/qwen3_vl.py
 @@ -1024,14 +1024,19 @@ class Qwen3LLMModel(Qwen3Model):
@@ -2440,6 +2637,77 @@ index 1b6c185bcb..58ad9c7803 100644
              hidden_states, residual = layer(
                  positions,
                  hidden_states,
+@@ -1307,6 +1312,70 @@ class Qwen3VLForConditionalGeneration(nn.Module):
+         self.capture_aux_hidden_states = True
+         self.model.set_dflash_layers_to_capture([val + 1 for val in layer_ids])
+ 
++    def export_weights_to_hf_views(
++        self, names: List[str]
++    ) -> List[Tuple[str, torch.Tensor]]:
++        """Return HF-semantic read-only views of the live TP=1 parameters."""
++        if get_tensor_model_parallel_world_size() != 1:
++            raise ValueError("Qwen3-VL HF-view export currently requires SGLang TP=1")
++        if self.quant_config is not None:
++            raise ValueError("Qwen3-VL HF-view export does not support quantized weights")
++
++        params = dict(self.named_parameters(remove_duplicate=False))
++        modules = dict(self.named_modules())
++        exported = []
++        for hf_name in names:
++            internal_name = hf_name
++            if internal_name.startswith("model.language_model."):
++                internal_name = internal_name.replace("model.language_model.", "model.", 1)
++            elif internal_name.startswith("model.visual."):
++                internal_name = internal_name.replace("model.visual.", "visual.", 1)
++                internal_name = internal_name.replace("attn.qkv.", "attn.qkv_proj.")
++
++            shard_name = None
++            for candidate in ("q", "k", "v"):
++                token = f".{candidate}_proj"
++                if token in internal_name:
++                    internal_name = internal_name.replace(token, ".qkv_proj", 1)
++                    shard_name = candidate
++                    break
++
++            gate_up_shard = None
++            if ".gate_proj" in internal_name:
++                internal_name = internal_name.replace(".gate_proj", ".gate_up_proj", 1)
++                gate_up_shard = 0
++            elif ".up_proj" in internal_name:
++                internal_name = internal_name.replace(".up_proj", ".gate_up_proj", 1)
++                gate_up_shard = 1
++
++            if internal_name not in params:
++                raise KeyError(f"Cannot export HF weight {hf_name!r}; internal parameter {internal_name!r} is absent")
++
++            param = params[internal_name].detach()
++            module_name = internal_name.rsplit(".", 1)[0]
++            module = modules.get(module_name)
++            output_dim = int(getattr(params[internal_name], "output_dim", 0) or 0)
++
++            if shard_name is not None:
++                if module is None:
++                    raise KeyError(f"Missing QKV module {module_name!r} for {hf_name!r}")
++                sizes = {
++                    "q": int(module.q_proj_shard_size),
++                    "k": int(module.kv_proj_shard_size),
++                    "v": int(module.kv_proj_shard_size),
++                }
++                offsets = {"q": 0, "k": sizes["q"], "v": sizes["q"] + sizes["k"]}
++                param = param.narrow(output_dim, offsets[shard_name], sizes[shard_name])
++            elif gate_up_shard is not None:
++                if module is None or not hasattr(module, "output_sizes"):
++                    raise KeyError(f"Missing fused MLP module {module_name!r} for {hf_name!r}")
++                sizes = [int(size) for size in module.output_sizes]
++                offset = sum(sizes[:gate_up_shard])
++                param = param.narrow(output_dim, offset, sizes[gate_up_shard])
++
++            exported.append((hf_name, param))
++        return exported
++
+     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+         stacked_params_mapping = [
+             # (param_name, shard_name, shard_id)
 diff --git a/python/sglang/srt/multimodal/processors/base_processor.py b/python/sglang/srt/multimodal/processors/base_processor.py
 index 5b886a8791..bde20421ed 100644
 --- a/python/sglang/srt/multimodal/processors/base_processor.py
@@ -2935,3 +3203,112 @@ index 55566973af..46c1771af8 100644
          assert expect_name == actual_name, f"{expect_name=} {actual_name=}"
          assert (
              expect_should_compare == actual_should_compare
+diff --git a/test/registered/unit/models/test_qwen3_vl_weight_export.py b/test/registered/unit/models/test_qwen3_vl_weight_export.py
+new file mode 100644
+index 0000000000..8f67f91e8b
+--- /dev/null
++++ b/test/registered/unit/models/test_qwen3_vl_weight_export.py
+@@ -0,0 +1,103 @@
++"""Unit coverage for Qwen3-VL live HF-view weight export."""
++
++from sglang.test.ci.ci_register import register_cpu_ci
++
++
++register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
++
++import unittest
++from unittest.mock import patch
++
++import torch
++from torch import nn
++
++from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
++
++
++class _PackedLinear(nn.Module):
++    def __init__(self, rows, columns, *, output_sizes=None, q_size=None, kv_size=None):
++        super().__init__()
++        self.weight = nn.Parameter(torch.arange(rows * columns, dtype=torch.float32).reshape(rows, columns))
++        self.weight.output_dim = 0
++        if output_sizes is not None:
++            self.output_sizes = output_sizes
++        if q_size is not None:
++            self.q_proj_shard_size = q_size
++            self.kv_proj_shard_size = kv_size
++
++
++class _FakeQwen3VL(nn.Module):
++    export_weights_to_hf_views = Qwen3VLForConditionalGeneration.export_weights_to_hf_views
++
++    def __init__(self):
++        super().__init__()
++        self.quant_config = None
++
++        self.model = nn.Module()
++        self.model.layers = nn.ModuleList([nn.Module()])
++        layer = self.model.layers[0]
++        layer.self_attn = nn.Module()
++        layer.self_attn.qkv_proj = _PackedLinear(8, 2, q_size=4, kv_size=2)
++        layer.mlp = nn.Module()
++        layer.mlp.gate_up_proj = _PackedLinear(6, 2, output_sizes=[3, 3])
++
++        self.visual = nn.Module()
++        self.visual.blocks = nn.ModuleList([nn.Module()])
++        self.visual.blocks[0].attn = nn.Module()
++        self.visual.blocks[0].attn.qkv_proj = _PackedLinear(9, 2)
++
++        self.model.embed_tokens = nn.Embedding(5, 2)
++        self.lm_head = self.model.embed_tokens
++
++
++class TestQwen3VLWeightExport(unittest.TestCase):
++    def setUp(self):
++        self.model = _FakeQwen3VL()
++
++    def _export(self, names):
++        with patch("sglang.srt.models.qwen3_vl.get_tensor_model_parallel_world_size", return_value=1):
++            return dict(self.model.export_weights_to_hf_views(names))
++
++    def assertSharesStorage(self, exported, source):
++        self.assertEqual(exported.untyped_storage().data_ptr(), source.untyped_storage().data_ptr())
++
++    def test_text_qkv_and_gate_up_are_views(self):
++        names = [
++            "model.language_model.layers.0.self_attn.q_proj.weight",
++            "model.language_model.layers.0.self_attn.k_proj.weight",
++            "model.language_model.layers.0.self_attn.v_proj.weight",
++            "model.language_model.layers.0.mlp.gate_proj.weight",
++            "model.language_model.layers.0.mlp.up_proj.weight",
++        ]
++        exported = self._export(names)
++        qkv = self.model.model.layers[0].self_attn.qkv_proj.weight
++        gate_up = self.model.model.layers[0].mlp.gate_up_proj.weight
++
++        torch.testing.assert_close(exported[names[0]], qkv[:4])
++        torch.testing.assert_close(exported[names[1]], qkv[4:6])
++        torch.testing.assert_close(exported[names[2]], qkv[6:8])
++        torch.testing.assert_close(exported[names[3]], gate_up[:3])
++        torch.testing.assert_close(exported[names[4]], gate_up[3:])
++        for name in names[:3]:
++            self.assertSharesStorage(exported[name], qkv)
++        for name in names[3:]:
++            self.assertSharesStorage(exported[name], gate_up)
++
++    def test_vision_qkv_keeps_fused_layout(self):
++        name = "model.visual.blocks.0.attn.qkv.weight"
++        exported = self._export([name])[name]
++        source = self.model.visual.blocks[0].attn.qkv_proj.weight
++
++        torch.testing.assert_close(exported, source)
++        self.assertSharesStorage(exported, source)
++
++    def test_tied_embedding_exports_shared_storage(self):
++        names = ["model.language_model.embed_tokens.weight", "lm_head.weight"]
++        exported = self._export(names)
++
++        self.assertSharesStorage(exported[names[0]], self.model.model.embed_tokens.weight)
++        self.assertSharesStorage(exported[names[1]], self.model.model.embed_tokens.weight)
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -92,6 +92,7 @@ from .data import (
 from .initialize import init, is_megatron_main_rank
 from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
 from .model import forward_only, initialize_model_and_optimizer, save, train
+from .weight_update.colocate_handoff import ColocateWeightHandoff
 from .weight_update.common import named_params_and_buffers
 from .weight_update.update_weight_from_distributed import UpdateWeightFromDistributed
 from .weight_update.update_weight_from_tensor import UpdateWeightFromTensor
@@ -297,15 +298,40 @@ class MegatronTrainRayActor(TrainRayActor):
                 getattr(self.hf_config, "quantization_config", None),
                 args.hf_checkpoint,
             )
+            if getattr(self.args, "colocate_weight_handoff", False):
+                config_name = type(self.hf_config).__name__
+                text_config = getattr(self.hf_config, "text_config", self.hf_config)
+                if (
+                    config_name != "Qwen3VLConfig"
+                    or getattr(text_config, "hidden_size", None) != 2560
+                    or getattr(text_config, "num_hidden_layers", None) != 36
+                ):
+                    raise RuntimeError(
+                        "--colocate-weight-handoff V1 only supports Qwen3-VL-4B; "
+                        f"got {config_name}, hidden_size={getattr(text_config, 'hidden_size', None)}, "
+                        f"num_hidden_layers={getattr(text_config, 'num_hidden_layers', None)}"
+                    )
+                if push_quant_config:
+                    raise RuntimeError("--colocate-weight-handoff does not support quantized checkpoints")
             self.weight_updater = update_weight_cls(
                 self.args,
                 self.model,
-                weights_getter=lambda: self.weights_backuper.get("actor"),
+                weights_getter=self._get_actor_weights_for_rollout,
                 model_name=type(self.hf_config).__name__.lower()
                 if self.args.model_name is None
                 else self.args.model_name,
                 quantization_config=push_quant_config,
             )
+            self.colocate_handoff = None
+            if getattr(self.args, "colocate_weight_handoff", False):
+                self.colocate_handoff = ColocateWeightHandoff(
+                    args=self.args,
+                    model=self.model,
+                    optimizer=self.optimizer,
+                    weights_backuper=self.weights_backuper,
+                    weight_updater=self.weight_updater,
+                    memory_saver_enabled=self._torch_memory_saver_enabled,
+                )
         else:
             is_pp_src_rank = (
                 mpu.get_data_parallel_rank(with_context_parallel=True) == 0
@@ -359,7 +385,10 @@ class MegatronTrainRayActor(TrainRayActor):
             # recover to actor in the end.
             self._switch_model("actor")
             if self._per_step_rollout:
-                self.sleep()
+                if getattr(self.args, "colocate_weight_handoff", False):
+                    self.colocate_handoff.offload_initial_train_state()
+                else:
+                    self.sleep()
 
         self.rollout_engines = None
 
@@ -425,6 +454,33 @@ class MegatronTrainRayActor(TrainRayActor):
             raise ValueError(f"Cannot switch to unknown model tag: {target_tag}")
         self.weights_backuper.restore(target_tag)
         self._active_model_tag = target_tag
+
+    def _get_actor_weights_for_rollout(self):
+        handoff = getattr(self, "colocate_handoff", None)
+        if handoff is not None and handoff.has_live_train_weights:
+            return dict(
+                named_params_and_buffers(
+                    self.args,
+                    self.model,
+                    convert_to_global_name=self.args.megatron_to_hf_mode == "raw",
+                    translate_gpu_to_cpu=False,
+                )
+            )
+        return self.weights_backuper.get("actor")
+
+    def _activate_actor_weights(self) -> None:
+        handoff = getattr(self, "colocate_handoff", None)
+        if handoff is None:
+            self._switch_model("actor")
+            return
+        if not handoff.has_live_train_weights:
+            handoff.activate_train_weights()
+        self._active_model_tag = "actor"
+
+    def set_rollout_manager(self, rollout_manager):
+        super().set_rollout_manager(rollout_manager)
+        if getattr(self, "colocate_handoff", None) is not None:
+            self.colocate_handoff.set_rollout_manager(rollout_manager)
 
     def fill_routing_replay(self, data_iterator, num_microbatches, rollout_data):
         if "rollout_routed_experts" not in rollout_data:
@@ -619,7 +675,11 @@ class MegatronTrainRayActor(TrainRayActor):
             dist.barrier(group=get_gloo_group())
 
         if self.args.offload_train and self._per_step_rollout:
-            self.wake_up()
+            if getattr(self.args, "colocate_weight_handoff", False):
+                self.colocate_handoff.prepare_train()
+                self._active_model_tag = None
+            else:
+                self.wake_up()
 
         if self.args.debug_train_only:
             logger.info(f"start to get rollout_id: {rollout_id} data from transfer queue for debug with mcore.")
@@ -843,7 +903,10 @@ class MegatronTrainRayActor(TrainRayActor):
                         )
                     )
 
-                self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
+                if self.args.keep_old_actor:
+                    self._switch_model("old_actor")
+                else:
+                    self._activate_actor_weights()
                 if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
                     if self.args.use_routing_replay:
                         if self.args.use_rollout_routing_replay:
@@ -863,7 +926,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
                 # Restore model tag before train (keep_old_actor may have switched to old_actor).
                 if self._active_model_tag != "actor":
-                    self._switch_model("actor")
+                    self._activate_actor_weights()
 
             if should_compute_gae_in_actor:
                 if self.args.use_critic and "values" not in rollout_data:
@@ -878,6 +941,8 @@ class MegatronTrainRayActor(TrainRayActor):
             log_rollout_data(rollout_id, self.args, rollout_data)
 
             # Train
+            if self._active_model_tag != "actor":
+                self._activate_actor_weights()
             if self.args.use_routing_replay:
                 os.environ["ROUTING_REPLAY_STAGE"] = "replay_backward"
             with timer("actor_train"):
@@ -900,7 +965,8 @@ class MegatronTrainRayActor(TrainRayActor):
             RoutingReplay.clear_all()
 
         # update the cpu actor weight to the latest model
-        self.weights_backuper.backup("actor")
+        if not getattr(self.args, "colocate_weight_handoff", False):
+            self.weights_backuper.backup("actor")
 
         # Update ref model if needed
         if (
@@ -948,7 +1014,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 all_audio_seqlens, audio_seqlens, group=mpu.get_data_parallel_group(with_context_parallel=False)
             )
             Timer().audio_seqlens = sum(all_audio_seqlens, [])
-        log_perf_data(rollout_id, self.args, flops_counter=self.flops_counter)
+        if not getattr(self.args, "colocate_weight_handoff", False):
+            log_perf_data(rollout_id, self.args, flops_counter=self.flops_counter)
 
         is_train_done = (rollout_id + 1) == self.args.num_rollout
         if self.args.save is not None and (
@@ -959,10 +1026,14 @@ class MegatronTrainRayActor(TrainRayActor):
             self.save_model(rollout_id, force_sync=is_train_done)
         has_rollout = getattr(self, "rollout_manager", None) is not None
         if self._per_step_rollout:
-            if self.args.offload_train:
+            if self.args.offload_train and not getattr(self.args, "colocate_weight_handoff", False):
                 self.sleep()
             if has_rollout:
                 self.update_weights()
+        if getattr(self.args, "colocate_weight_handoff", False):
+            # The handoff timers are recorded by update_weights(), so emit this
+            # step's metrics only after the transition has completed.
+            log_perf_data(rollout_id, self.args, flops_counter=self.flops_counter)
         tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rollout_id))
         # RL-only generative eval (uses SGLang via rollout_manager.eval). SFT
         # uses local eval/predict runner below.
@@ -1574,7 +1645,11 @@ class MegatronTrainRayActor(TrainRayActor):
         # torch dist may trigger nccl communication during saving; resume the
         # paused model (process groups + tms) so save can issue collectives and
         # touch GPU tensors.
-        if self.args.offload_train and self._per_step_rollout:
+        if (
+            self.args.offload_train
+            and self._per_step_rollout
+            and not getattr(self.args, "colocate_weight_handoff", False)
+        ):
             reload_process_groups()
 
         if self.args.async_save:
@@ -1597,12 +1672,20 @@ class MegatronTrainRayActor(TrainRayActor):
 
             save_hf_model(self.args, rollout_id, self.model)
 
-        if self.args.offload_train and self._per_step_rollout:
+        if (
+            self.args.offload_train
+            and self._per_step_rollout
+            and not getattr(self.args, "colocate_weight_handoff", False)
+        ):
             destroy_process_groups()
 
     @timer
     def update_weights(self) -> None:
         if self.args.debug_train_only or self.args.debug_rollout_only:
+            return
+
+        if getattr(self.args, "colocate_weight_handoff", False):
+            self.colocate_handoff.to_rollout()
             return
 
         if self.args.offload_train:

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -7,7 +7,7 @@ import os
 import uuid
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from functools import partial
 from pathlib import Path
 
@@ -24,6 +24,7 @@ from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.utils import get_model_config, unwrap_model
 from megatron.training.global_vars import get_args
 from megatron.training.training import get_model
+from torch_memory_saver import torch_memory_saver
 
 from relax.backends.megatron.checkpoint import _save_lora_to_checkpoint
 from relax.engine.sft.runtime import is_sft_mode
@@ -45,6 +46,7 @@ from .checkpoint import load_checkpoint, save_checkpoint
 from .data import DataIterator, get_batch
 from .loss import loss_function
 from .model_provider import get_model_provider_func, wrap_model_provider_with_freeze
+from .weight_update.static_state import relocate_colocate_static_tensors
 
 
 logger = get_logger(__name__)
@@ -263,11 +265,28 @@ def setup_model_and_optimizer(
     if getattr(args, "dynamic_context_parallel", False) or getattr(args, "context_parallel_size", 1) > 1:
         _relax_gdn_cp_config_assert()
 
-    model = get_model(
-        wrap_model_provider_with_freeze(get_model_provider_func(args, role), args),
-        ModelType.encoder_or_decoder,
-        wrap_with_ddp=role in ["actor", "critic"],
+    handoff_enabled = role == "actor" and getattr(args, "colocate_weight_handoff", False)
+    allocated_before = torch.cuda.memory_allocated() if handoff_enabled else 0
+    model_allocation = (
+        torch_memory_saver.region(tag="colocate_train_model", enable_cpu_backup=False)
+        if handoff_enabled
+        else nullcontext()
     )
+    with model_allocation:
+        model = get_model(
+            wrap_model_provider_with_freeze(get_model_provider_func(args, role), args),
+            ModelType.encoder_or_decoder,
+            wrap_with_ddp=role in ["actor", "critic"],
+        )
+    if handoff_enabled:
+        args._colocate_train_model_bytes = max(torch.cuda.memory_allocated() - allocated_before, 0)
+        # This must run after leaving model_allocation so the clone lives in the
+        # default CUDA pool and keeps its contents across no-backup TMS resumes.
+        relocated_bytes = relocate_colocate_static_tensors(model)
+        logger.info(
+            "Relocated %d bytes of Qwen3-VL static rotary state outside the colocate train model region",
+            relocated_bytes,
+        )
 
     # Some model providers (e.g., Qwen3VLGPTModel) rebuild the decoder in __init__,
     # which causes duplicate RoutingReplay registrations. Rebuild the list from

--- a/relax/backends/megatron/weight_update/bridge_converter.py
+++ b/relax/backends/megatron/weight_update/bridge_converter.py
@@ -3,7 +3,7 @@
 import dataclasses
 import re
 from argparse import Namespace
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
 from typing import Any
 
@@ -43,6 +43,7 @@ class BridgeConverter:
         self._model = model
         self._quantization_config = quantization_config
         self._bridge_task_map: dict[str, Any] | None = None
+        self._bridge: Any = None
         self._bridge_mapping_registry: Any = None
         self._bridge_expert_transposes_down: bool = True
         self._configs_broadcast_done: bool = False
@@ -74,6 +75,7 @@ class BridgeConverter:
         from relax.utils.megatron_bridge_utils import patch_megatron_model
 
         bridge = AutoBridge.from_hf_pretrained(self._args.hf_checkpoint, trust_remote_code=True)
+        self._bridge = bridge._model_bridge
         with patch_megatron_model(self._model):
             tasks = bridge.get_conversion_tasks(self._model)
 
@@ -138,6 +140,106 @@ class BridgeConverter:
                 break
 
         logger.info("Bridge task map initialized with %d local tasks", len(self._bridge_task_map))
+
+    def get_hf_to_megatron_tasks(self) -> list[Any]:
+        """Return the resolved Bridge load tasks owned by this PP rank."""
+        self.init_tasks()
+        self.broadcast_and_apply_configs()
+        return sorted(
+            (
+                task
+                for task in self._bridge_task_map.values()
+                if task.param_weight is not None and task.megatron_module is not None
+            ),
+            key=lambda task: (task.vp_stage or 0, task.param_name),
+        )
+
+    def get_required_hf_names(self) -> list[str]:
+        """Return the unique HF tensors needed to restore local Megatron
+        weights."""
+        return self.get_required_hf_names_for_tasks(self.get_hf_to_megatron_tasks())
+
+    @staticmethod
+    def get_required_hf_names_for_tasks(tasks: Sequence[Any]) -> list[str]:
+        """Return unique HF source names for a sequence of Bridge tasks."""
+        names: list[str] = []
+        seen: set[str] = set()
+        for task in tasks:
+            hf_param = task.mapping.hf_param
+            task_names = [hf_param] if isinstance(hf_param, str) else list(hf_param.values())
+            for name in task_names:
+                if name not in seen:
+                    names.append(name)
+                    seen.add(name)
+        return names
+
+    def get_hf_to_megatron_task_groups(self, max_bytes: int) -> list[tuple[list[Any], list[str]]]:
+        """Group complete Bridge tasks for bounded, partial conversion.
+
+        A fused mapping such as QKV is never split because its three HF tensors
+        must be available to Bridge at the same time.  Target shard bytes
+        multiplied by TP size are a conservative estimate of the full TP1 HF
+        source size used by SGLang. These groups only bound temporary tensor
+        lifetime; no persistent conversion bucket is allocated.
+        """
+        if max_bytes <= 0:
+            raise ValueError(f"max_bytes must be positive, got {max_bytes}")
+
+        tp_size = max(mpu.get_tensor_model_parallel_world_size(), 1)
+        chunks: list[tuple[list[Any], list[str]]] = []
+        current_tasks: list[Any] = []
+        current_bytes = 0
+        for task in self.get_hf_to_megatron_tasks():
+            task_bytes = task.param_weight.numel() * task.param_weight.element_size() * tp_size
+            if current_tasks and current_bytes + task_bytes > max_bytes:
+                chunks.append((current_tasks, self.get_required_hf_names_for_tasks(current_tasks)))
+                current_tasks = []
+                current_bytes = 0
+            current_tasks.append(task)
+            current_bytes += task_bytes
+        if current_tasks:
+            chunks.append((current_tasks, self.get_required_hf_names_for_tasks(current_tasks)))
+        return chunks
+
+    @torch.no_grad()
+    def load_hf_views(self, state: Mapping[str, torch.Tensor], tasks: Sequence[Any] | None = None) -> int:
+        """Convert CUDA HF views and overwrite the existing local Megatron
+        shards."""
+        tasks = list(tasks) if tasks is not None else self.get_hf_to_megatron_tasks()
+        required_names = self.get_required_hf_names_for_tasks(tasks)
+        missing = [name for name in required_names if name not in state]
+        if missing:
+            raise ValueError(f"SGLang export is missing {len(missing)} weights: {missing[:8]}")
+
+        task_by_key = {(task.vp_stage or 0, task.param_name): task for task in tasks}
+        source = SimpleNamespace(state=state)
+        converted_count = 0
+        for converted in self._bridge.stream_weights_hf_to_megatron(
+            source,
+            self._model,
+            conversion_tasks=tasks,
+        ):
+            key = (converted.vp_stage or 0, converted.param_name)
+            task = task_by_key.get(key)
+            if task is None:
+                raise ValueError(f"Bridge returned an unknown Megatron weight: {key}")
+            target = task.param_weight
+            if converted.weight.shape != target.shape:
+                raise ValueError(
+                    f"Shape mismatch for {task.global_param_name}: "
+                    f"export={tuple(converted.weight.shape)}, target={tuple(target.shape)}"
+                )
+            if converted.weight.dtype != target.dtype:
+                raise ValueError(
+                    f"Dtype mismatch for {task.global_param_name}: "
+                    f"export={converted.weight.dtype}, target={target.dtype}"
+                )
+            target.copy_(converted.weight)
+            converted_count += 1
+
+        if converted_count != len(tasks):
+            raise ValueError(f"Bridge converted {converted_count} weights, expected {len(tasks)}")
+        return converted_count
 
     def broadcast_and_apply_configs(self) -> None:
         """Broadcast ``_config_map`` across PP ranks and patch remaining tasks.

--- a/relax/backends/megatron/weight_update/colocate_handoff.py
+++ b/relax/backends/megatron/weight_update/colocate_handoff.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Iterable
+
+import ray
+import torch
+import torch.distributed as dist
+from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
+from torch_memory_saver import torch_memory_saver
+
+from relax.utils import device as device_utils
+from relax.utils.distributed_utils import get_gloo_group
+from relax.utils.memory_utils import clear_memory
+from relax.utils.timer import Timer
+from relax.utils.weight_handoff import get_memory_preflight_error
+
+from .update_weight_from_sglang import UpdateWeightFromSGLang
+
+
+logger = logging.getLogger(__name__)
+
+_TRAIN_MODEL_REGION = "colocate_train_model"
+
+
+@contextmanager
+def _nvtx_range(name: str):
+    if torch.cuda.is_available():
+        with torch.cuda.nvtx.range(name):
+            yield
+    else:
+        yield
+
+
+def _leaf_optimizers(optimizer: Any) -> Iterable[Any]:
+    chained = getattr(optimizer, "chained_optimizers", None)
+    if chained is None:
+        yield optimizer
+        return
+    for child in chained:
+        yield from _leaf_optimizers(child)
+
+
+class ColocateWeightHandoff:
+    """Own the opt-in phase transition between Megatron and SGLang."""
+
+    def __init__(
+        self,
+        *,
+        args,
+        model,
+        optimizer,
+        weights_backuper,
+        weight_updater,
+        memory_saver_enabled: bool,
+    ) -> None:
+        if not memory_saver_enabled:
+            raise RuntimeError("--colocate-weight-handoff requires torch_memory_saver")
+        self.args = args
+        self.model = model
+        self.optimizer = optimizer
+        self.weights_backuper = weights_backuper
+        self.weight_updater = weight_updater
+        self.reverse_updater = UpdateWeightFromSGLang(weight_updater.bridge_converter)
+        self.rollout_manager = None
+        self.has_live_train_weights = True
+        self.initial_weight_sync = True
+        self._optimizer_offloaded = False
+        self._optimizer_offload_started: float | None = None
+        self._preflight_done = False
+        self._rollout_to_train_elapsed = 0.0
+        self._nvtx_phase: str | None = None
+        self._nonweight_offload_ref = None
+        self._nonweight_offload_started: float | None = None
+        self._train_region_bytes = int(getattr(args, "_colocate_train_model_bytes", 0))
+
+        leaves = list(_leaf_optimizers(optimizer))
+        unsupported = [type(opt).__name__ for opt in leaves if not hasattr(opt, "enable_state_offload")]
+        if unsupported:
+            raise RuntimeError(
+                "--colocate-weight-handoff requires Megatron DistributedOptimizer; "
+                f"unsupported optimizers: {unsupported}"
+            )
+        for opt in leaves:
+            opt.enable_state_offload()
+
+    def set_rollout_manager(self, rollout_manager) -> None:
+        self.rollout_manager = rollout_manager
+
+    def offload_initial_train_state(self) -> None:
+        """Free training-only GPU state before SGLang starts for the first
+        time."""
+        self._submit_optimizer_offload()
+        device_utils.synchronize()
+        self._release_optimizer_gpu_state()
+        torch_memory_saver.pause(_TRAIN_MODEL_REGION)
+        self.has_live_train_weights = False
+        clear_memory()
+
+    def _connect_rollout_engines(self) -> tuple[list[Any], int]:
+        if self.rollout_manager is None:
+            raise RuntimeError("Rollout manager is not attached to the colocate handoff")
+        rollout_engines, rollout_lock, num_new, gpu_counts, gpu_offsets = ray.get(
+            self.rollout_manager.get_rollout_engines_and_lock.remote()
+        )
+        if num_new > 0 or self.weight_updater._ipc_engine is None:
+            self.weight_updater.connect_rollout_engines(
+                rollout_engines,
+                rollout_lock,
+                engine_gpu_counts=gpu_counts,
+                engine_gpu_offsets=gpu_offsets,
+            )
+            dist.barrier(group=get_gloo_group())
+            if dist.get_rank() == 0:
+                ray.get(self.rollout_manager.clear_num_new_engines.remote())
+        return rollout_engines, num_new
+
+    def _record_peak_memory(self) -> None:
+        free_bytes, total_bytes = torch.cuda.mem_get_info()
+        used_gib = (total_bytes - free_bytes) / 1024**3
+        timer = Timer()
+        timer.timers["colocate_peak_gpu_memory_gib"] = max(
+            timer.timers.get("colocate_peak_gpu_memory_gib", 0.0), used_gib
+        )
+
+    def _push_phase(self, name: str) -> None:
+        if not torch.cuda.is_available():
+            return
+        if self._nvtx_phase is not None:
+            raise RuntimeError(f"NVTX phase {self._nvtx_phase!r} is already active")
+        torch.cuda.nvtx.range_push(name)
+        self._nvtx_phase = name
+
+    def _pop_phase(self, expected: str) -> None:
+        if not torch.cuda.is_available():
+            return
+        if self._nvtx_phase is None:
+            return
+        if self._nvtx_phase != expected:
+            raise RuntimeError(f"Expected NVTX phase {expected!r}, found {self._nvtx_phase!r}")
+        torch.cuda.nvtx.range_pop()
+        self._nvtx_phase = None
+
+    def _collect_preflight_errors(self, *, target: str, target_bytes: int) -> list[str]:
+        free_bytes, total_bytes = torch.cuda.mem_get_info()
+        bucket_bytes = int(self.args.update_weight_buffer_size)
+        margin_bytes = max(int(self.args.train_memory_margin_bytes), 0)
+        local_error = get_memory_preflight_error(
+            rank=dist.get_rank(),
+            target=target,
+            free_bytes=free_bytes,
+            total_bytes=total_bytes,
+            target_bytes=target_bytes,
+            bucket_bytes=bucket_bytes,
+            margin_bytes=margin_bytes,
+        )
+        errors = [None] * dist.get_world_size()
+        dist.all_gather_object(errors, local_error, group=get_gloo_group())
+        return [error for error in errors if error is not None]
+
+    def _preflight_allocation(self, *, target: str, target_bytes: int) -> None:
+        errors = self._collect_preflight_errors(target=target, target_bytes=target_bytes)
+        if errors:
+            raise RuntimeError(
+                "colocate weight handoff memory preflight failed before allocation: " + "; ".join(errors)
+            )
+
+    def _preflight_train_allocation(self) -> None:
+        if self._preflight_done:
+            return
+        self._preflight_allocation(target="Megatron", target_bytes=self._train_region_bytes)
+        self._preflight_done = True
+
+    def _preflight_rollout_allocation(self) -> None:
+        target_bytes = self.reverse_updater.last_source_bytes
+        if target_bytes <= 0:
+            raise RuntimeError("SGLang target weight size is unknown before train-to-rollout handoff")
+        self._preflight_allocation(target="SGLang", target_bytes=target_bytes)
+
+    def _begin_nonweight_offload(self) -> None:
+        if dist.get_rank() != 0:
+            return
+        self._nonweight_offload_started = time.monotonic()
+        self._nonweight_offload_ref = self.rollout_manager.offload.remote(
+            tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH]
+        )
+
+    def _complete_nonweight_offload(self) -> None:
+        if dist.get_rank() == 0 and self._nonweight_offload_ref is not None:
+            ray.get(self._nonweight_offload_ref)
+            Timer().add("sglang_nonweight_offload", time.monotonic() - self._nonweight_offload_started)
+            self._nonweight_offload_ref = None
+            self._nonweight_offload_started = None
+
+    def _submit_optimizer_offload(self) -> None:
+        if self._optimizer_offloaded:
+            return
+        self._optimizer_offload_started = time.monotonic()
+        for opt in _leaf_optimizers(self.optimizer):
+            opt.offload_states()
+        self._optimizer_offloaded = True
+
+    def _release_optimizer_gpu_state(self) -> None:
+        if not self._optimizer_offloaded:
+            return
+        for opt in _leaf_optimizers(self.optimizer):
+            opt.release_offloaded_gpu_states()
+        if self._optimizer_offload_started is not None:
+            Timer().add("optimizer_offload", time.monotonic() - self._optimizer_offload_started)
+            self._optimizer_offload_started = None
+
+    def _reload_optimizer(self) -> None:
+        if not self._optimizer_offloaded:
+            return
+        for opt in _leaf_optimizers(self.optimizer):
+            opt.reload_offloaded_states()
+        self._optimizer_offloaded = False
+        self._optimizer_offload_started = None
+
+    def prepare_train(self) -> None:
+        """Release rollout-only state and allocate the Megatron target
+        region."""
+        started = time.monotonic()
+        self._pop_phase("colocate_rollout")
+        with _nvtx_range("colocate_rollout_to_train"):
+            self._begin_nonweight_offload()
+            try:
+                errors = self._collect_preflight_errors(target="Megatron", target_bytes=self._train_region_bytes)
+                if errors:
+                    self._complete_nonweight_offload()
+                    dist.barrier(group=get_gloo_group())
+                    self._preflight_train_allocation()
+                else:
+                    self._preflight_done = True
+                torch_memory_saver.resume(_TRAIN_MODEL_REGION)
+                self._record_peak_memory()
+            except Exception:
+                self._complete_nonweight_offload()
+                dist.barrier(group=get_gloo_group())
+                if dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.onload_kv.remote())
+                raise
+        self._rollout_to_train_elapsed = time.monotonic() - started
+        self._push_phase("colocate_train")
+
+    def activate_train_weights(self) -> None:
+        """Complete SGLang->Megatron restore after any reference forward."""
+        started = time.monotonic()
+        try:
+            with _nvtx_range("sglang_to_megatron"):
+                self._complete_nonweight_offload()
+                dist.barrier(group=get_gloo_group())
+                self._connect_rollout_engines()
+                count = self.reverse_updater.update_weights(
+                    self.weight_updater._ipc_engine,
+                    expected_version=self.weight_updater.weight_version,
+                )
+                dist.barrier(group=get_gloo_group())
+            Timer().add("sglang_to_megatron", time.monotonic() - started)
+
+            if dist.get_rank() == 0:
+                ray.get(self.rollout_manager.offload.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS]))
+            dist.barrier(group=get_gloo_group())
+            self._reload_optimizer()
+            self.has_live_train_weights = True
+            Timer().add(
+                "colocate_rollout_to_train",
+                self._rollout_to_train_elapsed + time.monotonic() - started,
+            )
+            self._rollout_to_train_elapsed = 0.0
+            logger.info("Restored %d Megatron weights from live SGLang tensors", count)
+        except Exception:
+            self._pop_phase("colocate_train")
+            torch_memory_saver.pause(_TRAIN_MODEL_REGION)
+            clear_memory()
+            if dist.get_rank() == 0:
+                ray.get(self.rollout_manager.onload_kv.remote())
+            self._rollout_to_train_elapsed = 0.0
+            self._push_phase("colocate_rollout")
+            raise
+
+    def to_rollout(self) -> None:
+        """Push live Megatron weights, then release training state and resume
+        KV."""
+        started = time.monotonic()
+        self._pop_phase("colocate_train")
+        was_initial_sync = self.initial_weight_sync
+        rollout_weights_resumed = False
+        source_released = False
+        with _nvtx_range("colocate_train_to_rollout"):
+            try:
+                self._connect_rollout_engines()
+                if not was_initial_sync:
+                    self._submit_optimizer_offload()
+                    self._preflight_rollout_allocation()
+
+                if dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.onload_weights.remote())
+                dist.barrier(group=get_gloo_group())
+                rollout_weights_resumed = True
+                self._record_peak_memory()
+
+                update_started = time.monotonic()
+                # TMS-backed model storage cannot be exported through
+                # PyTorch's CUDA IPC reducer.  Keep the model in its tagged
+                # region, but allocate the existing flattened transfer
+                # buckets from an ordinary CUDA mempool.
+                with torch_memory_saver.disable():
+                    self.weight_updater.update_weights()
+                Timer().add("megatron_to_sglang", time.monotonic() - update_started)
+                dist.barrier(group=get_gloo_group())
+
+                if not was_initial_sync:
+                    release_started = time.monotonic()
+                    device_utils.synchronize()
+                    self._release_optimizer_gpu_state()
+                    torch_memory_saver.pause(_TRAIN_MODEL_REGION)
+                    clear_memory()
+                    Timer().add("train_weight_release", time.monotonic() - release_started)
+                    self.has_live_train_weights = False
+                    source_released = True
+
+                # KV/graph restoration may consume most of the rollout GPU.
+                # Wait until every colocated training rank has released its
+                # model and optimizer allocations before rank 0 resumes it.
+                dist.barrier(group=get_gloo_group())
+                if dist.get_rank() == 0:
+                    resume_started = time.monotonic()
+                    ray.get(self.rollout_manager.onload_kv.remote())
+                    Timer().add("rollout_kv_graph_resume", time.monotonic() - resume_started)
+                dist.barrier(group=get_gloo_group())
+                if was_initial_sync:
+                    initial_cpu_weights = self.weights_backuper.get("actor")
+                    initial_host_gib = (
+                        sum(tensor.numel() * tensor.element_size() for tensor in initial_cpu_weights.values())
+                        / 1024**3
+                    )
+                    Timer().add("colocate_weight_host_transfer_gib", initial_host_gib)
+                    self.weights_backuper.discard("actor")
+                    clear_memory(clear_host_memory=True)
+                    self.initial_weight_sync = False
+                else:
+                    Timer().timers.setdefault("colocate_weight_host_transfer_gib", 0.0)
+            except Exception:
+                # Once the Megatron source is released, the successfully updated
+                # SGLang weights are the only valid copy and must remain mapped.
+                if rollout_weights_resumed and not source_released and dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.offload.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS]))
+                if not was_initial_sync and not source_released:
+                    self._reload_optimizer()
+                self._push_phase("colocate_rollout" if source_released else "colocate_train")
+                raise
+        Timer().add("colocate_train_to_rollout", time.monotonic() - started)
+        self._push_phase("colocate_rollout")

--- a/relax/backends/megatron/weight_update/static_state.py
+++ b/relax/backends/megatron/weight_update/static_state.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from collections.abc import Sequence
+
+import torch
+
+
+def relocate_colocate_static_tensors(model_chunks: Sequence[torch.nn.Module]) -> int:
+    """Move Qwen3-VL static CUDA state out of the no-backup model region."""
+    relocated_bytes = 0
+    for model_chunk in model_chunks:
+        for module in model_chunk.modules():
+            if type(module).__name__ != "Qwen3VLMultimodalRotaryEmbedding":
+                continue
+            inv_freq = getattr(module, "inv_freq", None)
+            if not isinstance(inv_freq, torch.Tensor) or isinstance(inv_freq, torch.nn.Parameter):
+                raise RuntimeError(
+                    "--colocate-weight-handoff requires Qwen3-VL rotary inv_freq to be a non-parameter tensor"
+                )
+            module.inv_freq = inv_freq.detach().clone()
+            relocated_bytes += inv_freq.numel() * inv_freq.element_size()
+    if relocated_bytes == 0:
+        raise RuntimeError("--colocate-weight-handoff could not find Qwen3-VL rotary inv_freq")
+    return relocated_bytes

--- a/relax/backends/megatron/weight_update/update_weight_from_sglang.py
+++ b/relax/backends/megatron/weight_update/update_weight_from_sglang.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from typing import Any
+
+import ray
+import torch
+
+from relax.utils import device as device_utils
+from relax.utils.weight_handoff import validate_export_response
+
+from ..sglang import MultiprocessingSerializer, monkey_patch_torch_reductions
+from .bridge_converter import BridgeConverter
+
+
+class UpdateWeightFromSGLang:
+    """Restore Megatron shards from partial same-GPU SGLang CUDA IPC
+    exports."""
+
+    def __init__(self, converter: BridgeConverter) -> None:
+        self.converter = converter
+        self.names = converter.get_required_hf_names()
+        self.task_groups = converter.get_hf_to_megatron_task_groups(int(converter._args.update_weight_buffer_size))
+        self.last_source_bytes = 0
+
+    @torch.no_grad()
+    def update_weights(self, ipc_engine: Any, expected_version: int | str) -> int:
+        if ipc_engine is None:
+            raise RuntimeError("No colocated SGLang engine is paired with this Megatron rank")
+
+        monkey_patch_torch_reductions()
+        converted_count = 0
+        source_bytes = 0
+        for tasks, names in self.task_groups:
+            response = ray.get(ipc_engine.export_weights_to_tensor.remote(names=names, load_format="hf"))
+            metadata, serialized = validate_export_response(response, names, expected_version)
+            named_tensors = MultiprocessingSerializer.deserialize(serialized)
+            if [name for name, _ in named_tensors] != names:
+                raise RuntimeError("SGLang exported tensor names do not match the requested Bridge weights")
+
+            state = {}
+            for (name, tensor), item in zip(named_tensors, metadata, strict=True):
+                expected_shape = tuple(item.get("shape", ()))
+                expected_dtype = item.get("dtype")
+                if tuple(tensor.shape) != expected_shape:
+                    raise RuntimeError(
+                        f"SGLang export shape mismatch for {name}: metadata={expected_shape}, "
+                        f"tensor={tuple(tensor.shape)}"
+                    )
+                if str(tensor.dtype).removeprefix("torch.") != expected_dtype:
+                    raise RuntimeError(
+                        f"SGLang export dtype mismatch for {name}: metadata={expected_dtype}, tensor={tensor.dtype}"
+                    )
+                if not tensor.is_cuda:
+                    raise RuntimeError(f"SGLang export for {name} is not a CUDA IPC tensor")
+                state[name] = tensor
+                source_bytes += tensor.numel() * tensor.element_size()
+
+            converted_count += self.converter.load_hf_views(state, tasks=tasks)
+            # The sender may recycle this task group's temporary IPC storage
+            # once Bridge has consumed all mappings.
+            device_utils.synchronize()
+            del state, named_tensors, serialized, response
+
+        # All consumers must finish before the source engine can release its weight region.
+        device_utils.synchronize()
+        self.last_source_bytes = source_bytes
+        return converted_count

--- a/relax/backends/megatron/weight_update/update_weight_from_tensor.py
+++ b/relax/backends/megatron/weight_update/update_weight_from_tensor.py
@@ -88,6 +88,13 @@ class UpdateWeightFromTensor:
         self._model_update_groups = None
         self.distributed_rollout_engines: list[ActorHandle] = []
 
+    @property
+    def bridge_converter(self):
+        converter = getattr(self._hf_weight_iterator, "_bridge_converter", None)
+        if converter is None:
+            raise RuntimeError("Colocate weight handoff requires the Megatron Bridge weight iterator")
+        return converter
+
     def connect_rollout_engines(
         self,
         rollout_engines: Sequence[ActorHandle],

--- a/relax/backends/sglang/sglang_engine.py
+++ b/relax/backends/sglang/sglang_engine.py
@@ -758,9 +758,18 @@ class SGLangEngine(RayActor):
         response.raise_for_status()
         return response.json()["weight_version"]
 
-    def release_memory_occupation(self):
+    def export_weights_to_tensor(self, names: list[str], load_format: str = "hf"):
+        return self._make_request(
+            "export_weights_to_tensor",
+            {"names": names, "load_format": load_format},
+        )
+
+    def release_memory_occupation(self, tags: list[str] = None):
         self.flush_cache()
-        return self._make_request("release_memory_occupation")
+        return self._make_request(
+            "release_memory_occupation",
+            {"tags": tags},
+        )
 
     def resume_memory_occupation(self, tags: list[str] = None):
         """Available tags for multi-stage resume: weights, kv_cache."""

--- a/relax/components/actor.py
+++ b/relax/components/actor.py
@@ -237,7 +237,11 @@ class Actor(Base):
         # by /predict, no async GPU contention.
         if is_sft_mode(self.config):
             return True
-        if self.config.offload_rollout and self._rollout_barrier is not None:
+        if (
+            self.config.offload_rollout
+            and self._rollout_barrier is not None
+            and not getattr(self.config, "colocate_weight_handoff", False)
+        ):
             self._rollout_barrier.wait_offloaded_sync()
 
         # PPO colocate: also block until critic has finished this round
@@ -250,7 +254,6 @@ class Actor(Base):
             and self.step >= getattr(self.config, "num_critic_only_steps", 0)
         ):
             self._peer_barrier.wait_completed_round_sync(self.step)
-
         return True
 
     def _execute_training(self) -> bool:

--- a/relax/components/rollout.py
+++ b/relax/components/rollout.py
@@ -436,7 +436,7 @@ class Rollout(Base):
                 self._logger.info(f"Start rollout {local_step}/{self.config.num_rollout}")
                 try:
                     await self.rollout_manager.generate.remote(rollout_id=local_step)
-                    if self.config.offload_rollout:
+                    if self.config.offload_rollout and not getattr(self.config, "colocate_weight_handoff", False):
                         await self.rollout_manager.offload.remote()
                 except Exception as e:
                     error_msg = f"Rollout generation failed at step {local_step}: {type(e).__name__}: {str(e)}"

--- a/relax/distributed/ray/rollout.py
+++ b/relax/distributed/ray/rollout.py
@@ -559,12 +559,12 @@ class EngineGroup:
         ]
         return init_handles, port_cursors
 
-    def offload(self):
+    def offload(self, tags: list[str] | None = None):
         """Fire release_memory_occupation on all engines (non-blocking).
 
         Returns a list of Ray ObjectRefs.
         """
-        return [engine.release_memory_occupation.remote() for engine in self.engines if engine is not None]
+        return [engine.release_memory_occupation.remote(tags=tags) for engine in self.engines if engine is not None]
 
     def onload(self, tags: list[str] | None = None):
         """Fire resume_memory_occupation on all engines (non-blocking).
@@ -734,11 +734,11 @@ class RolloutServer:
                 [engine.resume_memory_occupation.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS]) for engine in new_engines_all]
             )
 
-    def offload(self):
+    def offload(self, tags: list[str] | None = None):
         """Release memory occupation across all groups (concurrent)."""
         handles = []
         for g in self.engine_groups:
-            handles.extend(g.offload())
+            handles.extend(g.offload(tags))
         return ray.get(handles) if handles else []
 
     def onload(self, tags: list[str] | None = None):
@@ -1128,18 +1128,18 @@ class RolloutManager(ReloadableMixin):
         except Exception as e:
             logger.warning(f"Failed to load data source: {e}")
 
-    async def offload(self):
-        self._offload_local()
+    async def offload(self, tags: list[str] | None = None):
+        self._offload_local(tags)
 
-    def _offload_local(self):
+    def _offload_local(self, tags: list[str] | None = None):
         """Sync body of offload(); safe to call directly from code running
         inside this actor's process (e.g. custom_reward_post_process)."""
-        if self.status == "offload":
+        if self.status == "offload" and tags is None:
             logger.info("Rollout already offloaded; skipping")
             return
         self.health_monitoring_pause()
         for srv in self.servers.values():
-            srv.offload()
+            srv.offload(tags)
         self.status = "offload"
 
     async def onload(self, tags: list[str] | None = None):

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -236,6 +236,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--colocate-weight-handoff",
+                action="store_true",
+                default=False,
+                help=(
+                    "Enable the experimental GPU-direct bidirectional weight handoff between "
+                    "Megatron and SGLang in synchronous colocate mode. Disabled by default."
+                ),
+            )
+            parser.add_argument(
                 "--offload",
                 action="store_true",
                 default=False,
@@ -2553,6 +2562,60 @@ def _normalize_sync_ppo_kl_args(args) -> bool:
     return True
 
 
+def _validate_colocate_weight_handoff(args) -> None:
+    if not getattr(args, "colocate_weight_handoff", False):
+        return
+
+    errors = []
+    if not getattr(args, "colocate", False) or getattr(args, "fully_async", False):
+        errors.append("requires synchronous --colocate mode")
+    if getattr(args, "train_backend", "megatron") != "megatron":
+        errors.append("requires the Megatron training backend")
+    if not getattr(args, "offload_train", False) or not getattr(args, "offload_rollout", False):
+        errors.append("requires --offload-train and --offload-rollout")
+    if getattr(args, "tensor_model_parallel_size", None) != 2:
+        errors.append("requires Megatron tensor parallel size 2")
+    if getattr(args, "pipeline_model_parallel_size", 1) != 1:
+        errors.append("requires Megatron pipeline parallel size 1")
+    if getattr(args, "expert_model_parallel_size", 1) != 1:
+        errors.append("requires Megatron expert parallel size 1")
+    if getattr(args, "context_parallel_size", 1) != 1:
+        errors.append("requires Megatron context parallel size 1")
+    if getattr(args, "rollout_num_gpus_per_engine", None) != 1:
+        errors.append("requires one GPU per SGLang engine (TP=1)")
+    if getattr(args, "sglang_pp_size", 1) != 1 or getattr(args, "sglang_ep_size", 1) != 1:
+        errors.append("requires SGLang PP=1 and EP=1")
+    if getattr(args, "sglang_data_parallel_size", 1) != 1:
+        errors.append("requires SGLang DP=1")
+    if getattr(args, "rollout_external", False) or getattr(args, "sglang_config", None):
+        errors.append("does not support external or custom multi-group rollout layouts")
+    if not getattr(args, "bf16", False) or getattr(args, "fp16", False):
+        errors.append("requires unquantized BF16 weights")
+    if not getattr(args, "use_distributed_optimizer", False):
+        errors.append("requires Megatron DistributedOptimizer")
+    if not getattr(args, "enable_weights_backuper", True):
+        errors.append("requires the initialization-only actor CPU backup")
+    if getattr(args, "num_layers", None) != 36 or getattr(args, "hidden_size", None) != 2560:
+        errors.append("only supports the Qwen3-VL-4B training shape")
+    if getattr(args, "megatron_to_hf_mode", None) != "bridge":
+        errors.append("requires --megatron-to-hf-mode bridge")
+    if getattr(args, "sglang_speculative_algorithm", None):
+        errors.append("does not support speculative decoding")
+    if getattr(args, "sglang_quantization", None):
+        errors.append("does not support quantized SGLang weights")
+    if getattr(args, "use_critic", False):
+        errors.append("does not support a critic")
+    if getattr(args, "genrm_model_path", None):
+        errors.append("does not support a colocated generative reward model")
+    if is_managed_opd_teacher_enabled(args) or getattr(args, "opd_teacher_load", None):
+        errors.append("does not support a teacher model")
+    if getattr(args, "keep_old_actor", False):
+        errors.append("does not support --keep-old-actor")
+
+    if errors:
+        raise ValueError("--colocate-weight-handoff " + "; ".join(errors))
+
+
 def slime_validate_args(args):
     # Backward compatibility: old scripts may pass --enable-gloo-process-groups
     if not hasattr(args, "use_gloo_process_groups"):
@@ -3014,6 +3077,8 @@ def slime_validate_args(args):
 
     if args.use_critic:
         args.offload_train = True
+
+    _validate_colocate_weight_handoff(args)
 
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path

--- a/relax/utils/training/tensor_backper.py
+++ b/relax/utils/training/tensor_backper.py
@@ -41,6 +41,10 @@ class TensorBackuper(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def discard(self, tag: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     def restore(self, tag: str):
         raise NotImplementedError
 
@@ -70,6 +74,9 @@ class _TensorBackuperNormal(TensorBackuper):
     def copy(self, *, src_tag: str, dst_tag: str):
         for name in self._backups[dst_tag]:
             self._backups[dst_tag][name].copy_(self._backups[src_tag][name])
+
+    def discard(self, tag: str) -> None:
+        self._backups.pop(tag, None)
 
     @torch.no_grad()
     def restore(self, tag: str) -> None:
@@ -106,6 +113,11 @@ class _TensorBackuperNoop(TensorBackuper):
         assert tag == self._single_tag
         assert _compute_hash_dict(dict(self._source_getter())) == self._backup_hash_dict
         device_utils.synchronize()
+
+    def discard(self, tag: str) -> None:
+        if tag != self._single_tag:
+            raise ValueError(f"Cannot discard unknown tensor backup tag: {tag}")
+        self._backup_hash_dict = None
 
 
 def _compute_hash_dict(tensors: dict[str, torch.Tensor]):

--- a/relax/utils/training/train_metric_utils.py
+++ b/relax/utils/training/train_metric_utils.py
@@ -34,7 +34,10 @@ def log_perf_data_raw(
     if not is_primary_rank:
         return
 
-    log_dict = {f"perf/{key}_time": val for key, val in log_dict_raw.items()}
+    value_metrics = {"colocate_peak_gpu_memory_gib", "colocate_weight_host_transfer_gib"}
+    log_dict = {
+        (f"perf/{key}" if key in value_metrics else f"perf/{key}_time"): val for key, val in log_dict_raw.items()
+    }
 
     if timer_instance.seq_lens:
         log_dict["perf/actor_train_tokens"] = sum(timer_instance.seq_lens)

--- a/relax/utils/weight_handoff.py
+++ b/relax/utils/weight_handoff.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+
+def get_memory_preflight_error(
+    *,
+    rank: int,
+    target: str,
+    free_bytes: int,
+    total_bytes: int,
+    target_bytes: int,
+    bucket_bytes: int,
+    margin_bytes: int,
+) -> str | None:
+    required_bytes = target_bytes + bucket_bytes + margin_bytes
+    if free_bytes >= required_bytes:
+        return None
+    return (
+        f"rank={rank} target={target}, "
+        f"free={free_bytes / 1024**3:.2f} GiB, "
+        f"target_weights={target_bytes / 1024**3:.2f} GiB, "
+        f"conversion_bucket={bucket_bytes / 1024**3:.2f} GiB, "
+        f"margin={margin_bytes / 1024**3:.2f} GiB, "
+        f"total_gpu={total_bytes / 1024**3:.2f} GiB"
+    )
+
+
+def validate_export_response(response: dict, names: list[str], expected_version: int | str) -> tuple[list, str]:
+    if not response.get("success", False):
+        raise RuntimeError(f"SGLang weight export failed: {response.get('message', 'unknown error')}")
+
+    actual_version = response.get("weight_version")
+    if str(actual_version) != str(expected_version):
+        raise RuntimeError(f"SGLang weight version mismatch: expected {expected_version}, got {actual_version}")
+
+    metadata = response.get("metadata")
+    if not isinstance(metadata, list) or len(metadata) != len(names):
+        raise RuntimeError(
+            f"SGLang export metadata count mismatch: expected {len(names)}, "
+            f"got {0 if metadata is None else len(metadata)}"
+        )
+    if [item.get("name") for item in metadata] != names:
+        raise RuntimeError("SGLang export metadata names do not match the requested Bridge weights")
+
+    serialized = response.get("serialized_named_tensors")
+    if not serialized:
+        raise RuntimeError("SGLang export returned no serialized CUDA tensors")
+    return metadata, serialized

--- a/scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh
+++ b/scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 #
-# Qwen3-VL-4B 8xGPU colocate training script.
+# Qwen3-VL-4B colocate training script (8 GPUs by default).
 #
 # Usage:
 #   bash scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh
@@ -20,11 +20,20 @@ if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
 fi
 source "${MODEL_CONFIG_DIR}/qwen3-vl-4B.sh"
 
+TASK_GPUS="${TASK_GPUS:-${NUM_GPUS:-8}}"
+
 PROJECT_NAME="${PROJECT_NAME:=Relax/dev/openr1mm}"
 EXP_DIR="${EXP_DIR:-${SCRIPT_DIR}/../../../../exps}"
 MODEL_DIR="${MODEL_DIR:-${EXP_DIR}}"
 DATA_DIR="${DATA_DIR:-${EXP_DIR}}"
 NUM_ROLLOUT="${NUM_ROLLOUT:=200}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-64}"
+N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-8}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-512}"
+ROLLOUT_MAX_RESPONSE_LEN="${ROLLOUT_MAX_RESPONSE_LEN:-8192}"
+ROLLOUT_MAX_PROMPT_LEN="${ROLLOUT_MAX_PROMPT_LEN:-2048}"
+MAX_TOKENS_PER_GPU="${MAX_TOKENS_PER_GPU:-20480}"
+LOG_PROBS_MAX_TOKENS_PER_GPU="${LOG_PROBS_MAX_TOKENS_PER_GPU:-40960}"
 
 CKPT_ARGS=(
    --hf-checkpoint ${MODEL_DIR}/Qwen3-VL-4B-Instruct/
@@ -47,11 +56,11 @@ ROLLOUT_ARGS=(
    --balance-data
    --rm-type openr1mm
    --num-rollout ${NUM_ROLLOUT}
-   --rollout-batch-size 64
-   --n-samples-per-prompt 8
-   --global-batch-size 512
-   --rollout-max-response-len 8192
-   --rollout-max-prompt-len 2048
+   --rollout-batch-size ${ROLLOUT_BATCH_SIZE}
+   --n-samples-per-prompt ${N_SAMPLES_PER_PROMPT}
+   --global-batch-size ${GLOBAL_BATCH_SIZE}
+   --rollout-max-response-len ${ROLLOUT_MAX_RESPONSE_LEN}
+   --rollout-max-prompt-len ${ROLLOUT_MAX_PROMPT_LEN}
    --rollout-temperature 1.0
 )
 
@@ -70,8 +79,8 @@ PERF_ARGS=(
    # --qkv-format bshd
    # --micro-batch-size 1 # avoid OOM
    --use-dynamic-batch-size
-   --max-tokens-per-gpu 20480
-   --log-probs-max-tokens-per-gpu 40960
+   --max-tokens-per-gpu ${MAX_TOKENS_PER_GPU}
+   --log-probs-max-tokens-per-gpu ${LOG_PROBS_MAX_TOKENS_PER_GPU}
 
    --no-rope-fusion
    --calculate-per-token-loss
@@ -102,6 +111,7 @@ OPTIMIZER_ARGS=(
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 1
    --sglang-mem-fraction-static 0.8
+   --num-gpus-per-node "${TASK_GPUS}"
 )
 
 WANDB_ARGS=(
@@ -109,7 +119,7 @@ WANDB_ARGS=(
    --use-clearml
    --use-metrics-service
    --tb-project-name ${PROJECT_NAME}
-   --tb-experiment-name qwen3-vl-4b-GRPO-gpu8-${now}
+   --tb-experiment-name qwen3-vl-4b-GRPO-gpu${TASK_GPUS}-${now}
 )
 
 MISC_ARGS=(
@@ -123,12 +133,17 @@ MISC_ARGS=(
    --attention-backend flash
 )
 
+HANDOFF_ARGS=()
+if [ "${ENABLE_COLOCATE_WEIGHT_HANDOFF:-0}" = "1" ]; then
+   HANDOFF_ARGS+=(--colocate-weight-handoff)
+fi
+
 mkdir -p log
 ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
    ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
    --runtime-env-json="${RUNTIME_ENV_JSON}" \
    -- python3 -m relax.entrypoints.train \
-   --resource '{"actor": [1, 8], "rollout": [1, 8]}'\
+   --resource "{\"actor\": [1, ${TASK_GPUS}], \"rollout\": [1, ${TASK_GPUS}]}"\
    --max-staleness 0 \
    --num-data-storage-units 1 \
    --colocate \
@@ -141,4 +156,5 @@ ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
    "${WANDB_ARGS[@]}" \
    "${PERF_ARGS[@]}" \
    "${SGLANG_ARGS[@]}" \
-   "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-vl-4b-GRPO-gpu8-${now}.log
+   "${HANDOFF_ARGS[@]}" \
+   "${MISC_ARGS[@]}"  2>&1 | tee "log/qwen3-vl-4b-GRPO-gpu${TASK_GPUS}-${now}.log"

--- a/tests/backends/megatron/test_colocate_weight_handoff.py
+++ b/tests/backends/megatron/test_colocate_weight_handoff.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import pytest
+import torch
+
+from relax.backends.megatron.weight_update.static_state import relocate_colocate_static_tensors
+from relax.utils.weight_handoff import get_memory_preflight_error, validate_export_response
+
+
+NAMES = ["model.language_model.embed_tokens.weight", "lm_head.weight"]
+
+
+class Qwen3VLMultimodalRotaryEmbedding(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.inv_freq = torch.arange(8, dtype=torch.float32)
+
+
+class OtherRotaryEmbedding(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.inv_freq = torch.arange(4, dtype=torch.float32)
+
+
+def _response(**overrides):
+    response = {
+        "success": True,
+        "message": "Success",
+        "weight_version": "7",
+        "serialized_named_tensors": "ipc-payload",
+        "metadata": [{"name": name, "shape": [2, 2], "dtype": "bfloat16"} for name in NAMES],
+    }
+    response.update(overrides)
+    return response
+
+
+def test_export_response_validation_accepts_matching_contract():
+    metadata, serialized = validate_export_response(_response(), NAMES, expected_version=7)
+
+    assert [item["name"] for item in metadata] == NAMES
+    assert serialized == "ipc-payload"
+
+
+def test_export_response_validation_rejects_stale_version():
+    with pytest.raises(RuntimeError, match="version mismatch"):
+        validate_export_response(_response(weight_version="6"), NAMES, expected_version=7)
+
+
+def test_export_response_validation_rejects_missing_field():
+    with pytest.raises(RuntimeError, match="metadata count mismatch"):
+        validate_export_response(_response(metadata=_response()["metadata"][:1]), NAMES, expected_version=7)
+
+
+def test_export_response_validation_rejects_reordered_names():
+    metadata = list(reversed(_response()["metadata"]))
+    with pytest.raises(RuntimeError, match="metadata names"):
+        validate_export_response(_response(metadata=metadata), NAMES, expected_version=7)
+
+
+def test_memory_preflight_reports_all_allocation_components():
+    gib = 1024**3
+    error = get_memory_preflight_error(
+        rank=1,
+        target="Megatron",
+        free_bytes=3 * gib,
+        total_bytes=8 * gib,
+        target_bytes=2 * gib,
+        bucket_bytes=1 * gib,
+        margin_bytes=1 * gib,
+    )
+
+    assert error is not None
+    assert "rank=1 target=Megatron" in error
+    assert "target_weights=2.00 GiB" in error
+    assert "conversion_bucket=1.00 GiB" in error
+    assert "margin=1.00 GiB" in error
+
+
+def test_memory_preflight_accepts_exact_capacity():
+    assert (
+        get_memory_preflight_error(
+            rank=0,
+            target="SGLang",
+            free_bytes=4,
+            total_bytes=8,
+            target_bytes=2,
+            bucket_bytes=1,
+            margin_bytes=1,
+        )
+        is None
+    )
+
+
+def test_relocate_colocate_static_tensors_preserves_value_in_new_storage():
+    rotary = Qwen3VLMultimodalRotaryEmbedding()
+    original = rotary.inv_freq
+    model = torch.nn.ModuleList([rotary])
+
+    relocated_bytes = relocate_colocate_static_tensors([model])
+
+    assert torch.equal(rotary.inv_freq, original)
+    assert rotary.inv_freq.data_ptr() != original.data_ptr()
+    assert relocated_bytes == original.numel() * original.element_size()
+
+
+def test_relocate_colocate_static_tensors_ignores_other_rotary_modules():
+    rotary = OtherRotaryEmbedding()
+    original = rotary.inv_freq
+
+    with pytest.raises(RuntimeError, match="could not find Qwen3-VL rotary inv_freq"):
+        relocate_colocate_static_tensors([rotary])
+
+    assert rotary.inv_freq is original

--- a/tests/utils/test_arguments_opd_teacher_colocate.py
+++ b/tests/utils/test_arguments_opd_teacher_colocate.py
@@ -194,3 +194,62 @@ def test_arguments_dynamic_context_parallel_rejects_sft_eval(arguments_module):
 
     with pytest.raises(ValueError, match="this combination can hang and has not been fixed"):
         arguments_module.slime_validate_args(args)
+
+
+def _colocate_handoff_args(**overrides):
+    values = dict(
+        colocate_weight_handoff=True,
+        colocate=True,
+        fully_async=False,
+        train_backend="megatron",
+        offload_train=True,
+        offload_rollout=True,
+        tensor_model_parallel_size=2,
+        pipeline_model_parallel_size=1,
+        expert_model_parallel_size=1,
+        context_parallel_size=1,
+        rollout_num_gpus_per_engine=1,
+        sglang_pp_size=1,
+        sglang_ep_size=1,
+        sglang_data_parallel_size=1,
+        rollout_external=False,
+        sglang_config=None,
+        bf16=True,
+        fp16=False,
+        use_distributed_optimizer=True,
+        enable_weights_backuper=True,
+        num_layers=36,
+        hidden_size=2560,
+        megatron_to_hf_mode="bridge",
+        sglang_speculative_algorithm=None,
+        sglang_quantization=None,
+        use_critic=False,
+        genrm_model_path=None,
+        use_opd=False,
+        opd_teacher_load=None,
+        keep_old_actor=False,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_colocate_weight_handoff_accepts_v1_layout(arguments_module):
+    arguments_module._validate_colocate_weight_handoff(_colocate_handoff_args())
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"tensor_model_parallel_size": 1}, "tensor parallel size 2"),
+        ({"rollout_num_gpus_per_engine": 2}, "one GPU per SGLang engine"),
+        ({"enable_weights_backuper": False}, "initialization-only actor CPU backup"),
+        ({"num_layers": 40}, "Qwen3-VL-4B"),
+    ],
+)
+def test_colocate_weight_handoff_rejects_unsupported_layout(arguments_module, override, message):
+    with pytest.raises(ValueError, match=message):
+        arguments_module._validate_colocate_weight_handoff(_colocate_handoff_args(**override))
+
+
+def test_colocate_weight_handoff_disabled_is_a_noop(arguments_module):
+    arguments_module._validate_colocate_weight_handoff(SimpleNamespace(colocate_weight_handoff=False))


### PR DESCRIPTION
## What

- Closes #169.
- Adds an opt-in `--colocate-weight-handoff` path for Qwen3-VL-4B colocate training.
- Reuses live GPU weights in both phase transitions instead of staging actor weights through Host memory.
- Releases phase-specific non-weight state and overlaps optimizer offload with the train-to-rollout handoff.
- Keeps the existing colocate path unchanged when the switch is disabled.

## Why

On the four-GPU colocate baseline, rollout and training share the same GPUs and phase transitions block the full training step. The legacy `sleep + wake_up + update_weights` transition proxy takes 13.266 seconds out of a 22.361-second mean step, or 59.3% of the host-observed step wall time. Train-to-rollout is the dominant transition at 10.530 seconds.

The existing path also stages actor weights through Host memory and restores more engine state than each destination phase needs. This PR introduces direct GPU-to-GPU layout conversion and selective state release to reduce that serialized overhead.

## How

- Adds `ColocateWeightHandoff` to coordinate rollout-to-train and train-to-rollout transitions, memory preflight checks, source lifetime, failure cleanup, and timing metrics.
- Splits rollout-to-train into `prepare_train()` and `activate_train_weights()` so reference work and non-weight release can overlap before SGLang weights are imported into Megatron.
- Adds `UpdateWeightFromSGLang` and extends the Megatron Bridge conversion path to write the current TP2 shards directly from exported SGLang CUDA tensors.
- Adds a Qwen3-VL inverse mapping in the versioned SGLang patch for text QKV, gate/up projections, vision weights, and tied embeddings.
- Exposes read-only same-node CUDA IPC views through `export_weights_to_tensor()` without an entire-model staging buffer.
- Reuses Megatron's optimizer state offloader through a lazy `enable_state_offload()` entry point.
- Passes `weights`, `kv_cache`, and `cuda_graph` release tags through the Relax SGLang wrapper.
- Keeps the feature disabled by default and rejects unsupported layouts before target allocation.

### Supported V1 configuration

- Qwen3-VL-4B BF16 in colocate mode
- Megatron TP2 / PP1 / EP1
- SGLang TP1
- No quantization, speculative decoding, critic, teacher, or `keep-old-actor`

Disaggregated execution, cross-node reverse handoff, generic converter registration, and long-lived shared parameter addresses are out of scope.

## Testing

### Environment

- Base: `cfda05351d4b137f60e2b71d048beab1316d9d9f`
- Hardware: 4 x NVIDIA A800 80GB PCIe
- Python 3.12.3, CUDA 12.9, PyTorch 2.11.0+cu129
- SGLang 0.5.12.post1, Megatron-Bridge `2faedbf`, Megatron-LM `85bced0`
- Model: Qwen3-VL-4B-Instruct BF16
- Layout: Megatron TP2/PP1/EP1 and four SGLang TP1 engines

### Reproduction

```bash
export CUDA_VISIBLE_DEVICES=0,1,2,3
export NUM_GPUS=4 TASK_GPUS=4
export MODEL_DIR=/root/autodl-tmp/relax-workspace/models
export DATA_DIR=/root/autodl-tmp/relax-workspace/datasets
export NUM_ROLLOUT=23 ROLLOUT_BATCH_SIZE=8
export N_SAMPLES_PER_PROMPT=1 GLOBAL_BATCH_SIZE=8
export ROLLOUT_MAX_PROMPT_LEN=1024 ROLLOUT_MAX_RESPONSE_LEN=256
export MAX_TOKENS_PER_GPU=8192 LOG_PROBS_MAX_TOKENS_PER_GPU=8192
export OMP_NUM_THREADS=24 MKL_NUM_THREADS=24 OPENBLAS_NUM_THREADS=24

ENABLE_COLOCATE_WEIGHT_HANDOFF=0 \
bash scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh

ENABLE_COLOCATE_WEIGHT_HANDOFF=1 \
bash scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh
```

Both sides use the same model, data, hardware, batch sizes, sequence limits, sampling settings, three warmup steps, and 20 measured steps. Startup, checkpoint loading, CUDA graph capture, and dataset scanning are excluded.

### Test results

- `python -m pytest -q tests/backends/megatron/test_colocate_weight_handoff.py tests/utils/test_arguments_opd_teacher_colocate.py`: 19 passed.
- `python -m pytest -q test/registered/unit/models/test_qwen3_vl_weight_export.py`: 3 passed.
- Targeted `ruff check`: passed.
- `bash -n scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh`: passed.
- Versioned SGLang patch applies cleanly to `5a15cde`.
- Versioned Megatron patch applies cleanly to the merged Bridge/MCore source tree.

### Performance

Weighted throughput is total actor-train tokens divided by total measured step wall time.

| Metric | Switch off | Switch on | Change |
|---|---:|---:|---:|
| Mean step time | 22.361 s | 12.645 s | -43.45% |
| P50 step time | 22.505 s | 12.939 s | -42.51% |
| P95 step time | 22.899 s | 13.271 s | -42.05% |
| Weighted total-token throughput | 193.948 tok/s | 343.536 tok/s | +77.13% |
| Response-token throughput | 80.316 tok/s | 142.548 tok/s | +77.48% |
| Actor train MFU | 5.939% | 6.473% | +0.533 pp |
| Rollout-to-train | 2.736 s | 1.673 s | -38.84% |
| Train-to-rollout | 10.530 s | 2.822 s | -73.21% |
| Total transition proxy | 13.266 s | 4.495 s | -66.12% |

Optimized transition components:

| Component | Mean time |
|---|---:|
| SGLang non-weight offload | 0.153 s |
| SGLang-to-Megatron conversion | 0.531 s |
| Megatron-to-SGLang conversion | 0.740 s |
| Optimizer D2H offload | 1.786 s |
| Train weight release | 0.639 s |
| Rollout KV/graph resume | 0.315 s |

The optimized train-to-rollout components sum to 3.479 seconds while the enclosing transition is 2.822 seconds, indicating 0.658 seconds of measured overlap. Weight handoff transferred 0.000 GiB through Host staging. Optimized peak GPU memory was 49.415 GiB mean, 49.935 GiB P95, and 49.981 GiB maximum.

The phase and transition values above are host-observed wall times. The wall-time split changed from 85.51% wait-side / 14.49% train to 58.06% / 41.94%.

### Correctness and cleanup

- Mean train/rollout log-prob absolute difference: 0.01777 off vs. 0.01719 on.
- Mean mismatch KL: 0.001274 off vs. 0.000922 on.
- A separate `n=2` validation completed with nonzero steady-state gradient norms of 1.273 and 2.041.
- Every optimized transition exported 605 live SGLang tensors and updated 713 Megatron parameters.
- All jobs exited without CUDA OOM, NaN/Inf, Ray task failure, or actor failure.
- No Ray, SGLang, Megatron, or GPU compute process remained after shutdown.

- [ ] `pre-commit run --all-files` passes
- [x] Targeted tests pass
- [x] New tests added
- [x] Entry script and default-off configuration updated

## Risk and Rollback

- The optimized transition temporarily requires both source and destination weight layouts to fit on GPU. A preflight check fails before target allocation when the configured memory margin is insufficient.
- Source weights are retained until target validation succeeds. Failed handoffs release incomplete target state and keep the source phase usable.
- The implementation is intentionally restricted to the Qwen3-VL-4B TP2/TP1 layout in V1.
- Rollback requires only removing `--colocate-weight-handoff` or leaving `ENABLE_COLOCATE_WEIGHT_HANDOFF=0`, which restores the existing `sleep/wake/update_weights` path.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Before/after curves and sanitized benchmark logs will be attached to this Draft PR.
