### PR TITLE
[No.29] register, verify and document REINFORCE++ / REINFORCE++-baseline

### DIFF
--- a/.opencode/agents/algorithm-expert.md
+++ b/.opencode/agents/algorithm-expert.md
@@ -24,7 +24,7 @@ Relax 中 RL 算法族的配置、损失计算和奖励函数。For project-leve
 | **SAPO** | Soft gating 替代 hard clipping | `compute_sapo_loss()` |
 | **DAPO** | Dynamic batch size | `--use-dynamic-batch-size` |
 | **REINFORCE++** | Discounted REINFORCE | `--advantage-estimator reinforce_plus_plus` |
-| **REINFORCE++ BL** | + leave-one-out baseline | `--advantage-estimator reinforce_plus_plus_baseline` |
+| **REINFORCE++ BL** | + group-mean baseline（论文 §3.2，独立 k2 KL loss） | `--advantage-estimator reinforce_plus_plus_baseline` |
 | **OPD** | Teacher-student KL penalty | `--on-policy-distillation` |
 
 ## 核心参数

--- a/docs/algorithms/reinforce_plus_plus.md
+++ b/docs/algorithms/reinforce_plus_plus.md
@@ -21,40 +21,48 @@ actor / advantages / reference / actor_fwd，**无 critic**），由 `--advantag
 在 advantage 组件与 `policy_loss_function` 中分发。GRPO 族算法（GRPO / GSPO / SAPO / CISPO /
 REINFORCE++ / REINFORCE++-baseline）共享同一拓扑，拓扑定义集中为 `_GRPO_TOPOLOGY` 单一常量。
 
-| 配置值 | 含义 | 必需参数 |
-|---|---|---|
-| `reinforce_plus_plus` | Monte-Carlo 折扣回报，无 group baseline | `--normalize-advantages` |
-| `reinforce_plus_plus_baseline` | group-mean baseline 版本 | `--normalize-advantages` |
+| 配置值 | 含义 | 必需参数 | KL 口径（论文约定） |
+|---|---|---|---|
+| `reinforce_plus_plus` | Monte-Carlo 折扣回报，无 group baseline | `--normalize-advantages` | `--kl-coef β` 逐 token k1-style 惩罚折入回报（§3.1） |
+| `reinforce_plus_plus_baseline` | group-mean baseline 版本 | `--normalize-advantages` | `--use-kl-loss --kl-loss-type k2 --kl-loss-coef λ` 独立 k2 KL loss（§3.2）；`--kl-coef` 必须为 0 |
 
-`arguments.py` 强制两个变体开启 `--normalize-advantages`，否则报错。两个变体命名可清晰区分；
-切换算法需真正修改 `--advantage-estimator`，而非复制 GRPO recipe 改名。
+`arguments.py` 强制两个变体开启 `--normalize-advantages`，否则报错；并强制
+`reinforce_plus_plus_baseline` 的 `--kl-coef == 0`（其 KL 正则来自独立的 k2 KL loss，折入
+advantage 的惩罚项在该变体中不存在，设置 `--kl-coef` 会被静默忽略，故直接拒绝）。两个变体
+命名可清晰区分；切换算法需真正修改 `--advantage-estimator`，而非复制 GRPO recipe 改名。
 
 ## 3. 公式
 
 设第 $i$ 条样本响应长度 $R_i$、逐 token KL 为 $k_i \in \mathbb{R}^{R_i}$、响应 mask
-$m_i \in \{0,1\}^{R_i}$、标量奖励 $r_i$、KL 系数 $\beta$（`kl_coef`）、折扣 $\gamma$。
-记响应最后一个有效 token 下标为 $t^*_i = \max\{t : m_i[t]=1\}$。
+$m_i \in \{0,1\}^{R_i}$、标量奖励 $r_i$、KL 系数 $\beta$（`kl_coef`）、折扣 $\gamma$、
+独立 KL loss 系数 $\lambda$（`kl_loss_coef`）。记响应最后一个有效 token 下标为
+$t^*_i = \max\{t : m_i[t]=1\}$。
 
 ### 3.1 REINFORCE++（`get_reinforce_plus_plus_returns`）
 
-逐 token 奖励（KL 惩罚 + 终端奖励）：
+对应论文 §3.1 的 REINFORCE++（k=1）：逐 token 奖励（k1-style KL 惩罚 + 终端奖励）：
 
 $$
 \tilde r_i[t] = -\beta \cdot k_i[t] \cdot m_i[t], \quad
 \tilde r_i[t^*_i] \mathrel{+}= r_i
 $$
 
-折扣回报（反向累加）：
+其中逐 token KL 使用 **k1-style 估计器**（论文 "k1-style penalty"：
+$k_i[t] = \log \pi_{\theta_{\text{old}}}(o_t \mid \cdot) - \log \pi_{\text{ref}}(o_t \mid \cdot)$，
+即 Relax `compute_approx_kl` 的 `k1`，由 `--kl-loss-type k1` 选择）。折扣回报（反向累加）：
 
 $$
 G_i[t] = \tilde r_i[t] + \gamma \cdot G_i[t+1], \quad G_i[R_i] = 0
 $$
 
-advantage = return：$A_i = G_i$。**不做 group baseline**（使用原始 $r_i$）。
+advantage = return：$A_i = G_i$。**不做 group baseline**（使用原始 $r_i$）。$\beta$ 由
+`--kl-coef` 给出（recipe 默认 0.001）；论文取 $\gamma = 1$（即 $G_t = \sum_{i \geq t} \tilde r_i$），
+Relax 的 `--gamma` 默认值即 1.0，可配置。
 
 ### 3.2 REINFORCE++-baseline（`get_reinforce_plus_plus_baseline_advantages`）
 
-group baseline 在上游 `post_process_rewards`（`relax/utils/utils.py`）中预先减去：
+对应论文 §3.2 的 "REINFORCE++ /w baseline"（组采样变体，k > 1）。group baseline 在上游
+`post_process_rewards`（`relax/utils/utils.py`）中预先减去：
 
 $$
 \bar r_i = r_i - \mathrm{mean}_{j \in \text{group}(i)} r_j
@@ -62,11 +70,18 @@ $$
 
 与 GRPO / GSPO / SAPO / CISPO 不同，baseline 变体**只做 group-mean 减法，不做 std 归一化**
 （`post_process_rewards` 中 std 除法分支仅对 `grpo/gspo/sapo/cispo` 生效）。随后 advantage
-函数把 $(\bar r_i - \beta k_i)$ 广播到每个 token：
+函数把 $\bar r_i$ 广播到每个 token——**KL 惩罚不折入 advantage**（论文 §3.2：该变体采用
+独立 KL loss 项做正则）：
 
 $$
-A_i[t] = \bar r_i - \beta \cdot k_i[t], \quad \text{return} = A_i
+A_i[t] = \bar r_i, \quad \text{return} = A_i
 $$
+
+KL 正则由 `policy_loss_function` 中的**独立 k2 KL loss** 提供（论文 Eq. 8：
+$\mathcal{L} = \mathcal{L}_{\text{PPO}}(A^{\text{norm}}) + \lambda \cdot \mathbb{E}\left[
+\frac{1}{2} \left(\log \frac{\pi_\theta}{\pi_{\text{ref}}}\right)^2 \right]$，
+即 Relax `compute_approx_kl` 的 `k2`），由 `--use-kl-loss --kl-loss-type k2 --kl-loss-coef λ`
+启用。`arguments.py` 强制该变体 `--kl-coef == 0`（KL 不进 advantage）。
 
 ### 3.3 优势归一化（两变体共用，`--normalize-advantages`）
 
@@ -86,7 +101,7 @@ $$
 |---|---|---|---|
 | return 计算 | 逐 token 折扣 MC 回报 $G_t$ | 无折扣，广播标量 advantage | 广播标量 advantage |
 | group baseline | 否 | 是（group-mean，**无 std**） | 是（group-mean，**有 std**） |
-| KL 计入位置 | 逐 token 计入 reward | 逐 token 计入 advantage | 不计入 advantage（走单独 KL loss） |
+| KL 计入位置 | 逐 token k1-style 计入 reward（`--kl-coef`） | **不计入 advantage**（独立 k2 KL loss，`--use-kl-loss --kl-loss-type k2`） | 不计入 advantage（走单独 KL loss） |
 | advantage 归一化 | masked whiten over DP | masked whiten over DP | 可选 std 归一化（group 内） |
 | mask 作用域 | response token；padding 不注入奖励、不参与统计 | 同左 | 同左 |
 | loss reduction | per-token（`sum_of_sample_mean`，`--calculate-per-token-loss`） | 同左 | 同左 |
@@ -107,12 +122,14 @@ $$
 | GSPO | 同 GRPO 优势 | 是 | 是 | **sequence-level KL** | `compute_policy_loss` + seq KL |
 | SAPO | GRPO 优势 | 是 | 是 | soft sigmoid 非对称 τ | `compute_sapo_loss` |
 | CISPO | GRPO 优势 | 是 | 是 | 梯度只过 `log_probs` | `compute_cispo_loss` |
-| **REINFORCE++** | MC 折扣回报 $G_t$ | **否** | advantage whiten | 逐 token KL 计入 reward | `compute_policy_loss` |
-| **REINFORCE++-baseline** | $(\bar r - \beta k)$ 广播 | **是（无 std）** | advantage whiten | 逐 token KL 计入 advantage | `compute_policy_loss` |
+| **REINFORCE++** | MC 折扣回报 $G_t$ | **否** | advantage whiten | 逐 token k1-style KL 计入 reward（`--kl-coef`） | `compute_policy_loss` |
+| **REINFORCE++-baseline** | $\bar r$ 广播 | **是（无 std）** | advantage whiten | **独立 k2 KL loss**（`--use-kl-loss --kl-loss-type k2`） | `compute_policy_loss` + k2 KL loss |
 
 核心区别：
 - REINFORCE++ 用**逐 token 折扣 MC 回报**取代 GRPO 的「标量优势广播」；
-- KL 惩罚**直接进入 reward / advantage**（逐 token），而非 GRPO 的独立 KL loss；
+- REINFORCE++ 的 KL 惩罚**逐 token 直接进入 reward**（k1-style，`--kl-coef`），
+  baseline 变体的 KL 正则则是**独立 k2 KL loss**（论文 §3.2，Eq. 8），均与 GRPO 的
+  `low_var_kl` 单独 KL loss 估计器不同；
 - baseline 变体的 group baseline **不做 std 归一化**（与 GRPO 的关键差异）；
 - loss 复用 PPO clipped surrogate（`compute_policy_loss` 的 `else` 分支）。
 
@@ -157,11 +174,24 @@ fully-async 模式下对所有算法（含 REINFORCE++）均不生效。这是�
 - `examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh`
 
 基于单卡 GRPO quickstart，切换 `--advantage-estimator reinforce_plus_plus[_baseline]`
-并加 `--normalize-advantages`。
+并加 `--normalize-advantages`。KL 口径遵循论文（非零系数，随 recipe 生效）：
+
+- REINFORCE++：`--kl-coef 0.001 --kl-loss-type k1`（k1-style 惩罚折入折扣回报，§3.1）；
+- REINFORCE++-baseline：`--use-kl-loss --kl-loss-coef 0.001 --kl-loss-type k2`
+  （独立 k2 KL loss，`--kl-coef` 保持默认 0，§3.2）。
+
+GRPO 对比组使用 `contributor-program/2026-cohort-1/run-qwen3-0.6B-1xgpu-grpo.sh`
+（quickstart 原样，`--kl-loss-coef 0.00`），保证与仓库既有 GRPO 口径一致。
 
 ## 9. 验证方法
 
 同模型（Qwen3-0.6B）、数据（GSM8K）、预算、硬件（单卡，sync colocate）下分别运行
 GRPO / REINFORCE++ / REINFORCE++-baseline，对比 reward、loss、KL、吞吐（samples/s、step time）、
 GPU 利用率、峰值显存，不少于 3 个稳定窗口。稳定性护栏：无 NaN / Inf、无丢样本、有效 batch /
-序列长度不下降。
+序列长度不下降。**KL 必须在非零系数下验证**：REINFORCE++ 用 `--kl-coef 0.001`（k1 折入回报）、
+REINFORCE++-baseline 用 `--kl-loss-coef 0.001`（k2 独立 loss），recipe 内已固定，训练对比
+不得以 `kl-coef=0` / `kl-loss-coef=0.00` 替代（否则退化为无 KL 的纯 MC / 纯 group-mean
+口径，与本文档 §3 公式不符）。**KL 必须在非零系数下验证**：REINFORCE++ 用 `--kl-coef 0.001`（k1 折入回报）、
+REINFORCE++-baseline 用 `--kl-loss-coef 0.001`（k2 独立 loss），recipe 内已固定，训练对比
+不得以 `kl-coef=0` / `kl-loss-coef=0.00` 替代（否则退化为无 KL 的纯 MC / 纯 group-mean
+口径，与本文档 §3 公式不符）。

--- a/docs/algorithms/reinforce_plus_plus.md
+++ b/docs/algorithms/reinforce_plus_plus.md
@@ -149,13 +149,14 @@ $$
 `--normalize-advantages` 的 masked whiten 在 DP 组上聚合全局统计量。因统计量为全 token
 求和，**DP 切分不改变每个 token 的归一化结果**。
 
-### 6.3 已知限制：异步路径无 advantage whiten
+### 6.3 已知限制：fully-async 模式不支持本族变体
 
 advantage whiten（`distributed_masked_whiten`）只在同步路径
 `loss.py:compute_advantages_and_returns` 中执行；异步路径
-`relax/components/advantages.py:Advantages` 未做 whiten。即 `--normalize-advantages` 在
-fully-async 模式下对所有算法（含 REINFORCE++）均不生效。这是全算法共有的既有行为。
-推荐使用 sync colocate 模式以使 advantage 归一化生效。
+`relax/components/advantages.py:Advantages` 未做 whiten，且 `arguments.py` 对
+fully-async 模式强制 `assert not --normalize-advantages`。由于两个变体都必须开启
+`--normalize-advantages`（§2），**fully-async 下它们会被参数校验直接拒绝**（而非"归一化不生效"），
+这是全算法共有的既有行为。推荐使用 sync colocate 模式。
 
 ## 7. 测试
 
@@ -190,9 +191,6 @@ GRPO 对比组使用 community 的 GRPO quickstart（与本地
 GRPO / REINFORCE++ / REINFORCE++-baseline，对比 reward、loss、KL、吞吐（samples/s、step time）、
 GPU 利用率、峰值显存，不少于 3 个稳定窗口。稳定性护栏：无 NaN / Inf、无丢样本、有效 batch /
 序列长度不下降。**KL 必须在非零系数下验证**：REINFORCE++ 用 `--kl-coef 0.001`（k1 折入回报）、
-REINFORCE++-baseline 用 `--kl-loss-coef 0.001`（k2 独立 loss），recipe 内已固定，训练对比
-不得以 `kl-coef=0` / `kl-loss-coef=0.00` 替代（否则退化为无 KL 的纯 MC / 纯 group-mean
-口径，与本文档 §3 公式不符）。**KL 必须在非零系数下验证**：REINFORCE++ 用 `--kl-coef 0.001`（k1 折入回报）、
 REINFORCE++-baseline 用 `--kl-loss-coef 0.001`（k2 独立 loss），recipe 内已固定，训练对比
 不得以 `kl-coef=0` / `kl-loss-coef=0.00` 替代（否则退化为无 KL 的纯 MC / 纯 group-mean
 口径，与本文档 §3 公式不符）。

--- a/docs/algorithms/reinforce_plus_plus.md
+++ b/docs/algorithms/reinforce_plus_plus.md
@@ -1,0 +1,167 @@
+# REINFORCE++ / REINFORCE++-baseline
+
+> 参考：[arXiv:2501.03262](https://arxiv.org/abs/2501.03262)（REINFORCE++）。
+> 本文给出 Relax 中 REINFORCE++ 及其 baseline 变体的公式、归一化维度、mask 与 reduction
+> 口径，并明确其与 GRPO / GSPO / SAPO 的差异。
+
+## 1. 概述
+
+REINFORCE++ 在经典 REINFORCE 基础上引入逐 token KL 惩罚与 advantage 归一化；其 baseline
+变体额外引入 group-mean baseline。两者在 Relax 中作为 `--advantage-estimator` 的取值接入，
+与 GRPO / GSPO / SAPO 共享同一套服务拓扑，仅在 advantage / loss 计算上不同。
+
+社区中 REINFORCE 改进实现众多，命名与 baseline 口径常不统一。本文固定 Relax 的口径定义：
+公式、归一化维度、mask、reduction，以及两个变体与邻近算法的差异。
+
+## 2. 配置与命名
+
+算法通过 `--advantage-estimator`（`relax/utils/arguments.py`）选择。两个变体在
+`relax/core/registry.py:ALGOS` 中注册并复用 GRPO 服务拓扑（`_GRPO_TOPOLOGY`：rollout /
+actor / advantages / reference / actor_fwd，**无 critic**），由 `--advantage-estimator` 字符串
+在 advantage 组件与 `policy_loss_function` 中分发。GRPO 族算法（GRPO / GSPO / SAPO / CISPO /
+REINFORCE++ / REINFORCE++-baseline）共享同一拓扑，拓扑定义集中为 `_GRPO_TOPOLOGY` 单一常量。
+
+| 配置值 | 含义 | 必需参数 |
+|---|---|---|
+| `reinforce_plus_plus` | Monte-Carlo 折扣回报，无 group baseline | `--normalize-advantages` |
+| `reinforce_plus_plus_baseline` | group-mean baseline 版本 | `--normalize-advantages` |
+
+`arguments.py` 强制两个变体开启 `--normalize-advantages`，否则报错。两个变体命名可清晰区分；
+切换算法需真正修改 `--advantage-estimator`，而非复制 GRPO recipe 改名。
+
+## 3. 公式
+
+设第 $i$ 条样本响应长度 $R_i$、逐 token KL 为 $k_i \in \mathbb{R}^{R_i}$、响应 mask
+$m_i \in \{0,1\}^{R_i}$、标量奖励 $r_i$、KL 系数 $\beta$（`kl_coef`）、折扣 $\gamma$。
+记响应最后一个有效 token 下标为 $t^*_i = \max\{t : m_i[t]=1\}$。
+
+### 3.1 REINFORCE++（`get_reinforce_plus_plus_returns`）
+
+逐 token 奖励（KL 惩罚 + 终端奖励）：
+
+$$
+\tilde r_i[t] = -\beta \cdot k_i[t] \cdot m_i[t], \quad
+\tilde r_i[t^*_i] \mathrel{+}= r_i
+$$
+
+折扣回报（反向累加）：
+
+$$
+G_i[t] = \tilde r_i[t] + \gamma \cdot G_i[t+1], \quad G_i[R_i] = 0
+$$
+
+advantage = return：$A_i = G_i$。**不做 group baseline**（使用原始 $r_i$）。
+
+### 3.2 REINFORCE++-baseline（`get_reinforce_plus_plus_baseline_advantages`）
+
+group baseline 在上游 `post_process_rewards`（`relax/utils/utils.py`）中预先减去：
+
+$$
+\bar r_i = r_i - \mathrm{mean}_{j \in \text{group}(i)} r_j
+$$
+
+与 GRPO / GSPO / SAPO / CISPO 不同，baseline 变体**只做 group-mean 减法，不做 std 归一化**
+（`post_process_rewards` 中 std 除法分支仅对 `grpo/gspo/sapo/cispo` 生效）。随后 advantage
+函数把 $(\bar r_i - \beta k_i)$ 广播到每个 token：
+
+$$
+A_i[t] = \bar r_i - \beta \cdot k_i[t], \quad \text{return} = A_i
+$$
+
+### 3.3 优势归一化（两变体共用，`--normalize-advantages`）
+
+在同步（colocate）路径 `relax/backends/megatron/loss.py:compute_advantages_and_returns` 中，
+对拼接后的全 batch advantage 在 DP 组上做 masked whiten（`distributed_masked_whiten`，
+Bessel 修正）：
+
+$$
+\hat A = (A - \mu_{\text{mask}}) / \sqrt{\sigma^2_{\text{mask}} + \epsilon}
+$$
+
+统计量在**所有有效 token（mask=1）**上计算，padding / prompt 不参与。
+
+## 4. 归一化维度 / mask / reduction 口径
+
+| 项 | REINFORCE++ | REINFORCE++-baseline | GRPO |
+|---|---|---|---|
+| return 计算 | 逐 token 折扣 MC 回报 $G_t$ | 无折扣，广播标量 advantage | 广播标量 advantage |
+| group baseline | 否 | 是（group-mean，**无 std**） | 是（group-mean，**有 std**） |
+| KL 计入位置 | 逐 token 计入 reward | 逐 token 计入 advantage | 不计入 advantage（走单独 KL loss） |
+| advantage 归一化 | masked whiten over DP | masked whiten over DP | 可选 std 归一化（group 内） |
+| mask 作用域 | response token；padding 不注入奖励、不参与统计 | 同左 | 同左 |
+| loss reduction | per-token（`sum_of_sample_mean`，`--calculate-per-token-loss`） | 同左 | 同左 |
+
+**mask 口径**：`loss_masks` 为响应级 mask（有效 response token = 1，prompt / padding = 0）。
+- REINFORCE++ 中标量奖励仅注入到 $t^*_i$（最后一个有效 response token），不注入 prompt / padding；
+  padding 之后的 token 回报恒为 0。
+- 归一化与 loss reduction 均以 mask 加权，padding / prompt 不改变有效 token 统计。
+
+**reduction 口径**：loss 经 `compute_policy_loss`（PPO clipped surrogate）逐 token 计算，
+再由 `sum_of_sample_mean` 在有效 token 上做 sample-mean 归约（`--calculate-per-token-loss`）。
+
+## 5. 与 GRPO / GSPO / SAPO 的差异
+
+| 算法 | advantage / return | group baseline | std 归一化 | KL 处理 | loss |
+|---|---|---|---|---|---|
+| GRPO | $r - \text{mean}$ 广播 | 是 | 是 | per-token `ppo_kl`，单独 KL loss | `compute_policy_loss` |
+| GSPO | 同 GRPO 优势 | 是 | 是 | **sequence-level KL** | `compute_policy_loss` + seq KL |
+| SAPO | GRPO 优势 | 是 | 是 | soft sigmoid 非对称 τ | `compute_sapo_loss` |
+| CISPO | GRPO 优势 | 是 | 是 | 梯度只过 `log_probs` | `compute_cispo_loss` |
+| **REINFORCE++** | MC 折扣回报 $G_t$ | **否** | advantage whiten | 逐 token KL 计入 reward | `compute_policy_loss` |
+| **REINFORCE++-baseline** | $(\bar r - \beta k)$ 广播 | **是（无 std）** | advantage whiten | 逐 token KL 计入 advantage | `compute_policy_loss` |
+
+核心区别：
+- REINFORCE++ 用**逐 token 折扣 MC 回报**取代 GRPO 的「标量优势广播」；
+- KL 惩罚**直接进入 reward / advantage**（逐 token），而非 GRPO 的独立 KL loss；
+- baseline 变体的 group baseline **不做 std 归一化**（与 GRPO 的关键差异）；
+- loss 复用 PPO clipped surrogate（`compute_policy_loss` 的 `else` 分支）。
+
+## 6. CP / DP 行为
+
+### 6.1 CP（context parallel）
+
+`get_reinforce_plus_plus_returns` 是 CP-aware：每 rank 先 `all_gather_with_cp` 重建完整响应，
+在完整序列上计算 $G_t$，再 `slice_log_prob_with_cp` 切回本 rank 局部 chunk。因此 **CP 切分不改变
+有效 token 上的回报统计**——各 rank 局部 chunk 拼接等于 `cp_size=1` 的完整回报。
+
+`get_reinforce_plus_plus_baseline_advantages` 为纯逐样本计算（无 CP gather / slice），CP 切分
+天然不变。
+
+### 6.2 DP（data parallel）
+
+`--normalize-advantages` 的 masked whiten 在 DP 组上聚合全局统计量。因统计量为全 token
+求和，**DP 切分不改变每个 token 的归一化结果**。
+
+### 6.3 已知限制：异步路径无 advantage whiten
+
+advantage whiten（`distributed_masked_whiten`）只在同步路径
+`loss.py:compute_advantages_and_returns` 中执行；异步路径
+`relax/components/advantages.py:Advantages` 未做 whiten。即 `--normalize-advantages` 在
+fully-async 模式下对所有算法（含 REINFORCE++）均不生效。这是全算法共有的既有行为。
+推荐使用 sync colocate 模式以使 advantage 归一化生效。
+
+## 7. 测试
+
+| 测试文件 | 覆盖项 |
+|---|---|
+| `tests/utils/training/test_ppo_utils_reinforce.py` | 两变体 advantage / return 与独立参考实现逐元素对齐；变长、全零 reward、单样本、gamma 折扣、mask 不污染 padding、全 mask 报错；共享 `compute_policy_loss` 参考对齐 |
+| `tests/backends/megatron/test_reinforce_pp_cp_parity.py` | CP 切分不变性（returns）、baseline CP 不变性、DP 分区下 masked whiten 不变性 |
+| `tests/core/test_registry_reinforce.py` | 两变体已注册、复用 GRPO 拓扑、无 critic、`process_role` 返回 colocate |
+
+测试遵循代码库惯例：fake `megatron.core.mpu` + mock 分布式原语，CPU 单进程运行（与
+`test_ppo_gae_parity.py` 口径一致）。
+
+## 8. Recipe
+
+- `examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh`
+- `examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh`
+
+基于单卡 GRPO quickstart，切换 `--advantage-estimator reinforce_plus_plus[_baseline]`
+并加 `--normalize-advantages`。
+
+## 9. 验证方法
+
+同模型（Qwen3-0.6B）、数据（GSM8K）、预算、硬件（单卡，sync colocate）下分别运行
+GRPO / REINFORCE++ / REINFORCE++-baseline，对比 reward、loss、KL、吞吐（samples/s、step time）、
+GPU 利用率、峰值显存，不少于 3 个稳定窗口。稳定性护栏：无 NaN / Inf、无丢样本、有效 batch /
+序列长度不下降。

--- a/docs/algorithms/reinforce_plus_plus.md
+++ b/docs/algorithms/reinforce_plus_plus.md
@@ -180,8 +180,9 @@ fully-async 模式下对所有算法（含 REINFORCE++）均不生效。这是�
 - REINFORCE++-baseline：`--use-kl-loss --kl-loss-coef 0.001 --kl-loss-type k2`
   （独立 k2 KL loss，`--kl-coef` 保持默认 0，§3.2）。
 
-GRPO 对比组使用 `contributor-program/2026-cohort-1/run-qwen3-0.6B-1xgpu-grpo.sh`
-（quickstart 原样，`--kl-loss-coef 0.00`），保证与仓库既有 GRPO 口径一致。
+GRPO 对比组使用 community 的 GRPO quickstart（与本地
+`contributor-program/2026-cohort-1/run-qwen3-0.6B-1xgpu-grpo.sh` 逐字节一致，见
+`redai-infra/community` 仓库；`--kl-loss-coef 0.00`），保证与既有 GRPO 口径一致。
 
 ## 9. 验证方法
 

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh
@@ -7,7 +7,7 @@
 # Colocate mode: actor and rollout time-share the same GPU.
 #
 # train_iters = NUM_ROLLOUT × ROLLOUT_BATCH_SIZE × N_SAMPLES / GLOBAL_BATCH_SIZE
-#             = 100 × 4 × 4 / 16 = 100 steps
+#             = 100 × 4 × 8 / 16 = 200 steps
 #
 # Dataset: openai/gsm8k (~7.5K problems)
 #   Requires JSONL conversion before use; see beginner-task.md for the conversion script.
@@ -25,9 +25,12 @@
 #   train/pg_loss        — policy gradient loss (non-zero and decreasing)
 #   train/grad_norm      — gradient norm (stable, not exploding)
 #   eval/aime-2024-pass@1 — AIME-2024 passrate every 10 steps
-#   NOTE: REINFORCE++-baseline subtracts a group-mean baseline (no std) and
-#         whitens advantages (--normalize-advantages), so rollout/advantages
-#         hover near 0; rollout/raw_reward reflects accuracy.
+#   NOTE: REINFORCE++-baseline subtracts a group-mean baseline (no std),
+#         whitens advantages (--normalize-advantages), and regularizes with a
+#         separate k2 KL loss (--use-kl-loss --kl-loss-type k2 --kl-loss-coef
+#         0.001, paper §3.2), so rollout/advantages hover near 0 while
+#         rollout/raw_reward reflects accuracy. Watch train/kl_loss for the
+#         KL loss term.
 
 set -ex
 set -o pipefail
@@ -94,9 +97,13 @@ PERF_ARGS=(
 
 GRPO_ARGS=(
     --advantage-estimator reinforce_plus_plus_baseline --normalize-advantages
+    # Paper convention (arXiv:2501.03262 §3.2): group-mean baseline + global
+    # advantage normalization + a SEPARATE k2 KL loss term (--use-kl-loss
+    # --kl-loss-type k2 --kl-loss-coef). The KL penalty is NOT folded into the
+    # advantage; --kl-coef must stay 0 (validated in arguments.py).
     --use-kl-loss
-    --kl-loss-coef 0.00
-    --kl-loss-type low_var_kl
+    --kl-loss-coef 0.001
+    --kl-loss-type k2
     --entropy-coef 0.00
     --eps-clip 0.2
 

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3-0.6B 1xGPU REINFORCE++-baseline quickstart — GSM8K train, AIME-2024 eval.
+#
+# Colocate mode: actor and rollout time-share the same GPU.
+#
+# train_iters = NUM_ROLLOUT × ROLLOUT_BATCH_SIZE × N_SAMPLES / GLOBAL_BATCH_SIZE
+#             = 100 × 4 × 4 / 16 = 100 steps
+#
+# Dataset: openai/gsm8k (~7.5K problems)
+#   Requires JSONL conversion before use; see beginner-task.md for the conversion script.
+#   Expects: $DATA_DIR/gsm8k/train.jsonl with fields {question, answer}
+#
+# Usage:
+#   bash examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp-baseline.sh
+#
+# Key overridable env vars:
+#   MODEL_DIR  - dir containing Qwen3-0.6B/
+#   DATA_DIR   - dir containing gsm8k/train.jsonl and aime-2024/aime-2024.jsonl
+#
+# Metrics to watch in ClearML:
+#   rollout/raw_reward   — accuracy 0/1 (expect ~0.5–0.7 initial on GSM8K, rising over training)
+#   train/pg_loss        — policy gradient loss (non-zero and decreasing)
+#   train/grad_norm      — gradient norm (stable, not exploding)
+#   eval/aime-2024-pass@1 — AIME-2024 passrate every 10 steps
+#   NOTE: REINFORCE++-baseline subtracts a group-mean baseline (no std) and
+#         whitens advantages (--normalize-advantages), so rollout/advantages
+#         hover near 0; rollout/raw_reward reflects accuracy.
+
+set -ex
+set -o pipefail
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+RELAX_ROOT="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${RELAX_ROOT}/scripts/entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-0.6B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/beginner-task}"
+MODEL_DIR="${MODEL_DIR:-/your/model}"
+DATA_DIR="${DATA_DIR:-/your/data}"
+
+NUM_ROLLOUT="${NUM_ROLLOUT:=100}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:=4}"
+N_SAMPLES="${N_SAMPLES:=8}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:=16}"
+# train_iters = 100 × 4 × 8 / 16 = 200
+
+CKPT_ARGS=(
+    --hf-checkpoint ${MODEL_DIR}/Qwen3-0.6B
+    --ref-load ${MODEL_DIR}/Qwen3-0.6B
+    --megatron-to-hf-mode bridge
+    --warm-hf-checkpoint-page-cache
+)
+
+ROLLOUT_ARGS=(
+    --prompt-data ${DATA_DIR}/gsm8k/train.jsonl
+    --input-key question
+    --label-key answer
+    --apply-chat-template
+    --rollout-shuffle
+
+    --rm-type math
+
+    --num-rollout ${NUM_ROLLOUT}
+    --rollout-batch-size ${ROLLOUT_BATCH_SIZE}
+    --n-samples-per-prompt ${N_SAMPLES}
+    --rollout-max-response-len 2048
+    --rollout-temperature 1
+
+    --global-batch-size ${GLOBAL_BATCH_SIZE}
+    --balance-data
+    --use-fault-tolerance
+)
+
+PERF_ARGS=(
+    --tensor-model-parallel-size 1
+    --pipeline-model-parallel-size 1
+    --context-parallel-size 1
+    --expert-model-parallel-size 1
+    --expert-tensor-parallel-size 1
+
+    --calculate-per-token-loss
+    --use-dynamic-batch-size
+    --max-tokens-per-gpu 8192
+    --log-probs-max-tokens-per-gpu 8192
+)
+
+GRPO_ARGS=(
+    --advantage-estimator reinforce_plus_plus_baseline --normalize-advantages
+    --use-kl-loss
+    --kl-loss-coef 0.00
+    --kl-loss-type low_var_kl
+    --entropy-coef 0.00
+    --eps-clip 0.2
+
+    --use-rollout-logprobs
+)
+
+OPTIMIZER_ARGS=(
+    --optimizer adam
+    --lr 1e-6
+    --lr-decay-style constant
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.98
+)
+
+SGLANG_ARGS=(
+    --rollout-num-gpus-per-engine 1
+    # ~55% for training; SGLang uses 45%
+    --sglang-mem-fraction-static 0.45
+)
+
+WANDB_ARGS=(
+    --use-clearml
+    --use-metrics-service
+    --tb-project-name ${PROJECT_NAME}
+    --tb-experiment-name qwen3-0.6b-REINFORCEppBaseline-gsm8k-1xgpu-${now}
+)
+
+EVAL_ARGS=(
+    --skip-eval-before-train
+    --eval-interval 10
+    --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+    --eval-input-key prompt
+    --eval-label-key label
+    --n-samples-per-eval-prompt 4
+    --eval-max-response-len 2048
+    --log-passrate
+)
+
+MISC_ARGS=(
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --accumulate-allreduce-grads-in-fp32
+    --attention-softmax-in-fp32
+    --attention-backend flash
+)
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+    ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+    --runtime-env-json="${RUNTIME_ENV_JSON}" \
+    -- python3 -m relax.entrypoints.train \
+    --resource '{"actor": [1, 1], "rollout": [1, 1]}' \
+    --max-staleness 0 \
+    --num-data-storage-units 1 \
+    --colocate \
+    --use-health-check \
+    "${MODEL_ARGS[@]}" \
+    "${CKPT_ARGS[@]}" \
+    "${ROLLOUT_ARGS[@]}" \
+    "${EVAL_ARGS[@]}" \
+    "${OPTIMIZER_ARGS[@]}" \
+    "${GRPO_ARGS[@]}" \
+    "${WANDB_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
+    "${SGLANG_ARGS[@]}" \
+    "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-0.6b-REINFORCEppBaseline-gsm8k-1xgpu-${now}.log

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
@@ -29,7 +29,9 @@
 #         baseline and a per-token k1-style KL penalty (--kl-coef 0.001)
 #         folded into the return (paper §3.1); advantages are whitened
 #         (--normalize-advantages) and hover near 0, while rollout/raw_reward
-#         reflects accuracy. Watch train/ppo_kl for the KL magnitude.
+#         reflects accuracy. train/ppo_kl is the old-vs-current policy drift
+#         (not the folded penalty); the folded k1 penalty shows up as
+#         rollout/returns - rollout/raw_reward ≈ -β·Σk1.
 
 set -ex
 set -o pipefail

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
@@ -7,7 +7,7 @@
 # Colocate mode: actor and rollout time-share the same GPU.
 #
 # train_iters = NUM_ROLLOUT × ROLLOUT_BATCH_SIZE × N_SAMPLES / GLOBAL_BATCH_SIZE
-#             = 100 × 4 × 4 / 16 = 100 steps
+#             = 100 × 4 × 8 / 16 = 200 steps
 #
 # Dataset: openai/gsm8k (~7.5K problems)
 #   Requires JSONL conversion before use; see beginner-task.md for the conversion script.
@@ -26,8 +26,10 @@
 #   train/grad_norm      — gradient norm (stable, not exploding)
 #   eval/aime-2024-pass@1 — AIME-2024 passrate every 10 steps
 #   NOTE: REINFORCE++ uses a discounted Monte-Carlo return with no group
-#         baseline; advantages are whitened (--normalize-advantages) and hover
-#         near 0, while rollout/raw_reward reflects accuracy.
+#         baseline and a per-token k1-style KL penalty (--kl-coef 0.001)
+#         folded into the return (paper §3.1); advantages are whitened
+#         (--normalize-advantages) and hover near 0, while rollout/raw_reward
+#         reflects accuracy. Watch train/ppo_kl for the KL magnitude.
 
 set -ex
 set -o pipefail
@@ -94,9 +96,10 @@ PERF_ARGS=(
 
 GRPO_ARGS=(
     --advantage-estimator reinforce_plus_plus --normalize-advantages
-    --use-kl-loss
-    --kl-loss-coef 0.00
-    --kl-loss-type low_var_kl
+    # Paper convention (arXiv:2501.03262 §3.1): per-token k1-style KL penalty
+    # folded into the discounted return via --kl-coef (here 0.001).
+    --kl-coef 0.001
+    --kl-loss-type k1
     --entropy-coef 0.00
     --eps-clip 0.2
 

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3-0.6B 1xGPU REINFORCE++ quickstart — GSM8K train, AIME-2024 eval.
+#
+# Colocate mode: actor and rollout time-share the same GPU.
+#
+# train_iters = NUM_ROLLOUT × ROLLOUT_BATCH_SIZE × N_SAMPLES / GLOBAL_BATCH_SIZE
+#             = 100 × 4 × 4 / 16 = 100 steps
+#
+# Dataset: openai/gsm8k (~7.5K problems)
+#   Requires JSONL conversion before use; see beginner-task.md for the conversion script.
+#   Expects: $DATA_DIR/gsm8k/train.jsonl with fields {question, answer}
+#
+# Usage:
+#   bash examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh
+#
+# Key overridable env vars:
+#   MODEL_DIR  - dir containing Qwen3-0.6B/
+#   DATA_DIR   - dir containing gsm8k/train.jsonl and aime-2024/aime-2024.jsonl
+#
+# Metrics to watch in ClearML:
+#   rollout/raw_reward   — accuracy 0/1 (expect ~0.5–0.7 initial on GSM8K, rising over training)
+#   train/pg_loss        — policy gradient loss (non-zero and decreasing)
+#   train/grad_norm      — gradient norm (stable, not exploding)
+#   eval/aime-2024-pass@1 — AIME-2024 passrate every 10 steps
+#   NOTE: REINFORCE++ uses a discounted Monte-Carlo return with no group
+#         baseline; advantages are whitened (--normalize-advantages) and hover
+#         near 0, while rollout/raw_reward reflects accuracy.
+
+set -ex
+set -o pipefail
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+RELAX_ROOT="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${RELAX_ROOT}/scripts/entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-0.6B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/beginner-task}"
+MODEL_DIR="${MODEL_DIR:-/your/model}"
+DATA_DIR="${DATA_DIR:-/your/data}"
+
+NUM_ROLLOUT="${NUM_ROLLOUT:=100}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:=4}"
+N_SAMPLES="${N_SAMPLES:=8}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:=16}"
+# train_iters = 100 × 4 × 8 / 16 = 200
+
+CKPT_ARGS=(
+    --hf-checkpoint ${MODEL_DIR}/Qwen3-0.6B
+    --ref-load ${MODEL_DIR}/Qwen3-0.6B
+    --megatron-to-hf-mode bridge
+    --warm-hf-checkpoint-page-cache
+)
+
+ROLLOUT_ARGS=(
+    --prompt-data ${DATA_DIR}/gsm8k/train.jsonl
+    --input-key question
+    --label-key answer
+    --apply-chat-template
+    --rollout-shuffle
+
+    --rm-type math
+
+    --num-rollout ${NUM_ROLLOUT}
+    --rollout-batch-size ${ROLLOUT_BATCH_SIZE}
+    --n-samples-per-prompt ${N_SAMPLES}
+    --rollout-max-response-len 2048
+    --rollout-temperature 1
+
+    --global-batch-size ${GLOBAL_BATCH_SIZE}
+    --balance-data
+    --use-fault-tolerance
+)
+
+PERF_ARGS=(
+    --tensor-model-parallel-size 1
+    --pipeline-model-parallel-size 1
+    --context-parallel-size 1
+    --expert-model-parallel-size 1
+    --expert-tensor-parallel-size 1
+
+    --calculate-per-token-loss
+    --use-dynamic-batch-size
+    --max-tokens-per-gpu 8192
+    --log-probs-max-tokens-per-gpu 8192
+)
+
+GRPO_ARGS=(
+    --advantage-estimator reinforce_plus_plus --normalize-advantages
+    --use-kl-loss
+    --kl-loss-coef 0.00
+    --kl-loss-type low_var_kl
+    --entropy-coef 0.00
+    --eps-clip 0.2
+
+    --use-rollout-logprobs
+)
+
+OPTIMIZER_ARGS=(
+    --optimizer adam
+    --lr 1e-6
+    --lr-decay-style constant
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.98
+)
+
+SGLANG_ARGS=(
+    --rollout-num-gpus-per-engine 1
+    # ~55% for training; SGLang uses 45%
+    --sglang-mem-fraction-static 0.45
+)
+
+WANDB_ARGS=(
+    --use-clearml
+    --use-metrics-service
+    --tb-project-name ${PROJECT_NAME}
+    --tb-experiment-name qwen3-0.6b-REINFORCEpp-gsm8k-1xgpu-${now}
+)
+
+EVAL_ARGS=(
+    --skip-eval-before-train
+    --eval-interval 10
+    --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+    --eval-input-key prompt
+    --eval-label-key label
+    --n-samples-per-eval-prompt 4
+    --eval-max-response-len 2048
+    --log-passrate
+)
+
+MISC_ARGS=(
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --accumulate-allreduce-grads-in-fp32
+    --attention-softmax-in-fp32
+    --attention-backend flash
+)
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+    ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+    --runtime-env-json="${RUNTIME_ENV_JSON}" \
+    -- python3 -m relax.entrypoints.train \
+    --resource '{"actor": [1, 1], "rollout": [1, 1]}' \
+    --max-staleness 0 \
+    --num-data-storage-units 1 \
+    --colocate \
+    --use-health-check \
+    "${MODEL_ARGS[@]}" \
+    "${CKPT_ARGS[@]}" \
+    "${ROLLOUT_ARGS[@]}" \
+    "${EVAL_ARGS[@]}" \
+    "${OPTIMIZER_ARGS[@]}" \
+    "${GRPO_ARGS[@]}" \
+    "${WANDB_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
+    "${SGLANG_ARGS[@]}" \
+    "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-0.6b-REINFORCEpp-gsm8k-1xgpu-${now}.log

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -611,7 +611,6 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
             rewards=rewards,
             kl=kl,
             loss_masks=loss_masks,
-            kl_coef=args.kl_coef,
         )
         returns = advantages
 

--- a/relax/components/advantages.py
+++ b/relax/components/advantages.py
@@ -210,7 +210,6 @@ class Advantages(Base):
                 rewards=rewards,
                 kl=kl,
                 loss_masks=loss_masks,
-                kl_coef=self.config.kl_coef,
             )
             returns = advantages
 

--- a/relax/core/registry.py
+++ b/relax/core/registry.py
@@ -80,35 +80,28 @@ class ROLES_PPO_FULLY_ASYNC_ON_POLICY(StrEnum):
     reference: str = "reference"
 
 
+# GRPO-family algorithms (GRPO, GSPO, SAPO, CISPO, REINFORCE++,
+# REINFORCE++-baseline) share the same service topology — they differ only in
+# advantage/loss computation, dispatched by `--advantage-estimator` inside the
+# Advantages component and `policy_loss_function`. Registering each variant
+# here keeps the algorithm list a single source of truth (task #27: registry
+# dispatch instead of if/elif chains) and lets the Controller validate the key
+# end-to-end. REINFORCE++ variants reuse the GRPO topology (no critic).
+_GRPO_TOPOLOGY = {
+    ROLES.rollout: Rollout,
+    ROLES.actor: Actor,
+    ROLES.advantages: Advantages,
+    ROLES.reference: ActorFwd,
+    ROLES.actor_fwd: ActorFwd,
+}
+
 ALGOS = {
-    "grpo": {
-        ROLES.rollout: Rollout,
-        ROLES.actor: Actor,
-        ROLES.advantages: Advantages,
-        ROLES.reference: ActorFwd,
-        ROLES.actor_fwd: ActorFwd,
-    },
-    "gspo": {
-        ROLES.rollout: Rollout,
-        ROLES.actor: Actor,
-        ROLES.advantages: Advantages,
-        ROLES.reference: ActorFwd,
-        ROLES.actor_fwd: ActorFwd,
-    },
-    "sapo": {
-        ROLES.rollout: Rollout,
-        ROLES.actor: Actor,
-        ROLES.advantages: Advantages,
-        ROLES.reference: ActorFwd,
-        ROLES.actor_fwd: ActorFwd,
-    },
-    "cispo": {
-        ROLES.rollout: Rollout,
-        ROLES.actor: Actor,
-        ROLES.advantages: Advantages,
-        ROLES.reference: ActorFwd,
-        ROLES.actor_fwd: ActorFwd,
-    },
+    "grpo": dict(_GRPO_TOPOLOGY),
+    "gspo": dict(_GRPO_TOPOLOGY),
+    "sapo": dict(_GRPO_TOPOLOGY),
+    "cispo": dict(_GRPO_TOPOLOGY),
+    "reinforce_plus_plus": dict(_GRPO_TOPOLOGY),
+    "reinforce_plus_plus_baseline": dict(_GRPO_TOPOLOGY),
     "sft": {
         ROLES.sft: SFT,
         ROLES.actor: Actor,

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -2748,6 +2748,17 @@ def slime_validate_args(args):
                 "The 'reinforce_plus_plus' and 'reinforce_plus_plus_baseline' advantage estimators "
                 "require advantage normalization. Please add `--normalize-advantages` to your command."
             )
+        if args.advantage_estimator == "reinforce_plus_plus_baseline":
+            # Paper convention (arXiv:2501.03262 §3.2): the baseline variant
+            # applies a separate k2 KL loss (--use-kl-loss --kl-loss-type k2),
+            # NOT a per-token KL penalty folded into the advantage. Setting
+            # --kl-coef would be silently ignored, so reject it.
+            assert args.kl_coef == 0, (
+                "The 'reinforce_plus_plus_baseline' advantage estimator does not fold a "
+                "per-token KL penalty into the advantage (paper §3.2: group-mean baseline + "
+                "global normalization + separate k2 KL loss). Use `--use-kl-loss "
+                "--kl-loss-type k2 --kl-loss-coef <λ>` instead of `--kl-coef`."
+            )
 
         if args.fully_async:
             assert not args.normalize_advantages, (

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -441,6 +441,17 @@ def get_reinforce_plus_plus_returns(
     Returns:
         List[torch.Tensor]: A list of return (G_t) tensors for the
                             local sequence chunks owned by the current GPU rank.
+
+    Convention notes (see ``docs/algorithms/reinforce_plus_plus.md``):
+      * The scalar ``rewards[i]`` is injected **only** at the last masked
+        (response) token; prompt/padding tokens never receive it, and tokens
+        after the last response token stay zero.
+      * CP-aware: each rank gathers the full response (``all_gather_with_cp``),
+        computes G_t on the full sequence, then slices its local chunk
+        (``slice_log_prob_with_cp``); CP sharding is invariant on valid tokens.
+      * Unlike ``reinforce_plus_plus_baseline``, no group baseline is subtracted
+        (raw ``rewards`` are used); advantage whitening is applied later in the
+        sync path when ``--normalize-advantages`` is set.
     """
     from megatron.core import mpu
 
@@ -496,14 +507,30 @@ def get_reinforce_plus_plus_baseline_advantages(
     """Calculates the unwhitened advantages for the REINFORCE++-baseline
     algorithm.
 
-    Broadcasting the scalar (reward - group_baseline) to each token.
+    Broadcasting the scalar ``(reward - group_baseline) - kl_coef * kl`` to each
+    token, i.e. the per-token KL penalty is subtracted from the broadcast
+    scalar advantage and there is **no discounting** (contrast
+    ``get_reinforce_plus_plus_returns``, which uses a discounted Monte-Carlo
+    return).
+
+    Baseline convention (see ``docs/algorithms/reinforce_plus_plus.md``): the group
+    baseline is **not** subtracted here. It is subtracted upstream in
+    ``relax.utils.utils.post_process_rewards`` (group-mean, no std division —
+    unlike GRPO/GSPO/SAPO/CISPO which additionally divide by group std). The
+    ``rewards`` passed in therefore already carry ``(r - group_mean)``. The
+    optional ``--normalize-advantages`` whitening is applied later in the sync
+    path ``relax/backends/megatron/loss.py:compute_advantages_and_returns``.
 
     Args:
         rewards (Tensor): A tensor of scalar rewards, where the group-wise
-                                baseline has already been subtracted.
+                                baseline has already been subtracted upstream.
         kl (list[Tensor]): A list of per-token KL divergence tensors. Used to
                                  get the shape for broadcasting.
-        loss_masks (list[Tensor]): A list of per-token loss masks.
+        loss_masks (list[Tensor]): A list of per-token loss masks. Accepted for
+                                 API symmetry with
+                                 ``get_reinforce_plus_plus_returns``; not used
+                                 here because the per-token mask is enforced
+                                 downstream in loss reduction.
         kl_coef (float): Coefficient for the KL penalty.
 
     Returns:

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -502,24 +502,26 @@ def get_reinforce_plus_plus_baseline_advantages(
     rewards: torch.Tensor,
     kl: list[torch.Tensor],
     loss_masks: list[torch.Tensor],
-    kl_coef: float,
 ) -> list[torch.Tensor]:
     """Calculates the unwhitened advantages for the REINFORCE++-baseline
     algorithm.
 
-    Broadcasting the scalar ``(reward - group_baseline) - kl_coef * kl`` to each
-    token, i.e. the per-token KL penalty is subtracted from the broadcast
-    scalar advantage and there is **no discounting** (contrast
-    ``get_reinforce_plus_plus_returns``, which uses a discounted Monte-Carlo
-    return).
+    Broadcasting the scalar ``(reward - group_baseline)`` to each token, with
+    **no per-token KL penalty and no discounting**. Following the paper
+    (arXiv:2501.03262, §3.2 "REINFORCE++ /w baseline"), the baseline variant
+    subtracts only the group-mean baseline and applies a **separate k2 KL loss**
+    term in ``policy_loss_function`` (``--use-kl-loss --kl-loss-type k2``),
+    instead of folding the KL penalty into the advantage like the plain
+    REINFORCE++ variant (which uses a discounted Monte-Carlo return and is
+    documented in ``get_reinforce_plus_plus_returns``).
 
-    Baseline convention (see ``docs/algorithms/reinforce_plus_plus.md``): the group
-    baseline is **not** subtracted here. It is subtracted upstream in
+    Baseline convention (see ``docs/algorithms/reinforce_plus_plus.md``): the
+    group baseline is **not** subtracted here. It is subtracted upstream in
     ``relax.utils.utils.post_process_rewards`` (group-mean, no std division —
     unlike GRPO/GSPO/SAPO/CISPO which additionally divide by group std). The
     ``rewards`` passed in therefore already carry ``(r - group_mean)``. The
-    optional ``--normalize-advantages`` whitening is applied later in the sync
-    path ``relax/backends/megatron/loss.py:compute_advantages_and_returns``.
+    ``--normalize-advantages`` whitening is applied later in the sync path
+    ``relax/backends/megatron/loss.py:compute_advantages_and_returns``.
 
     Args:
         rewards (Tensor): A tensor of scalar rewards, where the group-wise
@@ -531,15 +533,13 @@ def get_reinforce_plus_plus_baseline_advantages(
                                  ``get_reinforce_plus_plus_returns``; not used
                                  here because the per-token mask is enforced
                                  downstream in loss reduction.
-        kl_coef (float): Coefficient for the KL penalty.
 
     Returns:
         list[Tensor]: A list of tensors containing the unwhitened advantages.
     """
     # Broadcast to get unwhitened advantages
     unwhitened_advantages = [
-        torch.ones_like(kl_tensor) * reward_val - kl_coef * kl_tensor
-        for kl_tensor, reward_val in zip(kl, rewards, strict=False)
+        torch.ones_like(kl_tensor) * reward_val for kl_tensor, reward_val in zip(kl, rewards, strict=False)
     ]
 
     return unwhitened_advantages

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -184,6 +184,13 @@ def post_process_rewards(args: Any, samples: list[Sample] | list[list[Sample]]):
         args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "reinforce_plus_plus_baseline"]
         and args.rewards_normalization
     ):
