### PR TITLE
【No.19】feat(rewards): run sync custom rewards in worker pool

### DIFF
--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -435,7 +435,9 @@ SFT also uses the general dataset flags from [Data Configuration](#data-configur
 | `--rm-type` | str | None | Built-in reward model type |
 | `--rm-type-fallback` | str | None | Fallback for unknown/missing reward types: `zero` scores 0.0 with a warning, a registered type name routes there. None keeps the error behavior |
 | `--rm-type-infer` | flag | False | Infer the reward type from the sample label via registered matchers when no explicit type is set; conflicts warn and the explicit type wins |
-| `--custom-rm-path` | str | None | Custom reward function path. Function signature: `def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | Custom reward function path. A single-sample function receives one sample; a batched/group function receives the complete sample list and returns one result per sample. Bypasses format-aware routing |
+| `--reward-max-concurrency` | int | 64 | Maximum concurrent reward calls in each caller process. One custom batch/group invocation counts as one call |
+| `--reward-num-workers` | int | 16 | Number of Ray actors used to run synchronous rewards. Async custom rewards do not use these workers |
 | `--reward-key` | str | None | Key to extract reward value when reward function returns dict |
 | `--eval-reward-key` | str | None | Reward key for evaluation. When None, equals `--reward-key` |
 | `--group-rm` | flag | False | Whether to compute reward for entire group |

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -116,13 +116,32 @@ python scripts/tools/process_avqa.py \
 
 ## Custom Reward Methods
 
-You can define `reward_func(args, sample: Sample, **kwargs) -> float` in your own `.py` file, then add it to your task launch script. See [DeepEyes](../examples/deepeyes.md) for a concrete example.
+Define either a single-sample reward,
+`reward_func(args, sample: Sample, **kwargs) -> int | float | dict`, or a batched/group reward,
+`reward_func(args, samples: list[Sample], **kwargs) -> list[int | float | dict]`, in your own `.py` file. Then add
+its import path to the launch script. See [DeepEyes](../examples/deepeyes.md) for an example.
 
 ```bash
 --custom-rm-path examples.deepeyes.reward_deepeyes.reward_func
 # Custom reward_func may return a dict; if so, specify which key corresponds to the actual reward score
 --reward-key score
 ```
+
+Synchronous functions run in process-isolated Ray `RewardWorker` actors. Functions declared with `async def` are
+awaited in the caller process and do not use the worker pool. `--reward-num-workers` sets the synchronous worker
+count, while `--reward-max-concurrency` limits concurrent reward calls in each caller process.
+
+A batched/group custom reward is called once with the complete sample list, and that call counts as one concurrent
+call. Custom functions are loaded lazily and cached until `custom_rm` is explicitly reloaded.
+
+Inputs and return values of synchronous custom rewards must be serializable by Ray.
+
+> **Warning: Set timeouts for external I/O**
+>
+> Cancelling the caller or its Ray task is best-effort. It does **not** guarantee termination of a Python function
+> that is already running in a `RewardWorker`. Every potentially blocking external I/O operation, such as an HTTP,
+> RPC, or database call, must set an explicit timeout. Otherwise, the worker may remain occupied until the function
+> returns, and later reward calls assigned to that worker must wait.
 
 ### Format-aware reward routing
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -435,7 +435,9 @@ SFT 还会用到通用的[数据配置](#数据配置)参数，特别是 `--inpu
 | `--rm-type` | str | None | 内置 Reward 模型类型 |
 | `--rm-type-fallback` | str | None | 未知/缺失 Reward 类型的回退策略：`zero` 记 0 分并告警，注册名则路由到该 Reward；None 保持报错行为 |
 | `--rm-type-infer` | flag | False | 无显式类型时按注册的 label matcher 推断 Reward 类型；与显式类型冲突时告警并以显式类型优先 |
-| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。函数签名：`def custom_rm(args, sample) -> float` |
+| `--custom-rm-path` | str | None | 自定义 Reward 函数路径。单样本函数接收一个样本；batch/group 函数接收完整样本列表，并为每个样本返回一个结果。会绕过格式感知路由 |
+| `--reward-max-concurrency` | int | 64 | 每个调用方进程内同时执行的 Reward 调用数上限。一次自定义 batch/group 调用计为一个调用 |
+| `--reward-num-workers` | int | 16 | 用于执行同步 Reward 的 Ray Actor 数量。异步自定义 Reward 不使用这些 worker |
 | `--reward-key` | str | None | Reward 函数返回 dict 时提取 reward 值的 key |
 | `--eval-reward-key` | str | None | 评估时的 reward key。None 时等于 `--reward-key` |
 | `--group-rm` | flag | False | 是否对整个 group 做 Reward 计算 |

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -115,13 +115,31 @@ python scripts/tools/process_avqa.py \
 
 ## 自定义 Reward 方法
 
-您可以在自己的 `.py` 文件内定义 `reward_func(args, sample: Sample, **kwargs) -> float`，然后在任务启动脚本内加入调用即可，具体使用可参考 [DeepEyes](../examples/deepeyes.md)。
+在自己的 `.py` 文件中定义单样本 Reward
+`reward_func(args, sample: Sample, **kwargs) -> int | float | dict`，或 batch/group Reward
+`reward_func(args, samples: list[Sample], **kwargs) -> list[int | float | dict]`，然后在启动脚本中配置其导入路径。
+具体使用可参考 [DeepEyes](../examples/deepeyes.md)。
 
 ```bash
 --custom-rm-path examples.deepeyes.reward_deepeyes.reward_func
 # 自定义 reward_func 允许返回 dict，但若如此您需要明确哪个 key 对应于实际的 reward 得分
 --reward-key score
 ```
+
+同步函数在进程隔离的 Ray `RewardWorker` Actor 中运行。使用 `async def` 声明的函数在调用方进程中直接
+`await`，不使用 worker 池。`--reward-num-workers` 设置同步 worker 数量，`--reward-max-concurrency`
+限制每个调用方进程内同时执行的 Reward 调用数。
+
+batch/group 自定义 Reward 每次接收完整的样本列表，一次调用只占用一个并发名额。自定义函数按需加载并缓存，
+直到显式触发 `custom_rm` reload。
+
+同步自定义 Reward 的输入和返回值必须可由 Ray 序列化。
+
+> **警告：外部 I/O 必须设置超时**
+>
+> 取消调用方或对应的 Ray task 只是 best-effort，**不能保证终止**已经在 `RewardWorker` 中执行的 Python
+> 函数。HTTP、RPC、数据库调用等可能阻塞的外部 I/O 操作必须显式设置 timeout。否则，该 worker 可能一直被占用，
+> 直到函数返回，后续分配到此 worker 的 Reward 调用也必须继续等待。
 
 ### 格式感知的 Reward 路由
 

--- a/relax/agentic/pipeline/reward.py
+++ b/relax/agentic/pipeline/reward.py
@@ -32,24 +32,12 @@ def _effective_reward_concurrency(args, *, explicit_limit: int | None = None) ->
 
 
 async def _async_rm(args, sample):
-    custom_rm_path = args.custom_rm_path
-    if custom_rm_path:
-        from relax.utils.utils import load_function
-
-        rm_function = load_function(custom_rm_path)
-        return await rm_function(args, sample)
     from relax.engine.rewards import async_rm
 
     return await async_rm(args, sample)
 
 
 async def _batched_async_rm(args, samples):
-    custom_rm_path = args.custom_rm_path
-    if custom_rm_path:
-        from relax.utils.utils import load_function
-
-        rm_function = load_function(custom_rm_path)
-        return await rm_function(args, samples)
     from relax.engine.rewards import batched_async_rm
 
     return await batched_async_rm(args, samples)

--- a/relax/engine/rewards/__init__.py
+++ b/relax/engine/rewards/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
 import asyncio
+import inspect
 import random
+from typing import Any, Callable
 
 import aiohttp
 import ray
@@ -17,6 +19,71 @@ from .registry import get_reward_spec, list_reward_types, register_reward, resol
 
 logger = get_logger(__name__)
 _shared_session: aiohttp.ClientSession | None = None
+_MAX_CONTEXT_VALUE_LENGTH = 64
+_MAX_GROUP_CONTEXT_SAMPLES = 4
+_MAX_GROUP_CONTEXT_LENGTH = 2048
+
+
+class RewardExecutionError(RuntimeError):
+    """Error raised when a custom reward fails for a sample or batch."""
+
+    def __init__(self, *, custom_rm_path: str, sample_context: str, cause: Exception) -> None:
+        self.custom_rm_path = custom_rm_path
+        self.sample_context = sample_context
+        self.cause = cause
+        super().__init__(
+            f"Custom reward {custom_rm_path!r} failed for {sample_context}: {type(cause).__name__}: {cause}"
+        )
+
+
+def _bounded_repr(value: Any) -> str:
+    value_repr = repr(value)
+    if len(value_repr) <= _MAX_CONTEXT_VALUE_LENGTH:
+        return value_repr
+    return f"{value_repr[: _MAX_CONTEXT_VALUE_LENGTH - 3]}..."
+
+
+def _is_async_callable(function: Callable[..., Any]) -> bool:
+    try:
+        unwrapped = inspect.unwrap(function)
+    except ValueError:
+        unwrapped = function
+    if inspect.iscoroutinefunction(unwrapped):
+        return True
+
+    call = getattr(unwrapped, "__call__", None)
+    if call is None:
+        return False
+    try:
+        call = inspect.unwrap(call)
+    except ValueError:
+        pass
+    return inspect.iscoroutinefunction(call)
+
+
+def _sample_context(sample: Sample | list[Sample]) -> str:
+    if isinstance(sample, list):
+        displayed_samples = sample[:_MAX_GROUP_CONTEXT_SAMPLES]
+        sample_contexts = "; ".join(
+            f"sample[{sample_index}]=({_sample_context(group_sample)})"
+            for sample_index, group_sample in enumerate(displayed_samples)
+        )
+        omitted_count = len(sample) - len(displayed_samples)
+        omitted_context = f", omitted_samples={omitted_count}" if omitted_count > 0 else ""
+        context = f"batch_size={len(sample)}, samples=[{sample_contexts}]{omitted_context}"
+        if len(context) > _MAX_GROUP_CONTEXT_LENGTH:
+            return f"{context[: _MAX_GROUP_CONTEXT_LENGTH - 3]}..."
+        return context
+    metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
+    request_id = metadata.get("request_id")
+    context = [
+        f"session_id={_bounded_repr(sample.session_id)}",
+        f"index={_bounded_repr(sample.index)}",
+        f"group_index={_bounded_repr(sample.group_index)}",
+    ]
+    if request_id is not None:
+        context.append(f"request_id={_bounded_repr(request_id)}")
+    return ", ".join(context)
 
 
 def _get_shared_session() -> aiohttp.ClientSession:
@@ -38,19 +105,57 @@ def _get_shared_session() -> aiohttp.ClientSession:
 # 1. CPU-intensive reward functions no longer block the async event loop.
 # 2. Thread-unsafe libraries (e.g. math_verify) are safely isolated inside
 #    their own process – each Actor is single-threaded by default.
-# 3. Global concurrency is bounded by the number of workers in the pool
-#    combined with the asyncio.Semaphore in batched_async_rm.
+# 3. Per-process concurrency is bounded by the number of workers in the pool
+#    combined with the asyncio.Semaphore in RewardExecutor.
 # ---------------------------------------------------------------------------
 
 
 @ray.remote(num_cpus=0.25)
 class RewardWorker:
-    """Stateless worker that executes synchronous reward functions in a
-    dedicated process.
+    """Worker that executes synchronous reward functions in a dedicated
+    process.
 
-    Each call receives the rm_type and the necessary arguments so the worker
-    does not need to hold any state.
+    Built-in rewards are dispatched by ``rm_type``. Custom reward functions are
+    loaded by import path once per worker and then reused for subsequent calls.
     """
+
+    def __init__(self) -> None:
+        self._custom_reward_functions: dict[str, Callable[..., Any]] = {}
+
+    def _load_custom_reward(self, path: str) -> Callable[..., Any]:
+        function = self._custom_reward_functions.get(path)
+        if function is None:
+            function = load_function(path)
+            if not callable(function):
+                raise TypeError(f"Custom reward {path!r} is not callable.")
+            self._custom_reward_functions[path] = function
+        return function
+
+    def reload_custom_reward(self, path: str) -> None:
+        """Reload and cache a custom reward function in this worker process."""
+        from relax.utils.reload_utils import reload_function
+
+        function = reload_function(path)
+        if function is None or not callable(function):
+            raise RuntimeError(f"Failed to reload custom reward {path!r} in RewardWorker.")
+        self._custom_reward_functions[path] = function
+
+    def compute_custom(
+        self,
+        path: str,
+        args: Any,
+        sample: Sample | list[Sample],
+        kwargs: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute a synchronous custom reward payload."""
+        function = self._load_custom_reward(path)
+        result = function(args, sample, **(kwargs or {}))
+        if inspect.isawaitable(result):
+            close = getattr(result, "close", None)
+            if close is not None:
+                close()
+            raise TypeError(f"Custom reward {path!r} returned an awaitable; declare it with async def.")
+        return result
 
     def compute(self, rm_type: str, response: str, label, metadata: dict | None = None):
         """Dispatch to the registered synchronous reward function.
@@ -69,13 +174,13 @@ class RewardWorker:
 
 
 # ---------------------------------------------------------------------------
-# RewardExecutor: manages the worker pool and global concurrency
+# RewardExecutor: manages the worker pool and per-process concurrency
 # ---------------------------------------------------------------------------
 
 
 class RewardExecutor:
     """Singleton that manages a pool of RewardWorker actors and an
-    asyncio.Semaphore for global concurrency control."""
+    asyncio.Semaphore for per-process concurrency control."""
 
     _instance: "RewardExecutor | None" = None
 
@@ -84,7 +189,11 @@ class RewardExecutor:
         self._num_workers = num_workers
         self._semaphore: asyncio.Semaphore | None = None
         self._workers: list = []
+        self._worker_init_lock = None
         self._worker_index = 0
+        self._custom_reward_functions: dict[str, Callable[..., Any]] = {}
+        self._custom_reward_is_async: dict[str, bool] = {}
+        self._submission_cleanup_tasks: set[asyncio.Task] = set()
 
     # -- singleton access -----------------------------------------------------
 
@@ -94,21 +203,37 @@ class RewardExecutor:
             cls._instance = cls(max_concurrency=max_concurrency, num_workers=num_workers)
         return cls._instance
 
+    @classmethod
+    def reload_custom_reward(cls, path: str) -> None:
+        """Refresh a custom reward in the executor and all worker processes."""
+        executor = cls._instance
+        if executor is None:
+            return
+        executor._reload_custom_reward(path)
+
     # -- lazy init (must happen inside an event loop) -------------------------
 
     def _ensure_semaphore(self):
         if self._semaphore is None:
             self._semaphore = asyncio.Semaphore(self._max_concurrency)
 
-    def _ensure_workers(self):
-        if not self._workers:
-            self._workers = [
-                RewardWorker.options(
-                    name=f"reward_worker_{i}",
-                    get_if_exists=True,
-                ).remote()
-                for i in range(self._num_workers)
-            ]
+    async def _ensure_workers(self):
+        if self._workers:
+            return
+        if self._worker_init_lock is None:
+            self._worker_init_lock = asyncio.Lock()
+        async with self._worker_init_lock:
+            if self._workers:
+                return
+            self._workers = await asyncio.to_thread(
+                lambda: [
+                    RewardWorker.options(
+                        name=f"reward_worker_{i}",
+                        get_if_exists=True,
+                    ).remote()
+                    for i in range(self._num_workers)
+                ]
+            )
             logger.info(
                 "RewardExecutor: created %d RewardWorker actors (max_concurrency=%d)",
                 self._num_workers,
@@ -120,24 +245,111 @@ class RewardExecutor:
         self._worker_index += 1
         return worker
 
+    def _load_custom_reward(self, path: str) -> Callable[..., Any]:
+        function = self._custom_reward_functions.get(path)
+        if function is None:
+            function = load_function(path)
+            if not callable(function):
+                raise TypeError(f"Custom reward {path!r} is not callable.")
+            self._custom_reward_functions[path] = function
+            self._custom_reward_is_async[path] = _is_async_callable(function)
+        return function
+
+    def _reload_custom_reward(self, path: str) -> None:
+        self._custom_reward_functions.pop(path, None)
+        self._custom_reward_is_async.pop(path, None)
+
+        if not self._workers:
+            return
+        ray.get([worker.reload_custom_reward.remote(path) for worker in self._workers])
+
+    @staticmethod
+    def _cancel_worker_call(ref, *, custom_rm_path: str) -> None:
+        try:
+            ray.cancel(ref, force=False)
+        except Exception as exc:
+            logger.warning("Failed to request cancellation for custom reward %r: %s", custom_rm_path, exc)
+
+    @classmethod
+    async def _cancel_after_submission(cls, submission_task: asyncio.Task, *, custom_rm_path: str) -> None:
+        try:
+            ref = await submission_task
+        except Exception as exc:
+            logger.warning(
+                "Custom reward %r submission failed while handling cancellation: %s",
+                custom_rm_path,
+                exc,
+            )
+            return
+        cls._cancel_worker_call(ref, custom_rm_path=custom_rm_path)
+
+    async def _submit_worker_call(self, submit: Callable[[], Any], *, custom_rm_path: str) -> Any:
+        submission_task = asyncio.create_task(asyncio.to_thread(submit))
+        try:
+            return await asyncio.shield(submission_task)
+        except asyncio.CancelledError:
+            cleanup_task = asyncio.create_task(
+                self._cancel_after_submission(submission_task, custom_rm_path=custom_rm_path)
+            )
+            self._submission_cleanup_tasks.add(cleanup_task)
+            cleanup_task.add_done_callback(self._submission_cleanup_tasks.discard)
+            raise
+
+    async def _execute_custom(
+        self,
+        args: Any,
+        sample: Sample | list[Sample],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        path = args.custom_rm_path
+        sample_context = _sample_context(sample)
+        try:
+            function = self._load_custom_reward(path)
+            if self._custom_reward_is_async[path]:
+                return await function(args, sample, **kwargs)
+
+            await self._ensure_workers()
+            worker = self._next_worker()
+            ref = await self._submit_worker_call(
+                lambda: worker.compute_custom.remote(path, args, sample, kwargs),
+                custom_rm_path=path,
+            )
+            try:
+                return await ref
+            except asyncio.CancelledError:
+                self._cancel_worker_call(ref, custom_rm_path=path)
+                raise
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            raise RewardExecutionError(
+                custom_rm_path=path,
+                sample_context=sample_context,
+                cause=exc,
+            ) from exc
+
     # -- public API -----------------------------------------------------------
+
+    async def _execute_custom_with_concurrency(self, args, sample: Sample | list[Sample], **kwargs):
+        """Execute one custom reward call with concurrency control."""
+        self._ensure_semaphore()
+        async with self._semaphore:
+            return await self._execute_custom(args, sample, kwargs)
 
     async def execute(self, args, sample: Sample, **kwargs):
         """Execute a single reward computation with concurrency control.
 
+        - Custom rm paths bypass the format-aware router: async customs are
+          awaited in the caller process; sync customs use ``compute_custom``.
+        - Non-custom paths keep ``resolve_rm_type`` / registry dispatch.
         - Async rm_types (remote_rm, dapo-genrm) run in the event loop.
         - Sync rm_types are dispatched to the Ray worker pool.
-        - Custom rm paths are called directly (user is responsible for
-          async safety).
         """
+        if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False):
+            return await self._execute_custom_with_concurrency(args, sample, **kwargs)
+
         self._ensure_semaphore()
-
         async with self._semaphore:
-            # --- custom rm path: delegate to user function directly ---
-            if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False):
-                rm_function = load_function(args.custom_rm_path)
-                return await rm_function(args, sample, **kwargs)
-
             metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
             route = resolve_rm_type(
                 metadata_rm_type=metadata.get("rm_type"),
@@ -167,7 +379,7 @@ class RewardExecutor:
             # Default to sync path for any non-empty rm_type not registered
             # as async; unknown types keep failing inside the worker.
             if rm_type:
-                self._ensure_workers()
+                await self._ensure_workers()
                 worker = self._next_worker()
                 ref = worker.compute.remote(rm_type, response, label, metadata=metadata)
                 return await ref
@@ -179,6 +391,17 @@ class RewardExecutor:
 # ---------------------------------------------------------------------------
 # Public API (backward-compatible)
 # ---------------------------------------------------------------------------
+
+
+def _get_reward_executor(args):
+    max_concurrency = getattr(args, "reward_max_concurrency", None)
+    if max_concurrency is None:
+        max_concurrency = 64
+    num_workers = getattr(args, "reward_num_workers", 16)
+    return RewardExecutor.get_or_create(
+        max_concurrency=max_concurrency,
+        num_workers=num_workers,
+    )
 
 
 async def _dummy_reward(args):
@@ -228,24 +451,19 @@ async def async_rm(args, sample: Sample, **kwargs):
     Delegates to RewardExecutor which handles concurrency control and process
     isolation for CPU-bound / thread-unsafe reward functions.
     """
-    max_concurrency = getattr(args, "reward_max_concurrency", 64)
-    num_workers = getattr(args, "reward_num_workers", 16)
-    executor = RewardExecutor.get_or_create(
-        max_concurrency=max_concurrency,
-        num_workers=num_workers,
-    )
-    return await executor.execute(args, sample, **kwargs)
+    return await _get_reward_executor(args).execute(args, sample, **kwargs)
 
 
 async def batched_async_rm(
     args,
     samples: list[Sample],
     **kwargs,
-) -> list[int | float]:
-    if args.custom_rm_path is not None:
-        # Ensure the custom reward function is implemented in batch mode
-        rm_function = load_function(args.custom_rm_path)
-        return await rm_function(args, samples, **kwargs)
-    tasks = [async_rm(args, sample, **kwargs) for sample in samples]
-    rewards = await asyncio.gather(*tasks)
-    return rewards
+) -> list[int | float | dict[str, Any]]:
+    """Score multiple samples.
+
+    Custom rewards receive the complete sample payload in one invocation.
+    Built-in rewards fan out through per-sample ``async_rm`` calls.
+    """
+    if args.custom_rm_path is not None and not kwargs.get("ignore_custom", False):
+        return await _get_reward_executor(args)._execute_custom_with_concurrency(args, samples, **kwargs)
+    return await asyncio.gather(*(async_rm(args, sample, **kwargs) for sample in samples))

--- a/relax/utils/reload_utils.py
+++ b/relax/utils/reload_utils.py
@@ -111,7 +111,7 @@ RELOADABLE_FUNCTIONS: List[ReloadableFunction] = [
         description="Rollout data post-processing function in Actor",
     ),
     # ========== Immediate Scope ==========
-    # These functions are loaded immediately and reloaded on each call
+    # Most functions are reloaded on each call; custom_rm is explicitly cached.
     ReloadableFunction(
         name="custom_loss_function",
         attr_name=None,
@@ -174,7 +174,7 @@ RELOADABLE_FUNCTIONS: List[ReloadableFunction] = [
         config_attr="custom_rm_path",
         scope=ReloadScope.IMMEDIATE,
         required=False,
-        description="Custom reward model function (auto-reloaded on each call)",
+        description="Custom reward model function (cached between explicit reloads)",
     ),
     ReloadableFunction(
         name="rollout_sample_filter",
@@ -379,7 +379,21 @@ class ReloadableMixin:
             logger.info(f"Updated {func_def.attr_name} from {module_path}")
             message = f"Module '{module_name}' reloaded and attribute updated"
         else:
-            # IMMEDIATE scope: Only refresh sys.modules, next load_function will get the new version
+            # IMMEDIATE scope: refresh module state; custom_rm also refreshes executor and workers.
+            if module_name == "custom_rm":
+                from relax.engine.rewards import RewardExecutor
+
+                try:
+                    RewardExecutor.reload_custom_reward(module_path)
+                except Exception as exc:
+                    logger.error(f"Failed to reload custom reward workers for {module_path}: {exc}")
+                    return {
+                        "success": False,
+                        "module_name": module_name,
+                        "module_path": module_path,
+                        "scope": func_def.scope.value,
+                        "error": f"Failed to reload custom reward workers: {exc}",
+                    }
             logger.info(f"Refreshed sys.modules cache for {module_path}")
             message = f"Module '{module_name}' reloaded - will take effect on next call"
 

--- a/tests/engine/rewards/custom_reward_fixtures.py
+++ b/tests/engine/rewards/custom_reward_fixtures.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import fcntl
+import functools
+import os
+import time
+from typing import Any
+
+
+_sync_load_attribute_count = 0
+_module_reload_count = globals().get("_module_reload_count", 0) + 1
+
+
+def sync_pid_reward(args: Any, sample: Any, **kwargs: Any) -> dict[str, int]:
+    del kwargs
+    if getattr(args, "reward_delay", 0):
+        time.sleep(args.reward_delay)
+    return {"pid": os.getpid(), "index": sample.index}
+
+
+async def async_pid_reward(args: Any, sample: Any, **kwargs: Any) -> dict[str, int]:
+    del args, kwargs
+    return {"pid": os.getpid(), "index": sample.index}
+
+
+async def async_batch_pid_reward(args: Any, samples: list[Any], **kwargs: Any) -> list[dict[str, int]]:
+    del args, kwargs
+    pid = os.getpid()
+    return [{"pid": pid, "index": sample.index, "batch_size": len(samples)} for sample in samples]
+
+
+async def async_reload_count_reward(args: Any, sample: Any, **kwargs: Any) -> dict[str, int]:
+    del args, kwargs
+    return {"pid": os.getpid(), "index": sample.index, "reload_count": _module_reload_count}
+
+
+class AsyncPidReward:
+    async def __call__(self, args: Any, sample: Any, **kwargs: Any) -> dict[str, int]:
+        del args, kwargs
+        return {"pid": os.getpid(), "index": sample.index}
+
+
+async_callable_pid_reward = AsyncPidReward()
+
+
+def _wrapped_async_pid_reward(function):
+    @functools.wraps(function)
+    def wrapper(*args: Any, **kwargs: Any):
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
+wrapped_async_pid_reward = _wrapped_async_pid_reward(async_pid_reward)
+
+
+def sync_conditional_reward(args: Any, sample: Any, **kwargs: Any) -> int:
+    del kwargs
+    if args.fail_reward:
+        raise ValueError(f"bad sample index={sample.index}")
+    return sample.index
+
+
+def _update_concurrency_counter(counter_path: str, delta: int) -> None:
+    with open(counter_path, "r+", encoding="utf-8") as counter_file:
+        fcntl.flock(counter_file.fileno(), fcntl.LOCK_EX)
+        current, maximum = (int(value) for value in counter_file.read().split(","))
+        counter_file.seek(0)
+        counter_file.truncate()
+        current += delta
+        counter_file.write(f"{current},{max(maximum, current)}")
+        counter_file.flush()
+        fcntl.flock(counter_file.fileno(), fcntl.LOCK_UN)
+
+
+def sync_concurrency_reward(args: Any, sample: Any, **kwargs: Any) -> float:
+    del sample, kwargs
+    _update_concurrency_counter(args.counter_path, 1)
+    try:
+        time.sleep(args.reward_delay)
+    finally:
+        _update_concurrency_counter(args.counter_path, -1)
+    return 1.0
+
+
+def sync_batch_conditional_reward(args: Any, samples: list[Any], **kwargs: Any) -> list[dict[str, int]]:
+    del kwargs
+    if args.fail_reward:
+        raise ValueError("batch reward failed")
+    pid = os.getpid()
+    return [{"pid": pid, "index": sample.index, "batch_size": len(samples)} for sample in samples]
+
+
+def sync_batch_concurrency_reward(args: Any, samples: list[Any], **kwargs: Any) -> list[float]:
+    del kwargs
+    _update_concurrency_counter(args.counter_path, 1)
+    try:
+        time.sleep(args.reward_delay)
+    finally:
+        _update_concurrency_counter(args.counter_path, -1)
+    return [1.0] * len(samples)
+
+
+def sync_reload_count_reward(args: Any, sample: Any, **kwargs: Any) -> dict[str, int]:
+    del args, kwargs
+    return {"pid": os.getpid(), "index": sample.index, "reload_count": _module_reload_count}
+
+
+def _sync_load_count_reward(args: Any, sample: Any, **kwargs: Any) -> dict[str, int]:
+    del kwargs
+    if getattr(args, "reward_delay", 0):
+        time.sleep(args.reward_delay)
+    return {"pid": os.getpid(), "index": sample.index, "load_count": _sync_load_attribute_count}
+
+
+def __getattr__(name: str) -> Any:
+    # load_function resolves this dynamic attribute once in each process. The
+    # reward result exposes the count so the test can distinguish loading from
+    # repeated reward invocations.
+    global _sync_load_attribute_count
+    if name == "sync_load_count_reward":
+        _sync_load_attribute_count += 1
+        return _sync_load_count_reward
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/engine/rewards/test_custom_reward_worker.py
+++ b/tests/engine/rewards/test_custom_reward_worker.py
@@ -1,0 +1,481 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from types import SimpleNamespace
+from typing import Any, Awaitable, Iterator, TypeVar
+
+import pytest
+
+
+try:
+    import ray
+
+    if not ray.is_initialized():
+        try:
+            ray.init(num_cpus=8, ignore_reinit_error=True)
+        except ValueError as exc:
+            if "When connecting to an existing cluster" in str(exc):
+                ray.init(ignore_reinit_error=True)
+            else:
+                raise
+
+    from relax.engine import rewards as rewards_module
+    from relax.engine.rewards import RewardExecutionError, RewardExecutor, async_rm, batched_async_rm
+    from relax.utils.reload_utils import ReloadableMixin
+    from relax.utils.types import Sample
+except ModuleNotFoundError as exc:
+    if exc.name != "ray":
+        raise
+    pytest.skip("Ray is not installed", allow_module_level=True)
+
+
+CUSTOM_REWARD_MODULE = "tests.engine.rewards.custom_reward_fixtures"
+SYNC_PID_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_pid_reward"
+ASYNC_PID_REWARD = f"{CUSTOM_REWARD_MODULE}.async_pid_reward"
+ASYNC_BATCH_PID_REWARD = f"{CUSTOM_REWARD_MODULE}.async_batch_pid_reward"
+ASYNC_CALLABLE_PID_REWARD = f"{CUSTOM_REWARD_MODULE}.async_callable_pid_reward"
+WRAPPED_ASYNC_PID_REWARD = f"{CUSTOM_REWARD_MODULE}.wrapped_async_pid_reward"
+SYNC_CONDITIONAL_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_conditional_reward"
+SYNC_CONCURRENCY_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_concurrency_reward"
+SYNC_BATCH_CONDITIONAL_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_batch_conditional_reward"
+SYNC_BATCH_CONCURRENCY_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_batch_concurrency_reward"
+SYNC_LOAD_COUNT_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_load_count_reward"
+SYNC_RELOAD_COUNT_REWARD = f"{CUSTOM_REWARD_MODULE}.sync_reload_count_reward"
+ASYNC_RELOAD_COUNT_REWARD = f"{CUSTOM_REWARD_MODULE}.async_reload_count_reward"
+RAY_TEST_TIMEOUT = 10
+
+
+T = TypeVar("T")
+
+
+def _make_args(**overrides: Any) -> SimpleNamespace:
+    defaults = {
+        "rm_type": "openr1mm",
+        "custom_rm_path": None,
+        "group_rm": False,
+        "reward_max_concurrency": 64,
+        "reward_num_workers": 4,
+        "rm_url": None,
+        "reward_key": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_sample(
+    index: int,
+    response: str = "response",
+    label: str = "label",
+    metadata: dict[str, Any] | None = None,
+    *,
+    group_index: int | None = None,
+    session_id: str | None = None,
+) -> "Sample":
+    return Sample(
+        response=response,
+        label=label,
+        metadata=metadata or {},
+        index=index,
+        group_index=group_index,
+        session_id=session_id,
+    )
+
+
+def _kill_workers(executor: RewardExecutor | None) -> None:
+    if executor is None:
+        return
+    for worker in executor._workers:
+        try:
+            ray.kill(worker)
+        except Exception:
+            # A worker may already be dead after an expected failure. Teardown
+            # must still clear the remaining actor handles.
+            pass
+    executor._workers.clear()
+
+
+async def _wait(awaitable: Awaitable[T], timeout: float = RAY_TEST_TIMEOUT) -> T:
+    return await asyncio.wait_for(awaitable, timeout=timeout)
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor() -> Iterator[None]:
+    _kill_workers(RewardExecutor._instance)
+    RewardExecutor._instance = None
+    yield
+    _kill_workers(RewardExecutor._instance)
+    RewardExecutor._instance = None
+
+
+@pytest.fixture
+def loaded_reward_paths(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    original_load_function = rewards_module.load_function
+    loaded_paths = []
+
+    def track_load(path: str):
+        loaded_paths.append(path)
+        return original_load_function(path)
+
+    monkeypatch.setattr(rewards_module, "load_function", track_load)
+    return loaded_paths
+
+
+class TestCustomRewardDispatch:
+    @pytest.mark.asyncio
+    async def test_sync_reward_runs_in_worker_without_blocking_event_loop(self, monkeypatch):
+        event_loop_thread = threading.get_ident()
+        submission_threads = []
+        original_to_thread = asyncio.to_thread
+
+        async def tracked_to_thread(function, /, *args, **kwargs):
+            def run():
+                submission_threads.append(threading.get_ident())
+                return function(*args, **kwargs)
+
+            return await original_to_thread(run)
+
+        monkeypatch.setattr(asyncio, "to_thread", tracked_to_thread)
+        args = _make_args(custom_rm_path=SYNC_PID_REWARD, reward_num_workers=1)
+
+        result = await _wait(async_rm(args, _make_sample(index=3)))
+
+        assert len(submission_threads) >= 2
+        assert all(thread_id != event_loop_thread for thread_id in submission_threads)
+        assert result["index"] == 3
+        assert result["pid"] != os.getpid()
+
+    @pytest.mark.asyncio
+    async def test_batched_sync_custom_reward_keeps_payload_contract(self):
+        args = _make_args(custom_rm_path=SYNC_BATCH_CONDITIONAL_REWARD, group_rm=False, fail_reward=False)
+        samples = [_make_sample(index=index) for index in range(3)]
+
+        rewards = await _wait(batched_async_rm(args, samples))
+
+        assert [reward["index"] for reward in rewards] == [0, 1, 2]
+        assert all(reward["batch_size"] == 3 for reward in rewards)
+        assert len({reward["pid"] for reward in rewards}) == 1
+        assert rewards[0]["pid"] != os.getpid()
+
+    @pytest.mark.asyncio
+    async def test_batched_async_custom_reward_keeps_payload_contract_without_workers(self):
+        args = _make_args(custom_rm_path=ASYNC_BATCH_PID_REWARD, group_rm=True)
+        samples = [_make_sample(index=index) for index in range(3)]
+
+        rewards = await _wait(batched_async_rm(args, samples))
+
+        assert [reward["index"] for reward in rewards] == [0, 1, 2]
+        assert all(reward["batch_size"] == 3 for reward in rewards)
+        assert {reward["pid"] for reward in rewards} == {os.getpid()}
+        assert RewardExecutor._instance._workers == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "custom_rm_path",
+        [ASYNC_PID_REWARD, ASYNC_CALLABLE_PID_REWARD, WRAPPED_ASYNC_PID_REWARD],
+        ids=["function", "callable", "wrapped"],
+    )
+    async def test_async_custom_reward_is_awaited_without_workers(self, custom_rm_path):
+        args = _make_args(custom_rm_path=custom_rm_path, reward_num_workers=2)
+
+        result = await _wait(async_rm(args, _make_sample(index=4)))
+
+        assert result == {"pid": os.getpid(), "index": 4}
+        assert RewardExecutor._instance._workers == []
+
+
+class TestRewardExecutorConfiguration:
+    @pytest.mark.asyncio
+    async def test_none_reward_max_concurrency_uses_executor_default(self):
+        args = _make_args(
+            custom_rm_path=ASYNC_PID_REWARD,
+            reward_max_concurrency=None,
+        )
+
+        result = await _wait(async_rm(args, _make_sample(index=4)))
+
+        assert result == {"pid": os.getpid(), "index": 4}
+        assert RewardExecutor._instance._max_concurrency == 64
+
+    @pytest.mark.asyncio
+    async def test_reward_max_concurrency_controls_sync_custom_reward(self, tmp_path):
+        counter_path = tmp_path / "counter.txt"
+        counter_path.write_text("0,0", encoding="utf-8")
+        args = _make_args(
+            custom_rm_path=SYNC_CONCURRENCY_REWARD,
+            counter_path=str(counter_path),
+            reward_delay=0.1,
+            reward_max_concurrency=2,
+            reward_num_workers=4,
+        )
+        samples = [_make_sample(index=index) for index in range(8)]
+
+        await _wait(asyncio.gather(*(async_rm(args, sample) for sample in samples)))
+
+        current, maximum = (int(value) for value in counter_path.read_text(encoding="utf-8").split(","))
+        assert current == 0
+        assert maximum == 2
+
+    @pytest.mark.asyncio
+    async def test_reward_max_concurrency_counts_complete_batch_as_one_invocation(self, tmp_path):
+        counter_path = tmp_path / "batch-counter.txt"
+        counter_path.write_text("0,0", encoding="utf-8")
+        args = _make_args(
+            custom_rm_path=SYNC_BATCH_CONCURRENCY_REWARD,
+            counter_path=str(counter_path),
+            reward_delay=0.1,
+            reward_max_concurrency=2,
+            reward_num_workers=4,
+        )
+        batches = [[_make_sample(index=batch_index * 3 + offset) for offset in range(3)] for batch_index in range(6)]
+
+        rewards = await _wait(asyncio.gather(*(batched_async_rm(args, samples) for samples in batches)))
+
+        current, maximum = (int(value) for value in counter_path.read_text(encoding="utf-8").split(","))
+        assert current == 0
+        assert maximum == 2
+        assert all(reward == [1.0, 1.0, 1.0] for reward in rewards)
+
+
+class TestCustomRewardLoading:
+    @pytest.mark.asyncio
+    async def test_sync_custom_reward_is_loaded_once_per_process(self, loaded_reward_paths):
+        args = _make_args(
+            custom_rm_path=SYNC_LOAD_COUNT_REWARD,
+            reward_delay=0.05,
+            reward_num_workers=3,
+        )
+        samples = [_make_sample(index=index) for index in range(12)]
+
+        results = await _wait(asyncio.gather(*(async_rm(args, sample) for sample in samples)))
+
+        assert loaded_reward_paths == [SYNC_LOAD_COUNT_REWARD]
+        assert len(RewardExecutor._instance._workers) == 3
+        assert len({result["pid"] for result in results}) == 3
+        assert {result["load_count"] for result in results} == {1}
+
+    @pytest.mark.asyncio
+    async def test_explicit_reload_refreshes_custom_reward_in_all_worker_processes(self):
+        args = _make_args(custom_rm_path=SYNC_RELOAD_COUNT_REWARD, reward_num_workers=3)
+        samples = [_make_sample(index=index) for index in range(3)]
+
+        before_reload = await _wait(asyncio.gather(*(async_rm(args, sample) for sample in samples)))
+        reload_owner = ReloadableMixin()
+        reload_owner.args = args
+        reload_result = reload_owner.reload_function_by_name("custom_rm")
+        after_reload = await _wait(asyncio.gather(*(async_rm(args, sample) for sample in samples)))
+
+        assert reload_result["success"] is True
+        before_reload_counts = {result["pid"]: result["reload_count"] for result in before_reload}
+        after_reload_counts = {result["pid"]: result["reload_count"] for result in after_reload}
+        assert len(before_reload_counts) == 3
+        assert after_reload_counts == {pid: reload_count + 1 for pid, reload_count in before_reload_counts.items()}
+
+    @pytest.mark.asyncio
+    async def test_explicit_reload_refreshes_cached_async_custom_reward(self):
+        args = _make_args(custom_rm_path=ASYNC_RELOAD_COUNT_REWARD)
+        sample = _make_sample(index=0)
+
+        before_reload = await _wait(async_rm(args, sample))
+        reload_owner = ReloadableMixin()
+        reload_owner.args = args
+        reload_result = reload_owner.reload_function_by_name("custom_rm")
+        after_reload = await _wait(async_rm(args, sample))
+
+        assert reload_result["success"] is True
+        assert before_reload["pid"] == os.getpid()
+        assert after_reload["pid"] == os.getpid()
+        assert after_reload["reload_count"] == before_reload["reload_count"] + 1
+        assert RewardExecutor._instance._workers == []
+
+
+class TestCustomRewardErrors:
+    @pytest.mark.asyncio
+    async def test_cancel_during_submission_cancels_eventual_ray_task(self, monkeypatch):
+        args = _make_args(
+            custom_rm_path=SYNC_PID_REWARD,
+            reward_delay=0,
+            reward_max_concurrency=1,
+            reward_num_workers=1,
+        )
+        await _wait(async_rm(args, _make_sample(index=-1)))
+
+        submission_started = threading.Event()
+        allow_submission = threading.Event()
+        original_to_thread = asyncio.to_thread
+        original_cancel = ray.cancel
+        cancelled_refs = []
+
+        async def delayed_to_thread(function, /, *args, **kwargs):
+            def run():
+                submission_started.set()
+                assert allow_submission.wait(timeout=RAY_TEST_TIMEOUT)
+                return function(*args, **kwargs)
+
+            return await original_to_thread(run)
+
+        def tracked_cancel(ref, *, force):
+            cancelled_refs.append(ref)
+            return original_cancel(ref, force=force)
+
+        monkeypatch.setattr(asyncio, "to_thread", delayed_to_thread)
+        monkeypatch.setattr(ray, "cancel", tracked_cancel)
+
+        cancelled_call = asyncio.create_task(async_rm(args, _make_sample(index=0)))
+        for _ in range(RAY_TEST_TIMEOUT * 50):
+            if submission_started.is_set():
+                break
+            await asyncio.sleep(0.02)
+        else:
+            pytest.fail("Ray task submission did not start.")
+
+        cancelled_call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(cancelled_call, timeout=1)
+
+        assert cancelled_refs == []
+        allow_submission.set()
+        for _ in range(RAY_TEST_TIMEOUT * 50):
+            if cancelled_refs:
+                break
+            await asyncio.sleep(0.02)
+        else:
+            pytest.fail("Submitted Ray task was not cancelled.")
+        assert len(cancelled_refs) == 1
+        args.reward_delay = 0
+        assert (await _wait(async_rm(args, _make_sample(index=1))))["index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_cancelled_sync_reward_allows_next_call_to_complete(self, tmp_path):
+        counter_path = tmp_path / "cancel-counter.txt"
+        counter_path.write_text("0,0", encoding="utf-8")
+        args = _make_args(
+            custom_rm_path=SYNC_CONCURRENCY_REWARD,
+            counter_path=str(counter_path),
+            reward_delay=0.5,
+            reward_max_concurrency=1,
+            reward_num_workers=1,
+        )
+        cancelled_call = asyncio.create_task(async_rm(args, _make_sample(index=0)))
+        for _ in range(RAY_TEST_TIMEOUT * 50):
+            if cancelled_call.done():
+                await cancelled_call
+            current, _ = (int(value) for value in counter_path.read_text(encoding="utf-8").split(","))
+            if current == 1:
+                break
+            await asyncio.sleep(0.02)
+        else:
+            pytest.fail("Synchronous custom reward did not start in the Ray actor.")
+
+        cancelled_call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_call
+
+        args.reward_delay = 0
+        assert await _wait(async_rm(args, _make_sample(index=1))) == 1.0
+        current, _ = (int(value) for value in counter_path.read_text(encoding="utf-8").split(","))
+        assert current == 0
+
+    @pytest.mark.asyncio
+    async def test_custom_reward_error_identifies_sample_and_next_call_completes(self):
+        args = _make_args(custom_rm_path=SYNC_CONDITIONAL_REWARD, fail_reward=True)
+        sample = _make_sample(index=17, group_index=2, session_id="session-17")
+
+        with pytest.raises(RewardExecutionError, match="index=17") as error_info:
+            await _wait(async_rm(args, sample))
+
+        error_message = str(error_info.value)
+        assert "session_id='session-17'" in error_message
+        assert "group_index=2" in error_message
+        assert error_info.value.__cause__ is error_info.value.cause
+
+        args.fail_reward = False
+        assert await _wait(async_rm(args, sample)) == 17
+
+    @pytest.mark.asyncio
+    async def test_group_error_is_bounded_and_releases_concurrency_slot(self):
+        args = _make_args(
+            custom_rm_path=SYNC_BATCH_CONDITIONAL_REWARD,
+            group_rm=True,
+            fail_reward=True,
+            reward_max_concurrency=1,
+            reward_num_workers=3,
+        )
+        long_id = "context-value-" * 100
+        samples = [
+            _make_sample(
+                index=index,
+                group_index=7,
+                session_id=f"session-{index}-{long_id}",
+                metadata={"request_id": f"request-{index}-{long_id}"},
+            )
+            for index in range(20)
+        ]
+
+        with pytest.raises(RewardExecutionError) as error_info:
+            await _wait(batched_async_rm(args, samples))
+
+        sample_context = error_info.value.sample_context
+        assert len(sample_context) <= 2048
+        assert "batch_size=20" in sample_context
+        assert "sample[0]" in sample_context
+        assert "sample[3]" in sample_context
+        assert "sample[4]" not in sample_context
+        assert "omitted_samples=16" in sample_context
+        assert long_id not in sample_context
+
+        args.fail_reward = False
+        rewards = await _wait(batched_async_rm(args, samples))
+        assert [reward["index"] for reward in rewards] == list(range(20))
+        assert all(reward["batch_size"] == 20 for reward in rewards)
+        assert len({reward["pid"] for reward in rewards}) == 1
+        assert rewards[0]["pid"] != os.getpid()
+
+
+class TestCustomRewardAndRouterCoexistence:
+    """Joint regressions against the Task 18 format-aware registry."""
+
+    @pytest.mark.asyncio
+    async def test_custom_rm_bypasses_router_with_unknown_metadata_rm_type(self):
+        from relax.engine.rewards import registry as reward_registry
+
+        reward_registry.reset_router_state()
+        args = _make_args(rm_type="math", custom_rm_path=SYNC_PID_REWARD, reward_num_workers=1)
+        sample = _make_sample(
+            index=9,
+            response="ignored",
+            label="ignored",
+            metadata={"rm_type": "totally_unknown_type"},
+        )
+
+        result = await _wait(async_rm(args, sample))
+
+        assert result == {"pid": result["pid"], "index": 9}
+        assert result["pid"] != os.getpid()
+        assert reward_registry.get_router_stats() == {}
+
+    @pytest.mark.asyncio
+    async def test_batched_custom_rm_bypasses_router_with_unknown_metadata_rm_type(self):
+        from relax.engine.rewards import registry as reward_registry
+
+        reward_registry.reset_router_state()
+        args = _make_args(
+            custom_rm_path=SYNC_BATCH_CONDITIONAL_REWARD,
+            group_rm=True,
+            fail_reward=False,
+            reward_num_workers=1,
+        )
+        samples = [
+            _make_sample(index=0, metadata={"rm_type": "totally_unknown_type"}),
+            _make_sample(index=1, metadata={"rm_type": "another_unknown_type"}),
+        ]
+
+        rewards = await _wait(batched_async_rm(args, samples))
+
+        assert [reward["index"] for reward in rewards] == [0, 1]
+        assert all(reward["batch_size"] == 2 for reward in rewards)
+        assert rewards[0]["pid"] != os.getpid()
+        assert reward_registry.get_router_stats() == {}

--- a/tests/engine/rewards/test_reward_worker.py
+++ b/tests/engine/rewards/test_reward_worker.py
@@ -507,7 +507,7 @@ class TestHighConcurrency:
             num_workers=args.reward_num_workers,
         )
         # Force worker initialization
-        executor._ensure_workers()
+        await executor._ensure_workers()
 
         initial_index = executor._worker_index
         n = 20

--- a/tests/test_agentic_rollout.py
+++ b/tests/test_agentic_rollout.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 
+from relax.agentic.pipeline.reward import RewardDomain
 from relax.agentic.pipeline.runtime import (
     BackendGenerateResult,
     RuntimeGroup,
@@ -58,6 +59,50 @@ def _runtime_args(**overrides):
     if base["over_sampling_batch_size"] is None:
         base["over_sampling_batch_size"] = base["rollout_batch_size"]
     return SimpleNamespace(**base)
+
+
+async def test_reward_domain_delegates_sample_reward_to_executor(monkeypatch) -> None:
+    calls: list[Sample] = []
+
+    async def fake_async_rm(args, sample):
+        del args
+        calls.append(sample)
+        return 1.0
+
+    monkeypatch.setattr("relax.engine.rewards.async_rm", fake_async_rm)
+    reward_domain = RewardDomain(
+        args=_runtime_args(reward_max_concurrency=1),
+        group_filter=None,
+        max_submissions_per_step=None,
+    )
+    sample = Sample(index=0, group_index=0, session_id="sample-0", metadata={})
+
+    rewarded_sample = await reward_domain._run_sample_reward(sample)
+
+    assert calls == [sample]
+    assert rewarded_sample.reward == 1.0
+
+
+async def test_reward_domain_delegates_group_reward_to_executor(monkeypatch) -> None:
+    calls: list[list[Sample]] = []
+
+    async def fake_batched_async_rm(args, samples):
+        del args
+        calls.append(samples)
+        return [float(sample.index) for sample in samples]
+
+    monkeypatch.setattr("relax.engine.rewards.batched_async_rm", fake_batched_async_rm)
+    reward_domain = RewardDomain(
+        args=_runtime_args(group_rm=True, reward_max_concurrency=1),
+        group_filter=None,
+        max_submissions_per_step=None,
+    )
+    group = [Sample(index=index, group_index=0, session_id=f"sample-{index}", metadata={}) for index in range(3)]
+
+    rewarded_group = await reward_domain._run_group_reward(group)
+
+    assert calls == [group]
+    assert [sample.reward for sample in rewarded_group] == [0.0, 1.0, 2.0]
 
 
 class _FakeTokenizer:


### PR DESCRIPTION
## What

Run synchronous custom reward functions in the existing process-isolated `RewardWorker` pool while continuing to await asynchronous custom rewards directly.

Closes #180.

## Why

Synchronous custom rewards previously ran in the rollout event loop. CPU-intensive or blocking user code could stall rollout and bypass the existing reward concurrency and worker settings.

## How

- Detect async functions, wrapped async functions, and async callable objects; await them directly without creating workers.
- Lazily create `RewardWorker` actors for synchronous rewards.
- Bound reward requests with `reward_max_concurrency` and size the synchronous pool with `reward_num_workers`.
- Keep each worker serial while allowing executor-level parallelism across workers.
- Preserve single-sample and complete-batch custom reward calls.
- Cache the custom callable once per executor or worker process until an explicit reload.
- Use the shared dispatcher for regular, batched, group, and agentic reward paths.
- Add bounded failure context while preserving the original exception cause.
- On caller cancellation, make a best-effort request to cancel the submitted Ray task without leaking a concurrency slot.
- Document the execution, concurrency, serialization, and cancellation semantics in English and Chinese.

### Concurrency Semantics

For synchronous rewards, effective parallelism is:

```text
min(reward_max_concurrency, reward_num_workers)
```

`reward_max_concurrency > 1` remains supported. Individual `RewardWorker` actors use Ray's default serial execution; parallelism comes from dispatching requests across multiple workers. A complete batched custom reward invocation consumes one concurrency slot.

Async custom rewards continue to execute in the executor and do not create or consume synchronous worker slots.

### Compatibility and Limitations

- No new command-line arguments or dependencies.
- The existing `reward_func(args, sample_or_samples, **kwargs)` interface is unchanged.
- Synchronous arguments and return values must be Ray-serializable.
- Cancelling the caller or its Ray task does not guarantee termination of a Python function already running in a worker. Synchronous custom rewards must set explicit timeouts for potentially blocking external I/O.

## Testing

- [x] `pre-commit run --all-files`
- [x] Targeted tests pass
- [x] GitHub Actions pass (Python 3.10, 3.11, and 3.12)
- [x] New tests added (if applicable)
- [x] Documentation updated (if applicable)

```text
RAY_ADDRESS=local pytest -q \
  tests/engine/rewards/test_custom_reward_worker.py \
  tests/engine/rewards/test_reward_worker.py \
  tests/test_agentic_rollout.py

75 passed, 16 warnings in 107.84s
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Not applicable.