+        # Group-mean baseline subtraction. Note the convention difference (see
+        # docs/algorithms/reinforce_plus_plus.md): GRPO/GSPO/SAPO/CISPO also
+        # divide by group std below, whereas reinforce_plus_plus_baseline only
+        # subtracts the group mean (no std) — its advantage function then
+        # broadcasts (reward - group_mean) - kl_coef * kl per token.
+        # reinforce_plus_plus (non-baseline) is intentionally NOT here: it uses
+        # raw rewards with a discounted Monte-Carlo return and no group baseline.
         # group norm
         rewards = torch.tensor(raw_rewards, dtype=torch.float)
         positions_by_group: dict[int, list[int]] = {}

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -188,7 +188,9 @@ def post_process_rewards(args: Any, samples: list[Sample] | list[list[Sample]]):
         # docs/algorithms/reinforce_plus_plus.md): GRPO/GSPO/SAPO/CISPO also
         # divide by group std below, whereas reinforce_plus_plus_baseline only
         # subtracts the group mean (no std) — its advantage function then
-        # broadcasts (reward - group_mean) - kl_coef * kl per token.
+        # broadcasts (reward - group_mean) per token, with no KL penalty folded
+        # in (the KL regularization is a separate k2 loss, see
+        # get_reinforce_plus_plus_baseline_advantages).
         # reinforce_plus_plus (non-baseline) is intentionally NOT here: it uses
         # raw rewards with a discounted Monte-Carlo return and no group baseline.
         # group norm

--- a/tests/backends/megatron/test_reinforce_pp_cp_parity.py
+++ b/tests/backends/megatron/test_reinforce_pp_cp_parity.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Distributed tests for REINFORCE++ / REINFORCE++-baseline (task #29).
+
+Two properties are verified in single-process mode with distributed primitives
+mocked (the convention used by ``test_ppo_gae_parity.py``: a fake
+``megatron.core.mpu`` plus mocked collectives):
+
+  * **CP gather/compute/slice wiring** — ``get_reinforce_plus_plus_returns`` is
+    CP-aware: each rank must gather the full response (``all_gather_with_cp``),
+    compute the discounted return on the full sequence, then slice its local
+    chunk back out (``slice_log_prob_with_cp``). We mock the two helpers with a
+    contiguous split and assert that concatenating the per-rank local chunks
+    reproduces the full-sequence return computed with ``cp_size == 1``. This
+    validates the gather/compute/slice wiring of the REINFORCE++ return logic;
+    the zig-zag chunking itself lives in ``relax.backends.megatron.cp_utils``
+    (shared infra, covered by its own tests) and is out of scope here.
+
+  * **DP whitening invariance** — REINFORCE++ variants require
+    ``--normalize-advantages``, which whitens advantages over the DP group via
+    ``distributed_masked_whiten`` (global masked mean/var). The whitened value
+    of every token must be identical regardless of how samples are partitioned
+    across DP ranks. We mock ``dist.all_reduce`` to aggregate a second rank's
+    statistics and check each rank's output matches the unpartitioned reference.
+"""
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+
+def _install_fake_megatron(monkeypatch, *, cp_size: int = 1, cp_rank: int = 0) -> None:
+    megatron = ModuleType("megatron")
+    core = ModuleType("megatron.core")
+    mpu = ModuleType("megatron.core.mpu")
+    mpu.get_context_parallel_world_size = lambda: cp_size
+    mpu.get_context_parallel_rank = lambda: cp_rank
+    core.mpu = mpu
+
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(sys.modules, "megatron.core.mpu", mpu)
+
+
+class _CPSplitSimulator:
+    """Mocks ``all_gather_with_cp`` / ``slice_log_prob_with_cp`` for cp_size=2
+    using a contiguous split, so the gather→compute→slice roundtrip can be
+    validated in a single process.
+
+    ``full`` is the canonical full-response tensor; each rank's local chunk is
+    ``full[:mid]`` (rank 0) / ``full[mid:]`` (rank 1). ``all_gather`` returns the
+    full tensor; ``slice`` returns the calling rank's chunk of the full result.
+    """
+
+    def __init__(self, full: torch.Tensor):
+        self.full = full
+        self.mid = full.size(0) // 2
+
+    def local_chunk(self, rank: int) -> torch.Tensor:
+        return self.full[: self.mid] if rank == 0 else self.full[self.mid :]
+
+    def all_gather(self, tensor, total_length, response_length, *args, **kwargs):
+        # Simulate reconstructing the full response from all CP ranks.
+        return self.full
+
+    def slice(self, log_prob, total_length, response_length, *args, **kwargs):
+        # Return the calling rank's contiguous chunk of the full result.
+        return log_prob[: self.mid] if self._rank == 0 else log_prob[self.mid :]
+
+    def set_rank(self, rank: int) -> None:
+        self._rank = rank
+
+
+class TestReinforcePlusPlusCPWiring:
+    """Wiring check: the CP-aware return must gather the full response before
+    computing, then slice consistently. Zig-zag chunking correctness is
+    ``cp_utils``' responsibility (shared infra) and is out of scope here."""
+
+    def test_local_chunks_concatenate_to_full_return(self, monkeypatch):
+        pytest.importorskip("torch")
+        _install_fake_megatron(monkeypatch, cp_size=1)  # for the cp=1 reference call
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        torch.manual_seed(0)
+        prompt_len, response_len = 3, 8
+        total_len = prompt_len + response_len
+        kl_full = torch.randn(response_len, dtype=torch.float32)
+        mask_full = torch.ones(response_len, dtype=torch.float32)
+        rewards = torch.tensor([1.5])
+        kl_coef, gamma = 0.05, 0.97
+
+        # Reference: full-sequence return with cp_size == 1.
+        ref = get_reinforce_plus_plus_returns(
+            rewards,
+            [kl_full],
+            [mask_full],
+            [response_len],
+            [total_len],
+            kl_coef=kl_coef,
+            gamma=gamma,
+        )[0]
+
+        # Simulate cp_size == 2: each rank gathers full, computes, slices local.
+        sim = _CPSplitSimulator(kl_full)
+        import relax.backends.megatron.cp_utils as cp_utils
+
+        monkeypatch.setattr(cp_utils, "all_gather_with_cp", sim.all_gather)
+        monkeypatch.setattr(cp_utils, "slice_log_prob_with_cp", sim.slice)
+        _install_fake_megatron(monkeypatch, cp_size=2, cp_rank=0)
+
+        local_chunks = []
+        for rank in (0, 1):
+            sim.set_rank(rank)
+            local = get_reinforce_plus_plus_returns(
+                rewards,
+                [sim.local_chunk(rank)],
+                [mask_full],
+                [response_len],
+                [total_len],
+                kl_coef=kl_coef,
+                gamma=gamma,
+            )[0]
+            local_chunks.append(local)
+
+        reconstructed = torch.cat(local_chunks)
+        assert reconstructed.shape == ref.shape
+        assert torch.allclose(reconstructed, ref, atol=1e-6), (reconstructed, ref)
+
+
+class TestReinforcePlusPlusBaselineCPLocality:
+    """``get_reinforce_plus_plus_baseline_advantages`` is purely per-sample (no
+    CP gather/slice), so its output is local to each rank and independent of CP
+    sharding — verified here by computing on halves and concatenating."""
+
+    def test_local_chunk_advantage_matches_full_slice(self, monkeypatch):
+        pytest.importorskip("torch")
+        _install_fake_megatron(monkeypatch, cp_size=2, cp_rank=0)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_baseline_advantages
+
+        torch.manual_seed(0)
+        kl_full = torch.randn(8, dtype=torch.float32)
+        rewards = torch.tensor([0.7])
+        kl_coef = 0.03
+
+        full_adv = get_reinforce_plus_plus_baseline_advantages(
+            rewards,
+            [kl_full],
+            [torch.ones(8)],
+            kl_coef=kl_coef,
+        )[0]
+
+        mid = kl_full.size(0) // 2
+        rank0_local = get_reinforce_plus_plus_baseline_advantages(
+            rewards,
+            [kl_full[:mid]],
+            [torch.ones(mid)],
+            kl_coef=kl_coef,
+        )[0]
+        rank1_local = get_reinforce_plus_plus_baseline_advantages(
+            rewards,
+            [kl_full[mid:]],
+            [torch.ones(8 - mid)],
+            kl_coef=kl_coef,
+        )[0]
+
+        reconstructed = torch.cat([rank0_local, rank1_local])
+        assert torch.allclose(reconstructed, full_adv, atol=1e-6)
+
+
+class TestDPMaskedWhitenInvariance:
+    """DP partition must not change ``distributed_masked_whiten`` per-token
+    output (the ``--normalize-advantages`` path used by REINFORCE++ variants)."""
+
+    @staticmethod
+    def _local_stats(values, mask):
+        return torch.tensor(
+            [(values * mask).sum(), ((values**2) * mask).sum(), mask.sum()],
+            dtype=torch.float32,
+        )
+
+    def test_partitioned_ranks_match_unpartitioned_reference(self, monkeypatch):
+        pytest.importorskip("torch")
+        import relax.utils.distributed_utils as du
+
+        torch.manual_seed(0)
+        full_advs = torch.randn(40, dtype=torch.float32)
+        full_masks = torch.ones(40, dtype=torch.float32)
+        # introduce some masked (padding) tokens so masked stats are exercised
+        full_masks[5:8] = 0
+        full_masks[22:26] = 0
+
+        # Reference: whiten the full batch as a single rank. With one rank,
+        # all_reduce is identity (the fake adds zeros).
+        monkeypatch.setattr(du.dist, "all_reduce", lambda t, *a, **k: t)
+        from relax.utils.distributed_utils import distributed_masked_whiten
+
+        ref_whitened = distributed_masked_whiten(full_advs, full_masks, process_group=None)
+
+        # DP=2: split into two ranks; each rank's all_reduce adds the OTHER
+        # rank's real local stats (simulating the cross-rank SUM).
+        mid = 20
+        advs0, advs1 = full_advs[:mid], full_advs[mid:]
+        masks0, masks1 = full_masks[:mid], full_masks[mid:]
+        stats0 = self._local_stats(advs0, masks0)
+        stats1 = self._local_stats(advs1, masks1)
+
+        def fake_for(other_stats):
+            def _all_reduce(tensor, *args, **kwargs):
+                tensor.add_(other_stats)
+                return tensor
+
+            return _all_reduce
+
+        monkeypatch.setattr(du.dist, "all_reduce", fake_for(stats1))
+        whitened0 = distributed_masked_whiten(advs0, masks0, process_group=None)
+        monkeypatch.setattr(du.dist, "all_reduce", fake_for(stats0))
+        whitened1 = distributed_masked_whiten(advs1, masks1, process_group=None)
+
+        reconstructed = torch.cat([whitened0, whitened1])
+        assert reconstructed.shape == ref_whitened.shape
+        assert torch.allclose(reconstructed, ref_whitened, atol=1e-6), (reconstructed, ref_whitened)

--- a/tests/backends/megatron/test_reinforce_pp_cp_parity.py
+++ b/tests/backends/megatron/test_reinforce_pp_cp_parity.py
@@ -146,13 +146,11 @@ class TestReinforcePlusPlusBaselineCPLocality:
         torch.manual_seed(0)
         kl_full = torch.randn(8, dtype=torch.float32)
         rewards = torch.tensor([0.7])
-        kl_coef = 0.03
 
         full_adv = get_reinforce_plus_plus_baseline_advantages(
             rewards,
             [kl_full],
             [torch.ones(8)],
-            kl_coef=kl_coef,
         )[0]
 
         mid = kl_full.size(0) // 2
@@ -160,13 +158,11 @@ class TestReinforcePlusPlusBaselineCPLocality:
             rewards,
             [kl_full[:mid]],
             [torch.ones(mid)],
-            kl_coef=kl_coef,
         )[0]
         rank1_local = get_reinforce_plus_plus_baseline_advantages(
             rewards,
             [kl_full[mid:]],
             [torch.ones(8 - mid)],
-            kl_coef=kl_coef,
         )[0]
 
         reconstructed = torch.cat([rank0_local, rank1_local])

--- a/tests/backends/megatron/test_reinforce_pp_cp_parity.py
+++ b/tests/backends/megatron/test_reinforce_pp_cp_parity.py
@@ -50,8 +50,9 @@ class _CPSplitSimulator:
     validated in a single process.
 
     ``full`` is the canonical full-response tensor; each rank's local chunk is
-    ``full[:mid]`` (rank 0) / ``full[mid:]`` (rank 1). ``all_gather`` returns the
-    full tensor; ``slice`` returns the calling rank's chunk of the full result.
+    ``full[:mid]`` (rank 0) / ``full[mid:]`` (rank 1). ``all_gather`` returns
+    the full tensor; ``slice`` returns the calling rank's chunk of the full
+    result.
     """
 
     def __init__(self, full: torch.Tensor):
@@ -75,8 +76,11 @@ class _CPSplitSimulator:
 
 class TestReinforcePlusPlusCPWiring:
     """Wiring check: the CP-aware return must gather the full response before
-    computing, then slice consistently. Zig-zag chunking correctness is
-    ``cp_utils``' responsibility (shared infra) and is out of scope here."""
+    computing, then slice consistently.
+
+    Zig-zag chunking correctness is ``cp_utils``' responsibility (shared infra)
+    and is out of scope here.
+    """
 
     def test_local_chunks_concatenate_to_full_return(self, monkeypatch):
         pytest.importorskip("torch")
@@ -171,7 +175,8 @@ class TestReinforcePlusPlusBaselineCPLocality:
 
 class TestDPMaskedWhitenInvariance:
     """DP partition must not change ``distributed_masked_whiten`` per-token
-    output (the ``--normalize-advantages`` path used by REINFORCE++ variants)."""
+    output (the ``--normalize-advantages`` path used by REINFORCE++
+    variants)."""
 
     @staticmethod
     def _local_stats(values, mask):

--- a/tests/core/test_registry_reinforce.py
+++ b/tests/core/test_registry_reinforce.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Registry tests for the REINFORCE++ / REINFORCE++-baseline algorithm entries
+(task #29).
+
+The two variants must be registered in ``ALGOS`` (otherwise the Controller
+rejects the key in ``register_all_serve``) and must reuse the GRPO service
+topology (no critic) — they differ only in advantage/loss computation.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+# `relax.core.registry` eagerly imports `relax.components.advantages`, which
+# imports `megatron.core` at module level. Skip when megatron is unavailable.
+pytest.importorskip("megatron.core")
+
+from relax.components.actor import Actor  # noqa: E402
+from relax.components.actor_fwd import ActorFwd  # noqa: E402
+from relax.components.advantages import Advantages  # noqa: E402
+from relax.components.rollout import Rollout  # noqa: E402
+from relax.core.registry import ALGOS, ROLES, ROLES_COLOCATE, process_role  # noqa: E402
+
+
+def _cfg(**kwargs):
+    defaults = dict(
+        debug_rollout_only=False,
+        debug_train_only=False,
+        fully_async=False,
+        hybrid=False,
+        loss_type="policy_loss",
+        advantage_estimator="grpo",
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestReinforceRegistry:
+    """The two REINFORCE++ variants are registered and reuse the GRPO topology."""
+
+    @pytest.mark.parametrize("key", ["reinforce_plus_plus", "reinforce_plus_plus_baseline"])
+    def test_variant_is_registered(self, key):
+        assert key in ALGOS
+
+    @pytest.mark.parametrize("key", ["reinforce_plus_plus", "reinforce_plus_plus_baseline"])
+    def test_variant_shares_grpo_topology(self, key):
+        expected = {
+            ROLES.rollout: Rollout,
+            ROLES.actor: Actor,
+            ROLES.advantages: Advantages,
+            ROLES.reference: ActorFwd,
+            ROLES.actor_fwd: ActorFwd,
+        }
+        assert ALGOS[key] == expected
+        # REINFORCE++ is actor-only (no value head), unlike PPO.
+        assert ROLES.critic not in ALGOS[key]
+
+    @pytest.mark.parametrize("key", ["reinforce_plus_plus", "reinforce_plus_plus_baseline"])
+    def test_process_role_returns_colocate_for_sync(self, key):
+        assert process_role(_cfg(advantage_estimator=key)) is ROLES_COLOCATE

--- a/tests/core/test_registry_reinforce.py
+++ b/tests/core/test_registry_reinforce.py
@@ -38,7 +38,8 @@ def _cfg(**kwargs):
 
 
 class TestReinforceRegistry:
-    """The two REINFORCE++ variants are registered and reuse the GRPO topology."""
+    """The two REINFORCE++ variants are registered and reuse the GRPO
+    topology."""
 
     @pytest.mark.parametrize("key", ["reinforce_plus_plus", "reinforce_plus_plus_baseline"])
     def test_variant_is_registered(self, key):

--- a/tests/utils/training/test_ppo_utils_reinforce.py
+++ b/tests/utils/training/test_ppo_utils_reinforce.py
@@ -88,21 +88,19 @@ def reference_reinforce_plus_plus_returns(
 def reference_reinforce_plus_plus_baseline_advantages(
     rewards: torch.Tensor,
     kl: list[torch.Tensor],
-    kl_coef: float,
 ) -> list[torch.Tensor]:
     """Plain-torch reference for
     ``get_reinforce_plus_plus_baseline_advantages``.
 
-    ``advantage = (reward - group_baseline) - kl_coef * kl`` broadcast to every
-    token. The group baseline is assumed already subtracted from ``rewards``
-    (done upstream in ``relax.utils.utils.post_process_rewards``); this reference
-    therefore mirrors the advantage function exactly: broadcast the scalar reward
-    and subtract the per-token KL penalty.
+    ``advantage = (reward - group_baseline)`` broadcast to every token, with no
+    per-token KL penalty (paper arXiv:2501.03262 §3.2: the baseline variant
+    applies a separate k2 KL loss instead of folding KL into the advantage).
+    The group baseline is assumed already subtracted from ``rewards`` (done
+    upstream in ``relax.utils.utils.post_process_rewards``); this reference
+    therefore mirrors the advantage function exactly: broadcast the scalar
+    reward to the per-token shape.
     """
-    return [
-        torch.ones_like(kl_tensor) * reward_val - kl_coef * kl_tensor
-        for kl_tensor, reward_val in zip(kl, rewards, strict=False)
-    ]
+    return [torch.ones_like(kl_tensor) * reward_val for kl_tensor, reward_val in zip(kl, rewards, strict=False)]
 
 
 def reference_policy_loss(
@@ -345,8 +343,8 @@ class TestReinforcePlusPlusBaselineAdvantages:
         kl = [torch.randn(6), torch.randn(4), torch.randn(9)]
         masks = [torch.ones(6), torch.ones(4), torch.ones(9)]
 
-        actual = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.03)
-        expected = reference_reinforce_plus_plus_baseline_advantages(rewards, kl, 0.03)
+        actual = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks)
+        expected = reference_reinforce_plus_plus_baseline_advantages(rewards, kl)
 
         assert len(actual) == len(expected)
         for a, e in zip(actual, expected, strict=False):
@@ -363,19 +361,27 @@ class TestReinforcePlusPlusBaselineAdvantages:
         kl = [torch.randn(7)]
         masks = [torch.ones(7)]
 
-        adv = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.0)[0]
+        adv = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks)[0]
         assert torch.allclose(adv, torch.full((7,), 2.0), atol=1e-6)
 
-    def test_kl_coef_zero(self, monkeypatch):
+    def test_kl_not_folded_into_advantage(self, monkeypatch):
+        """The baseline variant's advantage ignores per-token KL values.
+
+        Paper convention (arXiv:2501.03262 §3.2): the advantage is the
+        broadcast (reward - group baseline) only. Per-token KL must NOT change
+        it (KL is a separate k2 loss applied in policy_loss_function, not
+        here).
+        """
         pytest.importorskip("torch")
         install_fake_megatron(monkeypatch)
         from relax.utils.training.ppo_utils import get_reinforce_plus_plus_baseline_advantages
 
         rewards = torch.tensor([0.5, -0.5])
+        # deliberately non-trivial KL values — they must be ignored
         kl = [torch.randn(5), torch.randn(3)]
         masks = [torch.ones(5), torch.ones(3)]
 
-        adv = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.0)
+        adv = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks)
         for a, r in zip(adv, rewards, strict=False):
             assert torch.allclose(a, torch.full_like(a, r.item()), atol=1e-6)
 
@@ -387,8 +393,8 @@ class TestReinforcePlusPlusBaselineAdvantages:
         rewards = torch.tensor([1.0])
         kl = [torch.randn(4)]
         masks = [torch.ones(4)]
-        actual = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.2)
-        expected = reference_reinforce_plus_plus_baseline_advantages(rewards, kl, 0.2)
+        actual = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks)
+        expected = reference_reinforce_plus_plus_baseline_advantages(rewards, kl)
         assert torch.allclose(actual[0], expected[0], atol=1e-6)
 
 

--- a/tests/utils/training/test_ppo_utils_reinforce.py
+++ b/tests/utils/training/test_ppo_utils_reinforce.py
@@ -33,10 +33,11 @@ import torch
 def install_fake_megatron(monkeypatch, *, cp_size: int = 1) -> None:
     """Install a minimal fake ``megatron.core.mpu`` with the given ``cp_size``.
 
-    Mirrors the convention in ``tests/backends/megatron/test_ppo_gae_parity.py``
-    so ``ppo_utils`` can be imported and its CP-aware code path runs in plain
-    single-process mode. When ``cp_size == 1`` the ``all_gather_with_cp`` /
-    ``slice_log_prob_with_cp`` helpers are never reached.
+    Mirrors the convention in
+    ``tests/backends/megatron/test_ppo_gae_parity.py`` so ``ppo_utils`` can be
+    imported and its CP-aware code path runs in plain single-process mode. When
+    ``cp_size == 1`` the ``all_gather_with_cp`` / ``slice_log_prob_with_cp``
+    helpers are never reached.
     """
     megatron = ModuleType("megatron")
     core = ModuleType("megatron.core")
@@ -61,7 +62,8 @@ def reference_reinforce_plus_plus_returns(
     kl_coef: float,
     gamma: float,
 ) -> list[torch.Tensor]:
-    """Plain-torch reference for ``get_reinforce_plus_plus_returns`` (cp_size=1).
+    """Plain-torch reference for ``get_reinforce_plus_plus_returns``
+    (cp_size=1).
 
     For each sequence the per-token reward is ``-kl_coef * (kl * mask)`` with the
     scalar terminal reward added at the last masked (response) token, followed by
@@ -88,7 +90,8 @@ def reference_reinforce_plus_plus_baseline_advantages(
     kl: list[torch.Tensor],
     kl_coef: float,
 ) -> list[torch.Tensor]:
-    """Plain-torch reference for ``get_reinforce_plus_plus_baseline_advantages``.
+    """Plain-torch reference for
+    ``get_reinforce_plus_plus_baseline_advantages``.
 
     ``advantage = (reward - group_baseline) - kl_coef * kl`` broadcast to every
     token. The group baseline is assumed already subtracted from ``rewards``
@@ -153,7 +156,8 @@ def make_batch(seq_lens, n_response_per_seq, *, reward_fn, seed: int = 0):
 
 
 class TestReinforcePlusPlusReturns:
-    """Element-by-element correctness of ``get_reinforce_plus_plus_returns``."""
+    """Element-by-element correctness of
+    ``get_reinforce_plus_plus_returns``."""
 
     def test_matches_reference_variable_length(self, monkeypatch):
         pytest.importorskip("torch")
@@ -214,7 +218,8 @@ class TestReinforcePlusPlusReturns:
             assert torch.allclose(actual[i][0], token_rewards.sum(), atol=1e-6)
 
     def test_all_zero_reward(self, monkeypatch):
-        """All-zero rewards ⇒ returns reduce to discounted -kl_coef*kl on response."""
+        """All-zero rewards ⇒ returns reduce to discounted -kl_coef*kl on
+        response."""
         pytest.importorskip("torch")
         install_fake_megatron(monkeypatch)
         from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
@@ -272,8 +277,8 @@ class TestReinforcePlusPlusReturns:
         assert torch.allclose(actual[0][last_idx - 1], torch.tensor(0.9), atol=1e-6)
 
     def test_reward_only_at_last_masked_token(self, monkeypatch):
-        """The scalar reward must be injected at the last *response* token only,
-        never into masked prompt/padding positions, and padding after the
+        """The scalar reward must be injected at the last *response* token
+        only, never into masked prompt/padding positions, and padding after the
         response must stay zero."""
         pytest.importorskip("torch")
         install_fake_megatron(monkeypatch)
@@ -327,7 +332,8 @@ class TestReinforcePlusPlusReturns:
 
 
 class TestReinforcePlusPlusBaselineAdvantages:
-    """Element-by-element correctness of ``get_reinforce_plus_plus_baseline_advantages``."""
+    """Element-by-element correctness of
+    ``get_reinforce_plus_plus_baseline_advantages``."""
 
     def test_matches_reference(self, monkeypatch):
         pytest.importorskip("torch")
@@ -392,8 +398,9 @@ class TestReinforcePlusPlusBaselineAdvantages:
 
 
 class TestPolicyLossForReinforce:
-    """REINFORCE++ variants fall into the ``else`` branch of policy_loss_function
-    and reuse ``compute_policy_loss``; verify it against an independent ref."""
+    """REINFORCE++ variants fall into the ``else`` branch of
+    policy_loss_function and reuse ``compute_policy_loss``; verify it against
+    an independent ref."""
 
     def test_matches_reference(self):
         pytest.importorskip("torch")

--- a/tests/utils/training/test_ppo_utils_reinforce.py
+++ b/tests/utils/training/test_ppo_utils_reinforce.py
@@ -1,0 +1,413 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Numerical-correctness tests for the REINFORCE++ / REINFORCE++-baseline
+advantage estimators (task #29).
+
+Every test compares the Relax implementation in
+``relax.utils.training.ppo_utils`` against an **independent reference
+implementation** written from scratch in this module (plain torch, no Megatron,
+no ``@torch.compile``). The references follow the formulas documented in
+``docs/algorithms/reinforce_plus_plus.md`` and the original paper
+arXiv:2501.03262.
+
+Coverage targets (acceptance criteria of task #29):
+  * element-by-element agreement with an independent reference;
+  * variable-length responses;
+  * all-zero rewards;
+  * single-sample batches;
+  * mask does not pollute the reward injection / padding statistics.
+
+The CP>1 distributed path is exercised separately in
+``tests/backends/megatron/test_reinforce_pp_cp_parity.py``; here we force
+``cp_size == 1`` via a fake ``megatron.core.mpu`` so the per-rank math is tested
+in isolation.
+"""
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+
+def install_fake_megatron(monkeypatch, *, cp_size: int = 1) -> None:
+    """Install a minimal fake ``megatron.core.mpu`` with the given ``cp_size``.
+
+    Mirrors the convention in ``tests/backends/megatron/test_ppo_gae_parity.py``
+    so ``ppo_utils`` can be imported and its CP-aware code path runs in plain
+    single-process mode. When ``cp_size == 1`` the ``all_gather_with_cp`` /
+    ``slice_log_prob_with_cp`` helpers are never reached.
+    """
+    megatron = ModuleType("megatron")
+    core = ModuleType("megatron.core")
+    mpu = ModuleType("megatron.core.mpu")
+    mpu.get_context_parallel_world_size = lambda: cp_size
+    core.mpu = mpu
+
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(sys.modules, "megatron.core.mpu", mpu)
+
+
+# ---------------------------------------------------------------------------
+# Independent reference implementations (do NOT call Relax code).
+# ---------------------------------------------------------------------------
+
+
+def reference_reinforce_plus_plus_returns(
+    rewards: torch.Tensor,
+    kl: list[torch.Tensor],
+    loss_masks: list[torch.Tensor],
+    kl_coef: float,
+    gamma: float,
+) -> list[torch.Tensor]:
+    """Plain-torch reference for ``get_reinforce_plus_plus_returns`` (cp_size=1).
+
+    For each sequence the per-token reward is ``-kl_coef * (kl * mask)`` with the
+    scalar terminal reward added at the last masked (response) token, followed by
+    a discounted reverse cumulative sum ``G_t = r_t + gamma * G_{t+1}``.
+    """
+    returns = []
+    for i in range(len(rewards)):
+        mask = loss_masks[i]
+        token_rewards = -kl_coef * (kl[i] * mask)
+        last_idx = mask.nonzero(as_tuple=True)[0][-1]
+        token_rewards[last_idx] = token_rewards[last_idx] + rewards[i]
+
+        g = torch.zeros_like(token_rewards)
+        running = torch.zeros((), dtype=token_rewards.dtype, device=token_rewards.device)
+        for t in reversed(range(token_rewards.size(0))):
+            running = token_rewards[t] + gamma * running
+            g[t] = running
+        returns.append(g)
+    return returns
+
+
+def reference_reinforce_plus_plus_baseline_advantages(
+    rewards: torch.Tensor,
+    kl: list[torch.Tensor],
+    kl_coef: float,
+) -> list[torch.Tensor]:
+    """Plain-torch reference for ``get_reinforce_plus_plus_baseline_advantages``.
+
+    ``advantage = (reward - group_baseline) - kl_coef * kl`` broadcast to every
+    token. The group baseline is assumed already subtracted from ``rewards``
+    (done upstream in ``relax.utils.utils.post_process_rewards``); this reference
+    therefore mirrors the advantage function exactly: broadcast the scalar reward
+    and subtract the per-token KL penalty.
+    """
+    return [
+        torch.ones_like(kl_tensor) * reward_val - kl_coef * kl_tensor
+        for kl_tensor, reward_val in zip(kl, rewards, strict=False)
+    ]
+
+
+def reference_policy_loss(
+    ppo_kl: torch.Tensor,
+    advantages: torch.Tensor,
+    eps_clip: float,
+    eps_clip_high: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Plain-torch reference for ``compute_policy_loss`` (no dual-clip).
+
+    Standard PPO clipped surrogate: ``pg = -max(r*A, clip(r)*A)`` with
+    ``r = exp(-ppo_kl)`` and ``clipfrac`` flagging tokens where the clip binds.
+    """
+    ratio = (-ppo_kl).exp()
+    pg1 = -ratio * advantages
+    pg2 = -ratio.clamp(1 - eps_clip, 1 + eps_clip_high) * advantages
+    pg_loss = torch.maximum(pg1, pg2)
+    clipfrac = torch.gt(pg2, pg1).float()
+    return pg_loss, clipfrac
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build synthetic batches with variable lengths.
+# ---------------------------------------------------------------------------
+
+
+def make_batch(seq_lens, n_response_per_seq, *, reward_fn, seed: int = 0):
+    """Build (rewards, kl, loss_masks, response_lengths, total_lengths).
+
+    ``seq_lens`` are full sequence lengths; ``n_response_per_seq`` how many of
+    the trailing tokens are unmasked (response). The leading tokens are treated
+    as masked (prompt / padding) so mask-pollution behaviour is exercised.
+    """
+    torch.manual_seed(seed)
+    kl, masks = [], []
+    for total_len, resp_len in zip(seq_lens, n_response_per_seq, strict=False):
+        k = torch.randn(total_len, dtype=torch.float32)
+        m = torch.zeros(total_len, dtype=torch.float32)
+        m[-resp_len:] = 1.0
+        kl.append(k)
+        masks.append(m)
+    rewards = reward_fn(len(seq_lens))
+    response_lengths = list(n_response_per_seq)
+    total_lengths = list(seq_lens)
+    return rewards, kl, masks, response_lengths, total_lengths
+
+
+# ---------------------------------------------------------------------------
+# REINFORCE++ (Monte-Carlo discounted return) tests.
+# ---------------------------------------------------------------------------
+
+
+class TestReinforcePlusPlusReturns:
+    """Element-by-element correctness of ``get_reinforce_plus_plus_returns``."""
+
+    def test_matches_reference_variable_length(self, monkeypatch):
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        rewards, kl, masks, resp_lens, total_lens = make_batch(
+            [12, 7, 20],
+            [5, 3, 9],
+            reward_fn=lambda n: torch.randn(n),
+        )
+
+        actual = get_reinforce_plus_plus_returns(
+            rewards,
+            kl,
+            masks,
+            resp_lens,
+            total_lens,
+            kl_coef=0.04,
+            gamma=0.99,
+        )
+        expected = reference_reinforce_plus_plus_returns(rewards, kl, masks, 0.04, 0.99)
+
+        assert len(actual) == len(expected)
+        for a, e in zip(actual, expected, strict=False):
+            assert a.shape == e.shape
+            assert torch.allclose(a, e, atol=1e-6), (a, e)
+
+    def test_gamma_one_is_discounted_reverse_cumsum(self, monkeypatch):
+        """gamma=1 ⇒ G_t = sum of token rewards from t to end (reverse cumsum)."""
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        rewards, kl, masks, resp_lens, total_lens = make_batch(
+            [10, 8],
+            [4, 4],
+            reward_fn=lambda n: torch.tensor([2.0, -1.0]),
+        )
+
+        actual = get_reinforce_plus_plus_returns(
+            rewards,
+            kl,
+            masks,
+            resp_lens,
+            total_lens,
+            kl_coef=0.1,
+            gamma=1.0,
+        )
+        expected = reference_reinforce_plus_plus_returns(rewards, kl, masks, 0.1, 1.0)
+        for a, e in zip(actual, expected, strict=False):
+            assert torch.allclose(a, e, atol=1e-6)
+
+        # Sanity: with gamma=1, G at the first token equals total token-reward sum.
+        for i, (k, m, r) in enumerate(zip(kl, masks, rewards, strict=False)):
+            token_rewards = -0.1 * (k * m)
+            token_rewards[m.nonzero(as_tuple=True)[0][-1]] += r
+            assert torch.allclose(actual[i][0], token_rewards.sum(), atol=1e-6)
+
+    def test_all_zero_reward(self, monkeypatch):
+        """All-zero rewards ⇒ returns reduce to discounted -kl_coef*kl on response."""
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        rewards, kl, masks, resp_lens, total_lens = make_batch(
+            [9, 14],
+            [4, 6],
+            reward_fn=lambda n: torch.zeros(n),
+        )
+
+        actual = get_reinforce_plus_plus_returns(
+            rewards,
+            kl,
+            masks,
+            resp_lens,
+            total_lens,
+            kl_coef=0.05,
+            gamma=0.97,
+        )
+        expected = reference_reinforce_plus_plus_returns(rewards, kl, masks, 0.05, 0.97)
+        for a, e in zip(actual, expected, strict=False):
+            assert torch.allclose(a, e, atol=1e-6)
+
+        # No reward injection: the terminal token carries only the KL penalty.
+        for i, m in enumerate(masks):
+            last_idx = m.nonzero(as_tuple=True)[0][-1]
+            assert torch.allclose(actual[i][last_idx], -0.05 * kl[i][last_idx], atol=1e-6)
+
+    def test_single_sample(self, monkeypatch):
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        rewards, kl, masks, resp_lens, total_lens = make_batch(
+            [6],
+            [3],
+            reward_fn=lambda n: torch.tensor([1.0]),
+        )
+
+        actual = get_reinforce_plus_plus_returns(
+            rewards,
+            kl,
+            masks,
+            resp_lens,
+            total_lens,
+            kl_coef=0.0,
+            gamma=0.9,
+        )
+        expected = reference_reinforce_plus_plus_returns(rewards, kl, masks, 0.0, 0.9)
+        assert torch.allclose(actual[0], expected[0], atol=1e-6)
+
+        # kl_coef=0 ⇒ only the terminal reward propagates, discounted backwards.
+        last_idx = masks[0].nonzero(as_tuple=True)[0][-1]
+        assert torch.allclose(actual[0][last_idx], torch.tensor(1.0), atol=1e-6)
+        assert torch.allclose(actual[0][last_idx - 1], torch.tensor(0.9), atol=1e-6)
+
+    def test_reward_only_at_last_masked_token(self, monkeypatch):
+        """The scalar reward must be injected at the last *response* token only,
+        never into masked prompt/padding positions, and padding after the
+        response must stay zero."""
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        # 8-token sequence: 2 prompt (masked), 3 response (unmasked), 3 padding.
+        total_len, resp_len = 8, 3
+        kl = [torch.zeros(total_len, dtype=torch.float32)]
+        masks = [torch.tensor([0, 0, 1, 1, 1, 0, 0, 0], dtype=torch.float32)]
+        rewards = torch.tensor([5.0])
+
+        actual = get_reinforce_plus_plus_returns(
+            rewards,
+            kl,
+            masks,
+            [resp_len],
+            [total_len],
+            kl_coef=0.0,
+            gamma=1.0,
+        )[0]
+
+        last_idx = 4  # last response token
+        assert torch.allclose(actual[last_idx], torch.tensor(5.0), atol=1e-6)
+        # padding tokens after the response carry no return
+        assert torch.allclose(actual[5:], torch.zeros(3), atol=1e-6)
+        # prompt tokens before the response carry the discounted return forward
+        assert torch.allclose(actual[:2], torch.full((2,), 5.0), atol=1e-6)
+
+    def test_rejects_fully_masked_sequence(self, monkeypatch):
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_returns
+
+        kl = [torch.randn(5)]
+        masks = [torch.zeros(5)]  # fully masked ⇒ invalid
+        with pytest.raises(AssertionError, match="fully masked"):
+            get_reinforce_plus_plus_returns(
+                torch.tensor([1.0]),
+                kl,
+                masks,
+                [0],
+                [5],
+                kl_coef=0.0,
+                gamma=1.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# REINFORCE++-baseline advantage tests.
+# ---------------------------------------------------------------------------
+
+
+class TestReinforcePlusPlusBaselineAdvantages:
+    """Element-by-element correctness of ``get_reinforce_plus_plus_baseline_advantages``."""
+
+    def test_matches_reference(self, monkeypatch):
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_baseline_advantages
+
+        # rewards here already carry the group baseline subtracted upstream.
+        rewards = torch.tensor([0.8, -0.6, 0.1])
+        kl = [torch.randn(6), torch.randn(4), torch.randn(9)]
+        masks = [torch.ones(6), torch.ones(4), torch.ones(9)]
+
+        actual = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.03)
+        expected = reference_reinforce_plus_plus_baseline_advantages(rewards, kl, 0.03)
+
+        assert len(actual) == len(expected)
+        for a, e in zip(actual, expected, strict=False):
+            assert a.shape == e.shape
+            assert torch.allclose(a, e, atol=1e-6)
+
+    def test_broadcast_scalar(self, monkeypatch):
+        """The (reward - baseline) scalar must be identical on every token."""
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_baseline_advantages
+
+        rewards = torch.tensor([2.0])
+        kl = [torch.randn(7)]
+        masks = [torch.ones(7)]
+
+        adv = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.0)[0]
+        assert torch.allclose(adv, torch.full((7,), 2.0), atol=1e-6)
+
+    def test_kl_coef_zero(self, monkeypatch):
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_baseline_advantages
+
+        rewards = torch.tensor([0.5, -0.5])
+        kl = [torch.randn(5), torch.randn(3)]
+        masks = [torch.ones(5), torch.ones(3)]
+
+        adv = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.0)
+        for a, r in zip(adv, rewards, strict=False):
+            assert torch.allclose(a, torch.full_like(a, r.item()), atol=1e-6)
+
+    def test_single_sample(self, monkeypatch):
+        pytest.importorskip("torch")
+        install_fake_megatron(monkeypatch)
+        from relax.utils.training.ppo_utils import get_reinforce_plus_plus_baseline_advantages
+
+        rewards = torch.tensor([1.0])
+        kl = [torch.randn(4)]
+        masks = [torch.ones(4)]
+        actual = get_reinforce_plus_plus_baseline_advantages(rewards, kl, masks, kl_coef=0.2)
+        expected = reference_reinforce_plus_plus_baseline_advantages(rewards, kl, 0.2)
+        assert torch.allclose(actual[0], expected[0], atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Shared policy loss (REINFORCE++ variants reuse compute_policy_loss).
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyLossForReinforce:
+    """REINFORCE++ variants fall into the ``else`` branch of policy_loss_function
+    and reuse ``compute_policy_loss``; verify it against an independent ref."""
+
+    def test_matches_reference(self):
+        pytest.importorskip("torch")
+        from relax.utils.training.ppo_utils import compute_policy_loss as _compiled
+
+        compute_policy_loss = torch.compiler.disable(_compiled)
+
+        torch.manual_seed(1)
+        ppo_kl = torch.randn(50)
+        advantages = torch.randn(50)
+        eps_clip, eps_clip_high = 0.2, 0.28
+
+        actual_loss, actual_clip = compute_policy_loss(ppo_kl, advantages, eps_clip, eps_clip_high)
+        exp_loss, exp_clip = reference_policy_loss(ppo_kl, advantages, eps_clip, eps_clip_high)
+
+        assert torch.allclose(actual_loss, exp_loss, atol=1e-6)
+        assert torch.allclose(actual_clip, exp_clip, atol=1e-6)


### PR DESCRIPTION
## What

Register the `reinforce_plus_plus` / `reinforce_plus_plus_baseline` algorithm variants in `ALGOS`, add numerical and distributed tests, a design doc, and colocate recipes.

## Why

Closes #177.

The advantage functions for REINFORCE++ / REINFORCE++-baseline already existed in `ppo_utils.py`, but the two variants were never registered in `ALGOS`, so the Controller rejected the key (`Algorithm key 'reinforce_plus_plus' not registered in ALGOS`) and they could not run end-to-end. This makes them runnable and verifiable, and pins the formulas, normalization dimensions, mask and reduction semantics in a design doc and tests to resolve the "naming and baseline convention are not unified" gap flagged by task #29.

## How

- **Registry** (`relax/core/registry.py`): register both variants reusing the GRPO topology (no critic); factor the duplicated GRPO-family topologies into a shared `_GRPO_TOPOLOGY` constant (single source of truth — registry dispatch instead of if/elif). Behavior-equivalent for existing algorithms.
- **Algorithm convention** (per review, pinned to the paper arXiv:2501.03262):
  - `reinforce_plus_plus` (§3.1): per-token k1-style KL penalty (`--kl-loss-type k1`) folded into the discounted return via `--kl-coef`; global advantage whitening via `--normalize-advantages`. No group baseline.
  - `reinforce_plus_plus_baseline` (§3.2): group-mean baseline (upstream in `post_process_rewards`, no std division) + global advantage whitening + **separate k2 KL loss** (`--use-kl-loss --kl-loss-type k2 --kl-loss-coef`) — the KL penalty is NOT folded into the advantage. `get_reinforce_plus_plus_baseline_advantages` no longer subtracts `-kl_coef * kl` (signature drops `kl_coef`; call sites in `loss.py` / `advantages.py` updated); `arguments.py` now rejects `--kl-coef != 0` for the baseline estimator so the "silently no KL" configuration (v1 recipes) cannot recur.
- **Tests**:
  - `tests/utils/training/test_ppo_utils_reinforce.py` — element-wise parity vs independent plain-torch reference implementations for the returns, baseline advantages, and the shared `compute_policy_loss`. Covers variable-length responses, all-zero rewards, single-sample batches, gamma discount, mask not polluting prompt/padding, fully-masked rejection, and the paper convention that per-token KL does NOT enter the baseline advantage.
  - `tests/backends/megatron/test_reinforce_pp_cp_parity.py` — CP gather/compute/slice wiring of the returns (zig-zag chunking is `cp_utils`' responsibility, out of scope), baseline CP locality, and DP partition invariance of masked advantage whitening (fake `mpu` + mocked collectives, single process, per `test_ppo_gae_parity.py` convention).
  - `tests/core/test_registry_reinforce.py` — registration, topology reuse, no critic, `process_role` dispatch.
- **Docs** (`docs/algorithms/reinforce_plus_plus.md`): formulas, normalization dimensions, mask and reduction semantics, variant comparison vs GRPO/GSPO/SAPO, CP/DP behavior, and the known async-path whitening limitation. §3.1/§3.2/§4/§5 updated to the paper convention (k1 folded penalty for `reinforce_plus_plus`; separate k2 KL loss for the baseline variant).
- **Recipes**: `examples/algorithms/run-qwen3-0.6B-1xgpu-reinforce-pp.sh` (`--kl-coef 0.001 --kl-loss-type k1`) and `...-reinforce-pp-baseline.sh` (`--use-kl-loss --kl-loss-coef 0.001 --kl-loss-type k2`), switching `--advantage-estimator` and adding `--normalize-advantages`; header step math fixed to `100 × 4 × 8 / 16 = 200`.
- **Docstrings**: make the group-baseline convention explicit (subtracted upstream in `post_process_rewards`, group-mean without std unlike GRPO; whitening applied only in the sync path).

## Testing

```
pytest tests/utils/training/test_ppo_utils_reinforce.py \
       tests/backends/megatron/test_reinforce_pp_cp_parity.py \
       tests/core/test_registry_reinforce.py -v
```

- 20 new tests pass; 14 regression tests (`test_ppo_utils_grpo.py`, `test_registry_sft.py`) pass. `ruff check` / `ruff format --check` / `docformatter` clean (CI's pinned ruff 0.15.9).
- End-to-end training comparison with **non-zero KL** per the paper convention (Qwen3-0.6B + GSM8K, same budget, sync colocate, 3 seeds {1234, 42, 7}, 40 steps each, mean±std over stable region steps 5–39):

  | algorithm | raw_reward (last) | pg_loss | grad_norm | ppo_kl | kl_loss | clipfrac |
  |---|---|---|---|---|---|---|
  | GRPO | 0.9271±0.0147 | +0.0537±0.0076 | 1.129±0.052 | 6.20e-04 | 1.05e-03 (raw; coef 0) | 0.0007 |
  | REINFORCE++ | 0.9479±0.0295 | -0.0943±0.0017 | 1.736±0.015 | 6.07e-04 | folded into return (Δ returns−reward ≈ −0.001) | 0.0014 |
  | REINFORCE++-baseline | 0.9688±0.0000 | -0.0022±0.0033 | 1.457±0.053 | 6.48e-04 | 1.00e-03 (k2 loss, coef 0.001) | 0.0014 |

  All three stable (9/9 runs 40/40 steps, 0 NaN/Inf, 0 dropped samples); pg_loss / grad_norm / KL metrics are clearly distinct across algorithms, confirming `--advantage-estimator` actually switches the algorithm. Step time 12.4–13.3 s (samples/s 1.21–1.29, GBS 16) — budget-fair; GRPO reproduces the v1 numbers under the same seed/config (no regression from the changes). All 9 logs and 6 curve figures are included in the task-questionnaire (wps) submission bundle.
- **Reproducibility materials** (reviewer request): complete per-algorithm/per-seed commands, stats interval (steps 5–39), step time, and the 9 raw logs are listed in the training report (`deliverables/training-report.md`); logs archive: `redai-test/runs/log-{grpo,reinforcepp,reinforcepp-baseline}-seed{1234,42,7}.txt` (also bundled as a gist for the review thread). No NaN/Inf, no dropped samples, effective batch/seq-len unchanged — evidence extracted from the logs and tabulated in the report.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Breaking change / Bug fix / Refactoring / Performance / CI

## Notes

- No new CLI args; reuses existing `--advantage-estimator` / `--normalize-advantages`.
- Advantage whitening is applied only in the sync path; the async path does not whiten (pre-existing behavior shared by all algorithms, documented as a known limitation). Recommend sync colocate mode for REINFORCE++.
- Training comparison covers 3 seeds (1234/42/7) × 3 algorithms × 40 steps with non-zero KL; per-seed std is small (reward ≤ 0.05). Raw logs, run scripts, and the metric extraction script are listed in the report (§4) and bundled as a gist for the review thread.
