### PR TITLE
feat(rloo): add synchronous training baseline

### DIFF
--- a/examples/algorithms/run-qwen3-0.6B-2xgpu-rloo-grpo.sh
+++ b/examples/algorithms/run-qwen3-0.6B-2xgpu-rloo-grpo.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Matched 2xGPU Qwen3-0.6B GSM8K experiment for synchronous GRPO/RLOO.
+#
+# Usage:
+#   ALGORITHM=grpo NUM_ROLLOUT=10 bash examples/algorithms/run-qwen3-0.6B-2xgpu-rloo-grpo.sh
+#   ALGORITHM=rloo NUM_ROLLOUT=10 bash examples/algorithms/run-qwen3-0.6B-2xgpu-rloo-grpo.sh
+
+set -ex
+set -o pipefail
+
+ALGORITHM="${ALGORITHM:-rloo}"
+if [[ "${ALGORITHM}" != "grpo" && "${ALGORITHM}" != "rloo" ]]; then
+    echo "ALGORITHM must be grpo or rloo, got ${ALGORITHM}" >&2
+    exit 2
+fi
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+RELAX_ROOT="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+VENV_ROOT="${RELAX_ROOT}/.venv"
+export PATH="${VENV_ROOT}/bin:${PATH}"
+export MEGATRON="${MEGATRON:-${VENV_ROOT}/Megatron-LM}"
+export PYTHONPATH="${RELAX_ROOT}:${MEGATRON}:${PYTHONPATH:-}"
+NVIDIA_SITE="${VENV_ROOT}/lib/python3.12/site-packages/nvidia"
+export LD_LIBRARY_PATH="${NVIDIA_SITE}/cudnn/lib:${NVIDIA_SITE}/cu13/lib:${NVIDIA_SITE}/nccl/lib:${NVIDIA_SITE}/nvshmem/lib:${NVIDIA_SITE}/cusparselt/lib:${LD_LIBRARY_PATH:-}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+export NUM_GPUS=2
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-16}"
+export MKL_NUM_THREADS="${MKL_NUM_THREADS:-16}"
+export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-16}"
+
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${RELAX_ROOT}/scripts/entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-0.6B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:-Relax/rloo}"
+EXP_DIR="${EXP_DIR:-${RELAX_ROOT}/output/relax-onboarding}"
+MODEL_DIR="${MODEL_DIR:-${EXP_DIR}}"
+DATA_DIR="${DATA_DIR:-${EXP_DIR}}"
+NUM_ROLLOUT="${NUM_ROLLOUT:-10}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-4}"
+N_SAMPLES="${N_SAMPLES:-4}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-16}"
+MAX_RESPONSE_LEN="${MAX_RESPONSE_LEN:-512}"
+KL_COEF="${KL_COEF:-0.01}"
+SEED="${SEED:-1234}"
+CONTEXT_PARALLEL_SIZE="${CONTEXT_PARALLEL_SIZE:-1}"
+if (( CONTEXT_PARALLEL_SIZE > 1 )); then
+    ATTENTION_BACKEND="${ATTENTION_BACKEND:-local}"
+    QKV_FORMAT="${QKV_FORMAT:-bshd}"
+else
+    ATTENTION_BACKEND="${ATTENTION_BACKEND:-local}"
+    QKV_FORMAT="${QKV_FORMAT:-bshd}"
+fi
+
+CKPT_ARGS=(
+    --hf-checkpoint "${MODEL_DIR}/Qwen3-0.6B"
+    --ref-load "${MODEL_DIR}/Qwen3-0.6B"
+    --megatron-to-hf-mode bridge
+    --warm-hf-checkpoint-page-cache
+)
+
+ROLLOUT_ARGS=(
+    --prompt-data "${DATA_DIR}/gsm8k/train.jsonl"
+    --input-key question
+    --label-key answer
+    --apply-chat-template
+    --rollout-shuffle
+    --rm-type math
+    --num-rollout "${NUM_ROLLOUT}"
+    --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+    --n-samples-per-prompt "${N_SAMPLES}"
+    --rollout-max-response-len "${MAX_RESPONSE_LEN}"
+    --rollout-temperature 1.0
+    --global-batch-size "${GLOBAL_BATCH_SIZE}"
+    --balance-data
+    --use-fault-tolerance
+)
+
+PERF_ARGS=(
+    --tensor-model-parallel-size 1
+    --pipeline-model-parallel-size 1
+    --context-parallel-size "${CONTEXT_PARALLEL_SIZE}"
+    --expert-model-parallel-size 1
+    --expert-tensor-parallel-size 1
+    --qkv-format "${QKV_FORMAT}"
+    --micro-batch-size 1
+)
+if (( CONTEXT_PARALLEL_SIZE > 1 )); then
+    PERF_ARGS+=(--calculate-per-token-loss)
+fi
+
+if [[ "${ALGORITHM}" == "rloo" ]]; then
+    ALGO_ARGS=(
+        --advantage-estimator rloo
+        --kl-coef "${KL_COEF}"
+        --kl-loss-type k1
+        --entropy-coef 0.0
+    )
+else
+    ALGO_ARGS=(
+        --advantage-estimator grpo
+        --use-kl-loss
+        --kl-loss-coef "${KL_COEF}"
+        --kl-loss-type k1
+        --entropy-coef 0.0
+        --eps-clip 0.2
+    )
+fi
+
+OPTIMIZER_ARGS=(
+    --optimizer adam
+    --lr 1e-6
+    --lr-decay-style constant
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.98
+    --optimizer-cpu-offload
+    --optimizer-offload-fraction 1.0
+    --overlap-cpu-optimizer-d2h-h2d
+    --use-precision-aware-optimizer
+)
+
+SGLANG_ARGS=(
+    --rollout-num-gpus-per-engine 1
+    --sglang-mem-fraction-static 0.45
+)
+
+TRACKING_ARGS=(
+    --use-metrics-service
+    --tb-project-name "${PROJECT_NAME}"
+    --tb-experiment-name "qwen3-0.6b-${ALGORITHM}-gsm8k-2x5090-${now}"
+)
+
+MISC_ARGS=(
+    --seed "${SEED}"
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --accumulate-allreduce-grads-in-fp32
+    --attention-softmax-in-fp32
+    --no-gradient-accumulation-fusion
+    --recompute-granularity full
+    --recompute-method uniform
+    --recompute-num-layers 1
+    --spec local
+    --attention-backend "${ATTENTION_BACKEND}"
+)
+if [[ "${ATTENTION_BACKEND}" == "local" ]]; then
+    MISC_ARGS+=(--no-masked-softmax-fusion)
+fi
+
+mkdir -p "${RELAX_ROOT}/log"
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+    ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+    --runtime-env-json="${RUNTIME_ENV_JSON}" \
+    -- python3 -m relax.entrypoints.train \
+    --resource '{"actor": [1, 2], "rollout": [1, 2]}' \
+    --max-staleness 0 \
+    --num-data-storage-units 1 \
+    --num-gpus-per-node 2 \
+    --colocate \
+    --use-health-check \
+    "${MODEL_ARGS[@]}" \
+    "${CKPT_ARGS[@]}" \
+    "${ROLLOUT_ARGS[@]}" \
+    "${OPTIMIZER_ARGS[@]}" \
+    "${ALGO_ARGS[@]}" \
+    "${TRACKING_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
+    "${SGLANG_ARGS[@]}" \
+    "${MISC_ARGS[@]}" 2>&1 | tee "${RELAX_ROOT}/log/qwen3-0.6b-${ALGORITHM}-gsm8k-2x5090-${now}.log"

--- a/relax/backends/megatron/data.py
+++ b/relax/backends/megatron/data.py
@@ -908,6 +908,7 @@ def log_rollout_data(
                 "multimodal_train_inputs",
                 "loss_masks",
                 "sample_indices",
+                "group_indices",
                 "rollout_routed_experts",
                 "max_seq_lens",
                 "dynamic_global_batch_size",

--- a/relax/backends/megatron/data.py
+++ b/relax/backends/megatron/data.py
@@ -958,7 +958,10 @@ def log_rollout_data(
                             # Tensors have mismatched shapes (e.g. variable-length mbs in
                             # streaming mode) — fall back to per-mb mean then average.
                             val = torch.stack([v.float().mean() for v in val])
-                        val = val.mean() * cp_size
+                        # RLOO sequence metrics are already reconstructed and replicated
+                        # on every CP rank; token-sharded auxiliary metrics still need CP scaling.
+                        metric_cp_scale = 1 if key.startswith("rloo_") else cp_size
+                        val = val.mean() * metric_cp_scale
                 else:
                     if not isinstance(val[0], (int, float)):
                         continue

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -26,6 +26,8 @@ from relax.utils.training.ppo_utils import (
     compute_log_probs,
     compute_opsm_mask,
     compute_policy_loss,
+    compute_rloo_baselines_and_advantages,
+    compute_rloo_loss,
     compute_sapo_loss,
     get_advantages_and_returns_batch,
     get_grpo_returns,
@@ -510,13 +512,58 @@ def get_values(
     return torch.empty((0,), device=logits.device), res
 
 
+def _gather_rloo_inputs_across_dp(
+    shaped_rewards: torch.Tensor,
+    group_indices: list[int | None],
+) -> tuple[torch.Tensor, torch.Tensor, slice]:
+    """Gather sequence rewards and group IDs over DP, preserving rank-local order."""
+    for position, group_index in enumerate(group_indices):
+        if group_index is None:
+            raise ValueError(f"Sample.group_index is required for RLOO (missing at sample position {position}).")
+
+    local_group_indices = torch.tensor(group_indices, dtype=torch.int64, device=shaped_rewards.device)
+    dp_size = mpu.get_data_parallel_world_size(with_context_parallel=False)
+    if dp_size == 1:
+        return shaped_rewards, local_group_indices, slice(0, shaped_rewards.numel())
+
+    local_count = shaped_rewards.numel()
+    counts: list[int | None] = [None] * dp_size
+    dist.all_gather_object(
+        counts,
+        local_count,
+        group=mpu.get_data_parallel_group_gloo(with_context_parallel=False),
+    )
+    if any(count is None for count in counts):
+        raise RuntimeError("RLOO failed to gather local DP batch sizes.")
+    gathered_counts = [int(count) for count in counts]
+    max_count = max(gathered_counts)
+
+    padded_rewards = F.pad(shaped_rewards, (0, max_count - local_count))
+    padded_group_indices = F.pad(local_group_indices, (0, max_count - local_count), value=-1)
+    dp_group = mpu.get_data_parallel_group(with_context_parallel=False)
+    gathered_rewards = [torch.empty_like(padded_rewards) for _ in range(dp_size)]
+    gathered_group_indices = [torch.empty_like(padded_group_indices) for _ in range(dp_size)]
+    dist.all_gather(gathered_rewards, padded_rewards, group=dp_group)
+    dist.all_gather(gathered_group_indices, padded_group_indices, group=dp_group)
+
+    global_rewards = torch.cat(
+        [rank_rewards[:count] for rank_rewards, count in zip(gathered_rewards, gathered_counts, strict=True)]
+    )
+    global_group_indices = torch.cat(
+        [rank_groups[:count] for rank_groups, count in zip(gathered_group_indices, gathered_counts, strict=True)]
+    )
+    dp_rank = mpu.get_data_parallel_rank(with_context_parallel=False)
+    local_start = sum(gathered_counts[:dp_rank])
+    return global_rewards, global_group_indices, slice(local_start, local_start + local_count)
+
+
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:
     """Compute advantages and returns in-place based on
     `args.advantage_estimator`.
 
     This function extracts rewards, log-probs, values, and masks from
     `rollout_data`, computes KL divergences, then applies the chosen advantage
-    estimator. Supported methods: "grpo", "gspo", "sapo", "cispo", "ppo", "reinforce_plus_plus",
+    estimator. Supported methods: "grpo", "rloo", "gspo", "sapo", "cispo", "ppo", "reinforce_plus_plus",
     and "reinforce_plus_plus_baseline". When `args.normalize_advantages` is
     True, advantages are whitened across the data-parallel group using masked
     statistics.
@@ -572,6 +619,57 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
         # TODO: is the copy necessary?
         advantages = [r for r in returns]  # noqa: C416
 
+    elif args.advantage_estimator == "rloo":
+        rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
+        group_indices = rollout_data.get("group_indices")
+        if group_indices is None:
+            raise ValueError("RLOO requires group_indices in rollout data.")
+
+        if args.kl_coef != 0:
+            padded_iter = padded_total_lengths if padded_total_lengths is not None else [None] * len(kl)
+            max_seq_iter = max_seq_lens if max_seq_lens is not None else [None] * len(kl)
+            full_kl = [
+                all_gather_with_cp(
+                    k,
+                    total_length,
+                    response_length,
+                    padded_total_length,
+                    qkv_format=args.qkv_format,
+                    max_seq_len=max_seq_len,
+                )
+                for k, total_length, response_length, padded_total_length, max_seq_len in zip(
+                    kl, total_lengths, response_lengths, padded_iter, max_seq_iter, strict=True
+                )
+            ]
+            sequence_kl = torch.stack(
+                [
+                    (sample_kl * mask.to(sample_kl.device)).sum()
+                    for sample_kl, mask in zip(full_kl, loss_masks, strict=True)
+                ]
+            )
+        else:
+            sequence_kl = torch.zeros_like(rewards)
+
+        shaped_rewards = rewards - args.kl_coef * sequence_kl.detach()
+        global_rewards, global_group_indices, local_slice = _gather_rloo_inputs_across_dp(
+            shaped_rewards, group_indices
+        )
+        global_baselines, global_advantages = compute_rloo_baselines_and_advantages(
+            global_rewards,
+            global_group_indices,
+            args.n_samples_per_prompt,
+        )
+        baselines, sequence_advantages = global_baselines[local_slice], global_advantages[local_slice]
+        returns = get_grpo_returns(sequence_advantages, kl)
+        advantages = list(returns)
+        rollout_data["rloo_shaped_reward"] = list(shaped_rewards.split(1))
+        rollout_data["rloo_sequence_kl"] = list(sequence_kl.split(1))
+        rollout_data["rloo_baseline"] = list(baselines.split(1))
+        rollout_data["rloo_advantage"] = list(sequence_advantages.split(1))
+        rollout_data["rloo_advantage_abs"] = list(sequence_advantages.abs().split(1))
+        rollout_data["rloo_empty_response_fraction"] = [
+            (mask.sum() == 0).to(dtype=torch.float32).reshape(1) for mask in loss_masks
+        ]
     elif args.advantage_estimator == "ppo":
         old_rewards = rewards
         rewards = []
@@ -828,7 +926,7 @@ def policy_loss_function(
         old_log_probs = [lp.detach() for lp in log_probs]
 
     # Pre-gather log probs if needed by OPSM or GSPO to avoid duplicate gathering
-    need_full_log_probs = args.use_opsm or args.advantage_estimator == "gspo"
+    need_full_log_probs = args.use_opsm or args.advantage_estimator in ["gspo", "rloo"]
 
     full_log_probs = None
     full_old_log_probs = None
@@ -837,6 +935,7 @@ def policy_loss_function(
             padded_iter = [None] * len(log_probs)
         else:
             padded_iter = padded_total_lengths
+        max_seq_iter = max_seq_lens if max_seq_lens is not None else [None] * len(log_probs)
         # OPSM supports CP: reconstruct each sample's full response from its CP-local
         # zig-zag shards. Under dynamic CP, gather over this mb's dynamic CP sub-group
         # (size/rank/group), not the static CP group. (GSPO does not support CP.)
@@ -853,12 +952,14 @@ def policy_loss_function(
                 total_length,
                 response_length,
                 padded_total_length,
+                qkv_format=args.qkv_format,
+                max_seq_len=max_seq_len,
                 dynamic_cp_size=dynamic_cp_size,
                 dynamic_cp_rank=dynamic_cp_rank,
                 dynamic_cp_group=dynamic_cp_group,
             )
-            for log_prob, total_length, response_length, padded_total_length in zip(
-                log_probs, total_lengths, response_lengths, padded_iter, strict=False
+            for log_prob, total_length, response_length, padded_total_length, max_seq_len in zip(
+                log_probs, total_lengths, response_lengths, padded_iter, max_seq_iter, strict=False
             )
         ]
         full_old_log_probs = [
@@ -867,12 +968,14 @@ def policy_loss_function(
                 total_length,
                 response_length,
                 padded_total_length,
+                qkv_format=args.qkv_format,
+                max_seq_len=max_seq_len,
                 dynamic_cp_size=dynamic_cp_size,
                 dynamic_cp_rank=dynamic_cp_rank,
                 dynamic_cp_group=dynamic_cp_group,
             )
-            for old_log_prob, total_length, response_length, padded_total_length in zip(
-                old_log_probs, total_lengths, response_lengths, padded_iter, strict=False
+            for old_log_prob, total_length, response_length, padded_total_length, max_seq_len in zip(
+                old_log_probs, total_lengths, response_lengths, padded_iter, max_seq_iter, strict=False
             )
         ]
 
@@ -902,7 +1005,19 @@ def policy_loss_function(
         log_probs = torch.cat(log_probs, dim=0)
         ppo_kl = old_log_probs - log_probs
 
-    if args.advantage_estimator == "sapo":
+    if args.advantage_estimator == "rloo":
+        sequence_log_probs = torch.stack(
+            [
+                (sample_log_probs * mask.to(sample_log_probs.device)).sum()
+                for sample_log_probs, mask in zip(full_log_probs, batch["loss_masks"], strict=True)
+            ]
+        )
+        sequence_advantages = torch.cat(batch["rloo_advantage"], dim=0).to(sequence_log_probs.device)
+        sequence_pg_loss = compute_rloo_loss(sequence_log_probs, sequence_advantages).sum()
+        rloo_cp_rank = batch.get("dynamic_cp_rank", mpu.get_context_parallel_rank())
+        pg_loss = sequence_pg_loss if rloo_cp_rank == 0 else 0.0 * sequence_pg_loss
+        pg_clipfrac = torch.zeros_like(pg_loss)
+    elif args.advantage_estimator == "sapo":
         tau_pos = getattr(args, "sapo_tau_pos", 1.0)
         tau_neg = getattr(args, "sapo_tau_neg", 1.05)
         pg_loss, pg_clipfrac = compute_sapo_loss(
@@ -984,8 +1099,9 @@ def policy_loss_function(
     else:
         pg_loss_reducer = sum_of_sample_mean
 
-    pg_loss = pg_loss_reducer(pg_loss)
-    pg_clipfrac = sum_of_sample_mean(pg_clipfrac)
+    if args.advantage_estimator != "rloo":
+        pg_loss = pg_loss_reducer(pg_loss)
+        pg_clipfrac = sum_of_sample_mean(pg_clipfrac)
     ppo_kl = sum_of_sample_mean(ppo_kl)
 
     # entropy loss
@@ -1033,9 +1149,13 @@ def policy_loss_function(
             (torch.exp(old_log_probs) - torch.exp(rollout_log_probs)).abs()
         )
 
+    rloo_metric_scale = 1
+    if args.advantage_estimator == "rloo" and rloo_cp_rank == 0:
+        rloo_metric_scale = batch.get("dynamic_cp_size", mpu.get_context_parallel_world_size())
+
     reported_loss = {
-        "loss": loss.clone().detach(),
-        "pg_loss": pg_loss.clone().detach(),
+        "loss": loss.clone().detach() * rloo_metric_scale,
+        "pg_loss": pg_loss.clone().detach() * rloo_metric_scale,
         "entropy_loss": entropy_loss.clone().detach(),
         "pg_clipfrac": pg_clipfrac.clone().detach(),
         "ppo_kl": ppo_kl.clone().detach(),
@@ -1277,12 +1397,14 @@ def loss_function(
         dynamic_cp_rank=batch.get("dynamic_cp_rank", None),
     )
     num_samples = len(batch["response_lengths"])
+    sequence_level_rloo = args.advantage_estimator == "rloo"
+    use_token_normalization = args.calculate_per_token_loss and not sequence_level_rloo
 
     sum_of_sample_mean = get_sum_of_sample_mean(
         batch["total_lengths"],
         batch["response_lengths"],
         batch["loss_masks"],
-        args.calculate_per_token_loss,
+        use_token_normalization,
         args.qkv_format,
         batch.get("max_seq_lens", None),
         batch.get("padded_total_lengths", None),
@@ -1339,7 +1461,7 @@ def loss_function(
     # scaling); the per-token branch does NO CP scaling (normalization is the
     # all-reduced CP-local token count in finalize_model_grads).
     global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
-    if not args.calculate_per_token_loss:
+    if not use_token_normalization:
         if is_dummy:
             # Zero-out gradient contribution but keep the autograd graph
             # connected so PP/CP backward collectives still complete.
@@ -1366,7 +1488,7 @@ def loss_function(
     effective_num_tokens = torch.zeros_like(num_tokens) if is_dummy else num_tokens
     log_values = torch.tensor(
         [
-            num_samples if not args.calculate_per_token_loss else effective_num_tokens,
+            num_samples if not use_token_normalization else effective_num_tokens,
         ]
         + list(log.values()),
         device=logits.device,
@@ -1377,7 +1499,7 @@ def loss_function(
 
     return (
         loss,
-        (effective_num_tokens if args.calculate_per_token_loss else torch.tensor(1, device=logits.device)),
+        (effective_num_tokens if use_token_normalization else torch.tensor(1, device=logits.device)),
         {
             "keys": list(log.keys()),
             "values": log_values,

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -516,7 +516,8 @@ def _gather_rloo_inputs_across_dp(
     shaped_rewards: torch.Tensor,
     group_indices: list[int | None],
 ) -> tuple[torch.Tensor, torch.Tensor, slice]:
-    """Gather sequence rewards and group IDs over DP, preserving rank-local order."""
+    """Gather sequence rewards and group IDs over DP, preserving rank-local
+    order."""
     for position, group_index in enumerate(group_indices):
         if group_index is None:
             raise ValueError(f"Sample.group_index is required for RLOO (missing at sample position {position}).")

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -21,6 +21,7 @@ from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron.core.transformer.enums import AttnBackend
 from megatron.core.utils import get_model_config, unwrap_model
 from megatron.training.global_vars import get_args
 from megatron.training.training import get_model
@@ -181,6 +182,43 @@ def _main_loss_has_tokens(batch: dict) -> bool:
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         torch.distributed.all_reduce(num_tokens, group=mpu.get_data_parallel_group(with_context_parallel=True))
     return bool(num_tokens.item() > 0)
+
+
+def _get_rloo_native_cp_attention_mask(args: Namespace, batch: dict) -> torch.Tensor | None:
+    """Build the zig-zag query rows required by Megatron's native CP attention."""
+    cp_size = mpu.get_context_parallel_world_size()
+    if (
+        args.advantage_estimator != "rloo"
+        or cp_size == 1
+        or args.qkv_format != "bshd"
+        or args.attention_backend != AttnBackend.local
+    ):
+        return None
+
+    tokens = batch["tokens"]
+    local_sequence_length = tokens.shape[1]
+    if local_sequence_length % 2 != 0:
+        raise ValueError(
+            f"RLOO native context parallelism requires an even local sequence length, got {local_sequence_length}."
+        )
+
+    chunk_size = local_sequence_length // 2
+    global_sequence_length = local_sequence_length * cp_size
+    cp_rank = mpu.get_context_parallel_rank()
+    first = slice(cp_rank * chunk_size, (cp_rank + 1) * chunk_size)
+    second_chunk = 2 * cp_size - cp_rank - 1
+    second = slice(second_chunk * chunk_size, (second_chunk + 1) * chunk_size)
+    full_mask = torch.triu(
+        torch.ones(
+            (global_sequence_length, global_sequence_length),
+            dtype=torch.bool,
+            device=tokens.device,
+        ),
+        diagonal=1,
+    )
+    return torch.cat([full_mask[first], full_mask[second]], dim=0).reshape(
+        1, 1, local_sequence_length, global_sequence_length
+    )
 
 
 def get_optimizer_param_scheduler(args: Namespace, optimizer: MegatronOptimizer) -> OptimizerParamScheduler:
@@ -759,7 +797,7 @@ def forward_only(
             forward_packed_seq_params = batch["vlm_packed_seq_params"]
             forward_loss_mask = None
         else:
-            forward_attention_mask = None
+            forward_attention_mask = _get_rloo_native_cp_attention_mask(args, batch)
             forward_loss_mask = batch["full_loss_masks"]
 
         # Dynamic CP: the VL bridge (Qwen3VLModel.forward) reads pg_collection.cp
@@ -983,6 +1021,7 @@ def train_one_step(
                     "advantages",
                     "returns",
                     "rollout_log_probs",
+                    "rloo_advantage",
                     "max_seq_lens",
                     *_opd_keys,
                 ],
@@ -1024,7 +1063,7 @@ def train_one_step(
             forward_kwargs = {
                 "input_ids": batch["unsplit_tokens"] if use_unsplit else batch["tokens"],
                 "position_ids": None,
-                "attention_mask": None,
+                "attention_mask": _get_rloo_native_cp_attention_mask(args, batch),
                 "labels": None,
                 "packed_seq_params": None if use_unsplit else batch["packed_seq_params"],
                 "loss_mask": batch["full_loss_masks"],
@@ -1253,6 +1292,9 @@ def train(
     config = get_model_config(model[0])
     config.grad_scale_func = optimizer.scale_loss
     config.timers = None
+    if args.advantage_estimator == "rloo":
+        # Bridge requires the CLI flag for CP, but RLOO gradients normalize by sequences.
+        config.calculate_per_token_loss = False
     # train() is invoked once per rollout in Relax (vs. once per run upstream),
     # so guard the sync-func setup to be idempotent — re-assigning would trip
     # Megatron's "no_sync_func must be None" assert on rollout 1+.

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -185,7 +185,8 @@ def _main_loss_has_tokens(batch: dict) -> bool:
 
 
 def _get_rloo_native_cp_attention_mask(args: Namespace, batch: dict) -> torch.Tensor | None:
-    """Build the zig-zag query rows required by Megatron's native CP attention."""
+    """Build the zig-zag query rows required by Megatron's native CP
+    attention."""
     cp_size = mpu.get_context_parallel_world_size()
     if (
         args.advantage_estimator != "rloo"

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -206,18 +206,16 @@ def _get_rloo_native_cp_attention_mask(args: Namespace, batch: dict) -> torch.Te
     chunk_size = local_sequence_length // 2
     global_sequence_length = local_sequence_length * cp_size
     cp_rank = mpu.get_context_parallel_rank()
-    first = slice(cp_rank * chunk_size, (cp_rank + 1) * chunk_size)
-    second_chunk = 2 * cp_size - cp_rank - 1
-    second = slice(second_chunk * chunk_size, (second_chunk + 1) * chunk_size)
-    full_mask = torch.triu(
-        torch.ones(
-            (global_sequence_length, global_sequence_length),
-            dtype=torch.bool,
-            device=tokens.device,
-        ),
-        diagonal=1,
+    first_start = cp_rank * chunk_size
+    second_start = (2 * cp_size - cp_rank - 1) * chunk_size
+    query_positions = torch.cat(
+        [
+            torch.arange(first_start, first_start + chunk_size, device=tokens.device),
+            torch.arange(second_start, second_start + chunk_size, device=tokens.device),
+        ]
     )
-    return torch.cat([full_mask[first], full_mask[second]], dim=0).reshape(
+    key_positions = torch.arange(global_sequence_length, device=tokens.device)
+    return (key_positions.unsqueeze(0) > query_positions.unsqueeze(1)).reshape(
         1, 1, local_sequence_length, global_sequence_length
     )
 

--- a/relax/core/registry.py
+++ b/relax/core/registry.py
@@ -81,6 +81,13 @@ class ROLES_PPO_FULLY_ASYNC_ON_POLICY(StrEnum):
 
 
 ALGOS = {
+    "rloo": {
+        ROLES.rollout: Rollout,
+        ROLES.actor: Actor,
+        ROLES.advantages: Advantages,
+        ROLES.reference: ActorFwd,
+        ROLES.actor_fwd: ActorFwd,
+    },
     "grpo": {
         ROLES.rollout: Rollout,
         ROLES.actor: Actor,

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -1566,6 +1566,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 choices=[
                     "grpo",
+                    "rloo",
                     "gspo",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
@@ -2743,6 +2744,33 @@ def slime_validate_args(args):
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 
     if not is_sft:
+        if args.advantage_estimator == "rloo":
+            if args.fully_async or args.hybrid:
+                raise ValueError("RLOO currently supports synchronous colocate training only.")
+            if args.n_samples_per_prompt < 2:
+                raise ValueError(f"RLOO requires --n-samples-per-prompt >= 2, got {args.n_samples_per_prompt}.")
+            if args.normalize_advantages:
+                raise ValueError("RLOO uses its leave-one-out advantage directly; remove --normalize-advantages.")
+            if args.use_kl_loss:
+                raise ValueError(
+                    "RLOO applies KL through sequence reward shaping; use --kl-coef instead of --use-kl-loss."
+                )
+            if args.kl_coef != 0 and args.kl_loss_type != "k1":
+                raise ValueError("RLOO reward shaping requires --kl-loss-type k1.")
+            if args.custom_reward_post_process_path is not None:
+                raise ValueError("RLOO does not support --custom-reward-post-process-path.")
+            if getattr(args, "agentic_custom_advantage_path", None) is not None:
+                raise ValueError("RLOO does not support --agentic-custom-advantage-path.")
+            if args.use_tis or args.get_mismatch_metrics or args.use_opsm:
+                raise ValueError("RLOO does not yet support TIS, mismatch metrics, or OPSM.")
+            if args.use_opd:
+                raise ValueError("RLOO with on-policy distillation is not supported in the synchronous baseline.")
+            if args.entropy_coef != 0:
+                raise ValueError("RLOO sequence loss currently requires --entropy-coef 0.")
+            if getattr(args, "dynamic_context_parallel", False):
+                raise ValueError("RLOO currently supports static context parallelism only.")
+            if getattr(args, "custom_pg_loss_reducer_function_path", None) is not None:
+                raise ValueError("RLOO does not support a custom policy-loss reducer.")
         if args.advantage_estimator in ["reinforce_plus_plus", "reinforce_plus_plus_baseline"]:
             assert args.normalize_advantages, (
                 "The 'reinforce_plus_plus' and 'reinforce_plus_plus_baseline' advantage estimators "

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -2747,6 +2747,11 @@ def slime_validate_args(args):
         if args.advantage_estimator == "rloo":
             if args.fully_async or args.hybrid:
                 raise ValueError("RLOO currently supports synchronous colocate training only.")
+            if getattr(args, "partial_rollout", False):
+                raise ValueError(
+                    "RLOO does not support partial rollout because recycled prefixes are off-policy; "
+                    "disable --partial-rollout."
+                )
             if args.n_samples_per_prompt < 2:
                 raise ValueError(f"RLOO requires --n-samples-per-prompt >= 2, got {args.n_samples_per_prompt}.")
             if args.normalize_advantages:
@@ -3082,6 +3087,15 @@ def slime_validate_args(args):
                 f"// num_steps_per_rollout {args.num_steps_per_rollout}"
             )
         args.global_batch_size = global_batch_size
+
+    if (
+        args.advantage_estimator == "rloo"
+        and args.global_batch_size != args.rollout_batch_size * args.n_samples_per_prompt
+    ):
+        raise ValueError(
+            "RLOO requires exactly one optimizer update per rollout; set --global-batch-size equal to "
+            "--rollout-batch-size * --n-samples-per-prompt and remove multi-step rollout settings."
+        )
 
     if args.n_samples_per_prompt == 1:
         args.grpo_std_normalization = False

--- a/relax/utils/training/data_fields.py
+++ b/relax/utils/training/data_fields.py
@@ -13,6 +13,8 @@ def _base_rollout_fields(args: Namespace) -> list[str]:
         "rewards",
         "raw_reward",
     ]
+    if getattr(args, "advantage_estimator", None) == "rloo":
+        fields.append("group_indices")
     if getattr(args, "use_rollout_routing_replay", False):
         fields.append("rollout_routed_experts")
     if getattr(args, "multimodal_keys", None) is not None:

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -17,6 +17,64 @@ from relax.utils.logging_utils import get_logger
 logger = get_logger(__name__)
 
 
+def compute_rloo_baselines_and_advantages(
+    rewards: torch.Tensor,
+    group_indices: list[int | None] | torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-prompt leave-one-out baselines in sample order."""
+    if group_size < 2:
+        raise ValueError(f"RLOO requires group_size >= 2, got {group_size}.")
+    if rewards.ndim != 1:
+        raise ValueError(f"RLOO rewards must be one-dimensional, got shape {tuple(rewards.shape)}.")
+    if len(group_indices) != rewards.numel():
+        raise ValueError(
+            f"RLOO rewards/group_indices length mismatch: {rewards.numel()} rewards vs {len(group_indices)} groups."
+        )
+
+    invalid_positions = torch.nonzero(~torch.isfinite(rewards), as_tuple=False).flatten()
+    if invalid_positions.numel() > 0:
+        positions = invalid_positions.tolist()
+        raise ValueError(f"RLOO rewards must be finite; invalid sample positions: {positions}.")
+
+    if not isinstance(group_indices, torch.Tensor):
+        for position, group_index in enumerate(group_indices):
+            if group_index is None:
+                raise ValueError(f"Sample.group_index is required for RLOO (missing at sample position {position}).")
+        group_indices = torch.tensor(group_indices, dtype=torch.int64, device=rewards.device)
+    else:
+        if group_indices.ndim != 1:
+            raise ValueError(f"RLOO group_indices must be one-dimensional, got shape {tuple(group_indices.shape)}.")
+        group_indices = group_indices.to(device=rewards.device, dtype=torch.int64)
+
+    unique_groups, inverse_indices, group_counts = torch.unique(
+        group_indices,
+        sorted=False,
+        return_inverse=True,
+        return_counts=True,
+    )
+    invalid_groups = torch.nonzero(group_counts != group_size, as_tuple=False).flatten()
+    if invalid_groups.numel() > 0:
+        invalid_group = invalid_groups[0]
+        raise ValueError(
+            f"RLOO reward group {unique_groups[invalid_group].item()} has "
+            f"{group_counts[invalid_group].item()} samples, expected {group_size}."
+        )
+
+    group_sums = torch.zeros(unique_groups.numel(), dtype=rewards.dtype, device=rewards.device)
+    group_sums.scatter_add_(0, inverse_indices, rewards)
+    baselines = (group_sums[inverse_indices] - rewards) / (group_size - 1)
+    advantages = rewards - baselines
+
+    return baselines, advantages
+
+
+@torch.compile(dynamic=True)
+def compute_rloo_loss(sequence_log_probs: torch.Tensor, advantages: torch.Tensor) -> torch.Tensor:
+    """Return the per-sequence REINFORCE loss."""
+    return -(advantages.detach() * sequence_log_probs)
+
+
 def validate_ppo_config(config: Namespace) -> None:
     if getattr(config, "advantage_estimator", None) != "ppo":
         return

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -14,6 +14,7 @@ from tensordict import TensorDict
 from relax.utils.device import get_ray_accelerator_name
 from relax.utils.logging_utils import get_logger
 from relax.utils.misc import load_function
+from relax.utils.training.ppo_utils import compute_rloo_baselines_and_advantages
 from relax.utils.types import Sample
 
 
@@ -109,6 +110,9 @@ def convert_samples_to_train_data(args: Any, samples: list[Sample] | list[list[S
         "sample_indices": [sample.index for sample in samples],
     }
 
+    if args.advantage_estimator == "rloo":
+        train_data["group_indices"] = [sample.group_index for sample in samples]
+
     # loss mask
     # TODO: compress the loss mask
     loss_masks = []
@@ -178,6 +182,14 @@ def post_process_rewards(args: Any, samples: list[Sample] | list[list[Sample]]):
         return custom_reward_post_process_func(args, samples)
 
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
+    if args.advantage_estimator == "rloo":
+        rewards = torch.tensor(raw_rewards, dtype=torch.float32)
+        compute_rloo_baselines_and_advantages(
+            rewards,
+            [sample.group_index for sample in samples],
+            args.n_samples_per_prompt,
+        )
+        return raw_rewards, raw_rewards
     if getattr(args, "agentic_custom_advantage_path", None) is not None:
         return raw_rewards, [sample.custom_advantage for sample in samples]
     if (

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -439,11 +439,12 @@ def get_debug_data(args, rollout_id: int, batch_size, dp_rank: int) -> Dict[str,
     data = [Sample.from_dict(sample) for sample in data]
     if (ratio := args.load_debug_rollout_data_subsample) is not None:
         original_num_rows = len(data)
-        if (
+        group_aware_subsampling = args.advantage_estimator == "rloo" or (
             args.custom_reward_post_process_path is None
             and args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "reinforce_plus_plus_baseline"]
             and args.rewards_normalization
-        ):
+        )
+        if group_aware_subsampling:
             group_ids = list(dict.fromkeys(sample.group_index for sample in data))
             if None in group_ids:
                 raise ValueError("Sample.group_index is required for group-aware debug subsampling.")

--- a/tests/backends/megatron/test_data_rloo_metrics.py
+++ b/tests/backends/megatron/test_data_rloo_metrics.py
@@ -44,6 +44,7 @@ def test_log_rollout_data_keeps_rloo_sequence_metrics_cp_invariant(monkeypatch):
         "rloo_advantage": [torch.tensor([-1.0]), torch.tensor([1.0])],
         "rloo_advantage_abs": [torch.tensor([1.0]), torch.tensor([1.0])],
         "rloo_empty_response_fraction": [torch.tensor([0.0]), torch.tensor([1.0])],
+        "group_indices": [7, 9],
         "custom_tensor_metric": [torch.tensor([1.0]), torch.tensor([3.0])],
     }
 
@@ -55,4 +56,5 @@ def test_log_rollout_data_keeps_rloo_sequence_metrics_cp_invariant(monkeypatch):
     assert captured["rloo_advantage"] == 0.0
     assert captured["rloo_advantage_abs"] == 1.0
     assert captured["rloo_empty_response_fraction"] == 0.5
+    assert "group_indices" not in captured
     assert captured["custom_tensor_metric"] == 4.0

--- a/tests/backends/megatron/test_data_rloo_metrics.py
+++ b/tests/backends/megatron/test_data_rloo_metrics.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from argparse import Namespace
+
+import pytest
+import torch
+
+from relax.backends.megatron import data
+
+
+def test_log_rollout_data_keeps_rloo_sequence_metrics_cp_invariant(monkeypatch):
+    monkeypatch.setattr(data.mpu, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(data.mpu, "is_pipeline_last_stage", lambda: True)
+    monkeypatch.setattr(data.mpu, "get_context_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(data.mpu, "get_data_parallel_group", lambda with_context_parallel=True: None)
+    monkeypatch.setattr(data.dist, "all_reduce", lambda tensor, op, group: None)
+    captured = {}
+
+    def fake_gather_log_data(metric_name, args, rollout_id, log_dict):
+        captured.update(log_dict)
+        return {f"{metric_name}/{key}": value for key, value in log_dict.items()}
+
+    monkeypatch.setattr(data, "gather_log_data", fake_gather_log_data)
+    args = Namespace(
+        dynamic_context_parallel=False,
+        qkv_format="bshd",
+        is_vl_model=False,
+        uses_unsplit_forward=False,
+        use_opd=False,
+        ci_test=False,
+        log_multi_turn=False,
+        log_correct_samples=False,
+    )
+    rollout_data = {
+        "response_lengths": [2, 2],
+        "loss_masks": [torch.ones(2), torch.ones(2)],
+        "total_lengths": [4, 4],
+        "rloo_shaped_reward": [torch.tensor([1.0]), torch.tensor([3.0])],
+        "rloo_sequence_kl": [torch.tensor([0.1]), torch.tensor([0.3])],
+        "rloo_baseline": [torch.tensor([0.5]), torch.tensor([1.5])],
+        "rloo_advantage": [torch.tensor([-1.0]), torch.tensor([1.0])],
+        "rloo_advantage_abs": [torch.tensor([1.0]), torch.tensor([1.0])],
+        "rloo_empty_response_fraction": [torch.tensor([0.0]), torch.tensor([1.0])],
+        "custom_tensor_metric": [torch.tensor([1.0]), torch.tensor([3.0])],
+    }
+
+    data.log_rollout_data(0, args, rollout_data)
+
+    assert captured["rloo_shaped_reward"] == 2.0
+    assert captured["rloo_sequence_kl"] == pytest.approx(0.2)
+    assert captured["rloo_baseline"] == 1.0
+    assert captured["rloo_advantage"] == 0.0
+    assert captured["rloo_advantage_abs"] == 1.0
+    assert captured["rloo_empty_response_fraction"] == 0.5
+    assert captured["custom_tensor_metric"] == 4.0

--- a/tests/backends/megatron/test_data_rloo_metrics.py
+++ b/tests/backends/megatron/test_data_rloo_metrics.py
@@ -5,7 +5,10 @@ from argparse import Namespace
 import pytest
 import torch
 
-from relax.backends.megatron import data
+
+pytest.importorskip("megatron.core")
+
+from relax.backends.megatron import data  # noqa: E402
 
 
 def test_log_rollout_data_keeps_rloo_sequence_metrics_cp_invariant(monkeypatch):

--- a/tests/backends/megatron/test_loss_rloo.py
+++ b/tests/backends/megatron/test_loss_rloo.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from argparse import Namespace
+
+import torch
+
+from relax.backends.megatron import loss
+
+
+def test_compute_rloo_advantages_applies_sequence_kl_before_leave_one_out(monkeypatch):
+    monkeypatch.setattr(loss.mpu, "is_pipeline_last_stage", lambda: True)
+    monkeypatch.setattr(loss.mpu, "get_data_parallel_world_size", lambda with_context_parallel=False: 1)
+    monkeypatch.setattr(loss.mpu, "get_context_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(loss.mpu, "get_context_parallel_group", lambda: None)
+    monkeypatch.setattr(
+        loss,
+        "compute_approx_kl",
+        lambda log_probs, ref_log_probs, kl_loss_type: log_probs - ref_log_probs,
+    )
+    gather_calls = []
+
+    def fake_all_gather(
+        tensor,
+        total_length,
+        response_length,
+        padded_total_length=None,
+        qkv_format="thd",
+        max_seq_len=None,
+        **kwargs,
+    ):
+        gather_calls.append((qkv_format, max_seq_len))
+        return tensor
+
+    monkeypatch.setattr(loss, "all_gather_with_cp", fake_all_gather)
+
+    args = Namespace(
+        advantage_estimator="rloo",
+        use_rollout_logprobs=False,
+        kl_coef=0.5,
+        kl_loss_type="k1",
+        qkv_format="bshd",
+        is_vl_model=False,
+        uses_unsplit_forward=False,
+        n_samples_per_prompt=2,
+        normalize_advantages=False,
+        use_opd=False,
+    )
+    rollout_data = {
+        "log_probs": [torch.tensor([-0.2, -0.4]), torch.tensor([-0.5])],
+        "ref_log_probs": [torch.tensor([-0.3, -0.1]), torch.tensor([-0.7])],
+        "rewards": [1.0, 0.0],
+        "values": None,
+        "response_lengths": [2, 1],
+        "loss_masks": [torch.tensor([1.0, 0.0]), torch.tensor([1.0])],
+        "total_lengths": [4, 3],
+        "max_seq_lens": [8, 8],
+        "group_indices": [7, 7],
+    }
+
+    loss.compute_advantages_and_returns(args, rollout_data)
+    assert gather_calls == [("bshd", 8), ("bshd", 8)]
+
+    expected_kl = torch.tensor([0.1, 0.2])
+    expected_shaped_rewards = torch.tensor([0.95, -0.1])
+    expected_baselines = torch.tensor([-0.1, 0.95])
+    expected_advantages = torch.tensor([1.05, -1.05])
+
+    assert torch.allclose(torch.cat(rollout_data["rloo_sequence_kl"]), expected_kl, atol=1e-6)
+    assert torch.allclose(torch.cat(rollout_data["rloo_shaped_reward"]), expected_shaped_rewards, atol=1e-6)
+    assert torch.allclose(torch.cat(rollout_data["rloo_baseline"]), expected_baselines, atol=1e-6)
+    assert torch.allclose(torch.cat(rollout_data["rloo_advantage"]), expected_advantages, atol=1e-6)
+    assert torch.allclose(rollout_data["advantages"][0], torch.full((2,), 1.05), atol=1e-6)
+    assert torch.allclose(rollout_data["advantages"][1], torch.full((1,), -1.05), atol=1e-6)
+
+
+def test_compute_rloo_advantages_keeps_empty_response_in_baseline(monkeypatch):
+    monkeypatch.setattr(loss.mpu, "is_pipeline_last_stage", lambda: True)
+    monkeypatch.setattr(loss.mpu, "get_data_parallel_world_size", lambda with_context_parallel=False: 1)
+
+    args = Namespace(
+        advantage_estimator="rloo",
+        use_rollout_logprobs=True,
+        kl_coef=0.0,
+        kl_loss_type="k1",
+        qkv_format="thd",
+        is_vl_model=False,
+        uses_unsplit_forward=False,
+        n_samples_per_prompt=2,
+        normalize_advantages=False,
+        use_opd=False,
+    )
+    rollout_data = {
+        "rollout_log_probs": [torch.tensor([]), torch.tensor([-0.5])],
+        "ref_log_probs": None,
+        "rewards": [1.0, 0.0],
+        "values": None,
+        "response_lengths": [0, 1],
+        "loss_masks": [torch.tensor([]), torch.tensor([1.0])],
+        "total_lengths": [2, 3],
+        "group_indices": [3, 3],
+    }
+
+    loss.compute_advantages_and_returns(args, rollout_data)
+
+    assert rollout_data["advantages"][0].numel() == 0
+    assert torch.allclose(rollout_data["advantages"][1], torch.tensor([-1.0]))
+    assert torch.equal(torch.cat(rollout_data["rloo_empty_response_fraction"]), torch.tensor([1.0, 0.0]))

--- a/tests/backends/megatron/test_loss_rloo.py
+++ b/tests/backends/megatron/test_loss_rloo.py
@@ -2,9 +2,13 @@
 
 from argparse import Namespace
 
+import pytest
 import torch
 
-from relax.backends.megatron import loss
+
+pytest.importorskip("megatron.core")
+
+from relax.backends.megatron import loss  # noqa: E402
 
 
 def test_compute_rloo_advantages_applies_sequence_kl_before_leave_one_out(monkeypatch):

--- a/tests/backends/megatron/test_model_rloo_cp.py
+++ b/tests/backends/megatron/test_model_rloo_cp.py
@@ -4,9 +4,13 @@ from argparse import Namespace
 
 import pytest
 import torch
-from megatron.core.transformer.enums import AttnBackend
 
-from relax.backends.megatron import model
+
+pytest.importorskip("megatron.core")
+
+from megatron.core.transformer.enums import AttnBackend  # noqa: E402
+
+from relax.backends.megatron import model  # noqa: E402
 
 
 @pytest.mark.parametrize(

--- a/tests/backends/megatron/test_model_rloo_cp.py
+++ b/tests/backends/megatron/test_model_rloo_cp.py
@@ -30,10 +30,14 @@ def test_rloo_native_cp_attention_mask_selects_zigzag_query_rows(monkeypatch, cp
     )
     batch = {"tokens": torch.zeros((1, 4), dtype=torch.long)}
 
+    monkeypatch.setattr(model.torch, "triu", lambda *_args, **_kwargs: pytest.fail("global mask allocated"))
     actual = model._get_rloo_native_cp_attention_mask(args, batch)
 
-    full_mask = torch.triu(torch.ones((8, 8), dtype=torch.bool), diagonal=1)
-    expected = full_mask[expected_rows].reshape(1, 1, 4, 8)
+    query_positions = torch.tensor(expected_rows)
+    key_positions = torch.arange(8)
+    expected = (key_positions.unsqueeze(0) > query_positions.unsqueeze(1)).reshape(1, 1, 4, 8)
+    assert actual.shape == (1, 1, 4, 8)
+    assert actual.numel() == 4 * 8
     assert torch.equal(actual, expected)
 
 

--- a/tests/backends/megatron/test_model_rloo_cp.py
+++ b/tests/backends/megatron/test_model_rloo_cp.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from argparse import Namespace
+
+import pytest
+import torch
+from megatron.core.transformer.enums import AttnBackend
+
+from relax.backends.megatron import model
+
+
+@pytest.mark.parametrize(
+    ("cp_rank", "expected_rows"),
+    [
+        (0, [0, 1, 6, 7]),
+        (1, [2, 3, 4, 5]),
+    ],
+)
+def test_rloo_native_cp_attention_mask_selects_zigzag_query_rows(monkeypatch, cp_rank, expected_rows):
+    monkeypatch.setattr(model.mpu, "get_context_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(model.mpu, "get_context_parallel_rank", lambda: cp_rank)
+    args = Namespace(
+        advantage_estimator="rloo",
+        qkv_format="bshd",
+        attention_backend=AttnBackend.local,
+    )
+    batch = {"tokens": torch.zeros((1, 4), dtype=torch.long)}
+
+    actual = model._get_rloo_native_cp_attention_mask(args, batch)
+
+    full_mask = torch.triu(torch.ones((8, 8), dtype=torch.bool), diagonal=1)
+    expected = full_mask[expected_rows].reshape(1, 1, 4, 8)
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("advantage_estimator", "cp_size", "qkv_format", "attention_backend"),
+    [
+        ("grpo", 2, "bshd", AttnBackend.local),
+        ("rloo", 1, "bshd", AttnBackend.local),
+        ("rloo", 2, "thd", AttnBackend.local),
+        ("rloo", 2, "bshd", AttnBackend.flash),
+    ],
+)
+def test_rloo_native_cp_attention_mask_leaves_other_paths_unchanged(
+    monkeypatch,
+    advantage_estimator,
+    cp_size,
+    qkv_format,
+    attention_backend,
+):
+    monkeypatch.setattr(model.mpu, "get_context_parallel_world_size", lambda: cp_size)
+    args = Namespace(
+        advantage_estimator=advantage_estimator,
+        qkv_format=qkv_format,
+        attention_backend=attention_backend,
+    )
+
+    assert model._get_rloo_native_cp_attention_mask(args, {"tokens": torch.zeros((1, 4))}) is None
+
+
+def test_rloo_native_cp_attention_mask_rejects_odd_local_sequence(monkeypatch):
+    monkeypatch.setattr(model.mpu, "get_context_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(model.mpu, "get_context_parallel_rank", lambda: 0)
+    args = Namespace(
+        advantage_estimator="rloo",
+        qkv_format="bshd",
+        attention_backend=AttnBackend.local,
+    )
+
+    with pytest.raises(ValueError, match="even local sequence length"):
+        model._get_rloo_native_cp_attention_mask(args, {"tokens": torch.zeros((1, 3))})

--- a/tests/core/test_registry_rloo.py
+++ b/tests/core/test_registry_rloo.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Unit tests for synchronous RLOO registry entries."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+pytest.importorskip("megatron.core")
+
+from relax.core.registry import ALGOS, ROLES_COLOCATE, process_role  # noqa: E402
+
+
+def test_rloo_registry_matches_grpo_role_topology():
+    assert "rloo" in ALGOS
+    assert ALGOS["rloo"] == ALGOS["grpo"]
+
+
+def test_rloo_sync_process_role_uses_colocate_path():
+    config = SimpleNamespace(
+        debug_rollout_only=False,
+        debug_train_only=False,
+        fully_async=False,
+        hybrid=False,
+        loss_type="policy_loss",
+        advantage_estimator="rloo",
+    )
+
+    assert process_role(config) is ROLES_COLOCATE
+
+
+def test_default_grpo_registry_entry_remains_available():
+    assert "grpo" in ALGOS

--- a/tests/utils/test_arguments_opd_teacher_colocate.py
+++ b/tests/utils/test_arguments_opd_teacher_colocate.py
@@ -194,3 +194,52 @@ def test_arguments_dynamic_context_parallel_rejects_sft_eval(arguments_module):
 
     with pytest.raises(ValueError, match="this combination can hang and has not been fixed"):
         arguments_module.slime_validate_args(args)
+
+
+def _rloo_args() -> SimpleNamespace:
+    args = _opd_args()
+    args.advantage_estimator = "rloo"
+    args.use_opd = False
+    args.custom_reward_post_process_path = None
+    args.use_opsm = False
+    args.entropy_coef = 0.0
+    args.kl_loss_type = "k1"
+    args.num_steps_per_rollout = None
+    args.rewards_normalization = False
+    args.mask_offpolicy_in_partial_rollout = False
+    return args
+
+
+@pytest.mark.parametrize(
+    ("global_batch_size", "num_steps_per_rollout"),
+    [
+        (16, None),
+        (16, 2),
+    ],
+)
+def test_rloo_rejects_multiple_optimizer_updates_per_rollout(
+    arguments_module, global_batch_size, num_steps_per_rollout
+):
+    args = _rloo_args()
+    args.global_batch_size = global_batch_size
+    args.num_steps_per_rollout = num_steps_per_rollout
+
+    with pytest.raises(ValueError, match="exactly one optimizer update per rollout"):
+        arguments_module.slime_validate_args(args)
+
+
+def test_rloo_rejects_partial_rollout_even_with_offpolicy_prefix_mask(arguments_module):
+    args = _rloo_args()
+    args.partial_rollout = True
+    args.mask_offpolicy_in_partial_rollout = True
+
+    with pytest.raises(ValueError, match="does not support partial rollout"):
+        arguments_module.slime_validate_args(args)
+
+
+def test_rloo_accepts_one_full_grouped_batch_per_rollout(arguments_module):
+    args = _rloo_args()
+
+    arguments_module.slime_validate_args(args)
+
+    assert args.global_batch_size == args.rollout_batch_size * args.n_samples_per_prompt

--- a/tests/utils/test_utils_rloo.py
+++ b/tests/utils/test_utils_rloo.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from collections import Counter
+from types import SimpleNamespace
+
+import torch
+
+from relax.utils.types import Sample
+from relax.utils.utils import get_debug_data
+
+
+def test_get_debug_data_rloo_subsampling_preserves_complete_groups(tmp_path):
+    group_size = 4
+    samples = [
+        Sample(
+            group_index=group_index,
+            index=group_index * group_size + sample_index,
+            tokens=[1, 2],
+            response_length=1,
+            reward=float(sample_index),
+            status=Sample.Status.COMPLETED,
+        )
+        for group_index in range(4)
+        for sample_index in range(group_size)
+    ]
+    debug_path = tmp_path / "rollout-0.pt"
+    torch.save({"samples": [sample.to_dict() for sample in samples]}, debug_path)
+    args = SimpleNamespace(
+        load_debug_rollout_data=str(tmp_path / "rollout-{rollout_id}.pt"),
+        load_debug_rollout_data_subsample=0.5,
+        custom_reward_post_process_path=None,
+        advantage_estimator="rloo",
+        rewards_normalization=False,
+        n_samples_per_prompt=group_size,
+        reward_key=None,
+        multimodal_keys=None,
+        use_opd=False,
+        debug_train_only=True,
+    )
+
+    rollout_batch = get_debug_data(args, rollout_id=0, batch_size=2 * group_size, dp_rank=0)
+
+    group_counts = Counter(rollout_batch["group_indices"])
+    assert group_counts == {0: group_size, 3: group_size}

--- a/tests/utils/training/test_ppo_utils_rloo.py
+++ b/tests/utils/training/test_ppo_utils_rloo.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import pytest
+import torch
+
+from relax.utils.training.ppo_utils import (
+    compute_rloo_baselines_and_advantages,
+)
+from relax.utils.training.ppo_utils import (
+    compute_rloo_loss as _compiled_compute_rloo_loss,
+)
+
+
+compute_rloo_loss = torch.compiler.disable(_compiled_compute_rloo_loss)
+
+
+def test_rloo_baseline_and_advantage_match_reference_with_interleaved_groups():
+    rewards = torch.tensor([1.0, -1.0, 0.0, 2.0, 0.5, 1.0])
+    group_indices = [10, 20, 10, 20, 10, 20]
+
+    baselines, advantages = compute_rloo_baselines_and_advantages(rewards, group_indices, group_size=3)
+
+    expected_baselines = torch.tensor([0.25, 1.5, 0.75, 0.0, 0.5, 0.5])
+    expected_advantages = rewards - expected_baselines
+    assert torch.allclose(baselines, expected_baselines, atol=1e-6)
+    assert torch.allclose(advantages, expected_advantages, atol=1e-6)
+
+
+def test_rloo_tensor_group_indices_preserve_gathered_sample_order():
+    rewards = torch.tensor([1.0, -1.0, 0.0, 2.0, 0.5, 1.0])
+    group_indices = torch.tensor([10, 20, 10, 20, 10, 20])
+
+    baselines, advantages = compute_rloo_baselines_and_advantages(rewards, group_indices, group_size=3)
+
+    expected_baselines = torch.tensor([0.25, 1.5, 0.75, 0.0, 0.5, 0.5])
+    assert torch.allclose(baselines, expected_baselines, atol=1e-6)
+    assert torch.allclose(advantages, rewards - expected_baselines, atol=1e-6)
+
+
+def test_rloo_group_size_two_and_float64_are_exact():
+    rewards = torch.tensor([3.0, -2.0], dtype=torch.float64)
+
+    baselines, advantages = compute_rloo_baselines_and_advantages(rewards, [0, 0], group_size=2)
+
+    assert baselines.dtype == torch.float64
+    assert torch.equal(baselines, torch.tensor([-2.0, 3.0], dtype=torch.float64))
+    assert torch.equal(advantages, torch.tensor([5.0, -5.0], dtype=torch.float64))
+
+
+@pytest.mark.parametrize("group_size", [0, 1])
+def test_rloo_rejects_group_size_below_two(group_size):
+    with pytest.raises(ValueError, match="group_size >= 2"):
+        compute_rloo_baselines_and_advantages(torch.tensor([1.0]), [0], group_size)
+
+
+@pytest.mark.parametrize(
+    ("rewards", "group_indices", "message"),
+    [
+        (torch.tensor([1.0, 0.0]), [None, 0], "group_index"),
+        (torch.tensor([1.0, 0.0, 0.5]), [0, 0, 1], "group 1 has 1 samples"),
+        (torch.tensor([1.0, float("nan")]), [0, 0], "finite"),
+        (torch.tensor([1.0, float("inf")]), [0, 0], "finite"),
+        (torch.tensor([1.0, -float("inf")]), [0, 0], "finite"),
+    ],
+)
+def test_rloo_rejects_invalid_groups_and_rewards(rewards, group_indices, message):
+    with pytest.raises(ValueError, match=message):
+        compute_rloo_baselines_and_advantages(rewards, group_indices, group_size=2)
+
+
+def test_rloo_sequence_loss_matches_masked_reference_and_empty_response():
+    log_probs = [
+        torch.tensor([-0.2, -0.3, -0.4]),
+        torch.tensor([], dtype=torch.float32),
+        torch.tensor([-0.5, -0.1]),
+    ]
+    masks = [
+        torch.tensor([1.0, 0.0, 1.0]),
+        torch.tensor([], dtype=torch.float32),
+        torch.tensor([1.0, 1.0]),
+    ]
+    advantages = torch.tensor([0.75, -0.75, 0.0])
+    sequence_log_probs = torch.stack([(values * mask).sum() for values, mask in zip(log_probs, masks, strict=True)])
+
+    actual = compute_rloo_loss(sequence_log_probs, advantages)
+
+    expected = torch.tensor([0.45, 0.0, 0.0])
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+
+def test_rloo_precomputed_advantages_are_dp_partition_invariant():
+    rewards = torch.tensor([1.0, 0.0, 0.5, -1.0, 2.0, 1.0])
+    groups = [0, 0, 0, 1, 1, 1]
+    baselines, advantages = compute_rloo_baselines_and_advantages(rewards, groups, group_size=3)
+
+    dp0 = (baselines[:3], advantages[:3])
+    dp1 = (baselines[3:], advantages[3:])
+
+    assert torch.equal(torch.cat([dp0[0], dp1[0]]), baselines)
+    assert torch.equal(torch.cat([dp0[1], dp1[1]]), advantages)
+
+
+def test_rloo_cp_split_preserves_sequence_loss_and_gradient():
+    full_log_probs = torch.tensor([-0.2, -0.3, -0.4, -0.1], requires_grad=True)
+    mask = torch.tensor([1.0, 0.0, 1.0, 1.0])
+    advantage = torch.tensor([0.75])
+
+    full_loss = compute_rloo_loss((full_log_probs * mask).sum().reshape(1), advantage).sum()
+    full_loss.backward()
+    expected_grad = full_log_probs.grad.clone()
+
+    cp_log_probs = full_log_probs.detach().clone().requires_grad_(True)
+    shard_sum = (cp_log_probs[:2] * mask[:2]).sum() + (cp_log_probs[2:] * mask[2:]).sum()
+    cp_loss = compute_rloo_loss(shard_sum.reshape(1), advantage).sum()
+    cp_loss.backward()
+
+    assert torch.allclose(cp_loss, full_loss.detach(), atol=1e-6)
+    assert torch.allclose(cp_log_probs.grad, expected_grad, atol=1e-6)


### PR DESCRIPTION
## What

Add synchronous REINFORCE Leave-One-Out (RLOO) as a public, critic-free algorithm.

This change includes:

- An `rloo` registry entry and argument validation.
- Leave-one-out baseline, advantage, sampled KL reward shaping, and sequence-level policy loss.
- Explicit prompt-group IDs and data-parallel aggregation.
- Static context-parallel reconstruction for valid response-token statistics.
- RLOO monitoring metrics and a reproducible two-GPU RLOO/GRPO example.
- Formula, edge-case, DP, CP, model-mask, and metric-aggregation tests.

Asynchronous RLOO is intentionally out of scope.

## Why

Relax provides GRPO and related critic-free algorithms, but it does not provide RLOO as a public baseline. GRPO's normalized group advantages and clipped token objective are not equivalent to RLOO's leave-one-out baseline and sequence-level REINFORCE objective.

A native implementation makes matched RLOO/GRPO comparisons possible without custom reward hooks or a value model.

Fixes #176.

## How

For each prompt group of size $K$ (the $K$ responses generated from the same prompt), RLOO computes a per-sequence KL penalty, a leave-one-out baseline, and a REINFORCE-style policy loss.

### Objective

For each response $i$ in the group:

$$
\text{KL}_i = \sum_t m_{i,t} \left( \log \pi_{\text{old},i,t} - \log \pi_{\text{ref},i,t} \right)
$$

$$
R_i = r_i - \beta \cdot \text{KL}_i
$$

$$
\text{baseline}_i = \frac{\sum_{j} R_j - R_i}{K - 1}
$$

$$
\text{advantage}_i = R_i - \text{baseline}_i
$$

$$
\mathcal{L}_i = -\mathrm{sg}\left( \text{advantage}_i \right) \cdot \sum_t m_{i,t} \log \pi_{\theta,i,t}
$$

$$
\mathcal{L} = \frac{1}{K} \sum_i \mathcal{L}_i
$$

### Notation

| Symbol | Meaning |
| --- | --- |
| $i$ | Index of a response in the prompt group, $i = 1, \dots, K$ |
| $t$ | Token position in response $i$ |
| $m_{i,t}$ | Binary mask: $1$ for real response tokens, $0$ for prompt and padding tokens |
| $r_i$ | Scalar reward for response $i$ from the task or reward model |
| $\beta$ | KL coefficient that controls deviation from the reference policy |
| $\pi_{\text{old}}$ | Policy used to collect the rollout data (old / behavior policy) |
| $\pi_{\text{ref}}$ | Reference policy (typically the SFT checkpoint) |
| $\pi_\theta$ | Current policy being trained |
| $\mathrm{sg}(\cdot)$ | Stop-gradient: the value is treated as a constant during back-propagation |

### Step-by-step explanation

1. **Per-sequence KL estimate** — $\text{KL}_i$ is the masked sum of log-probability differences between the old policy and the reference policy. It measures how far the current rollout distribution has drifted from the reference.

2. **Shaped reward** — $R_i$ subtracts a KL penalty $\beta \cdot \text{KL}_i$ from the raw reward $r_i$, discouraging the policy from moving too far away from the reference.

3. **Leave-one-out baseline** — $\text{baseline}_i$ is the average shaped reward of all responses in the same group except response $i$. This is the key RLOO baseline: each response is compared against the mean of its peers, rather than the group mean.

4. **Advantage** — $\text{advantage}_i$ is how much better (or worse) response $i$ is relative to the leave-one-out baseline. This naturally has mean zero over the group.

5. **Policy loss** — $\mathcal{L}_i$ scales the negative log-likelihood of the response by the stopped-gradient advantage. Stopping the gradient on the advantage keeps the baseline and reward terms from creating unwanted gradients through the policy.

6. **Group average** — $\mathcal{L}$ averages the per-sequence losses over the full group of $K$ responses, giving the final training objective.

### Implementation details

The implementation:

- Requires complete prompt groups with `K >= 2` and rejects non-finite rewards.
- Excludes prompt and padding tokens from KL and policy loss via the mask $m_{i,t}$.
- Gives empty responses zero policy loss and gradient while retaining their scalar reward in peer baselines.
- Gathers group IDs and shaped rewards over the explicit DP group before leave-one-out reduction.
- Reconstructs full response-token log probabilities under static CP before sequence reductions.
- Uses sequence-count loss normalization even when Megatron Bridge requires `--calculate-per-token-loss` for static CP compatibility.
- Supplies a native local BSHD causal mask for the RTX 5090 CP correctness path.
- Keeps existing estimator defaults and non-RLOO behavior unchanged.
- Rejects asynchronous, normalized-advantage, double-KL, dynamic-CP, and unsupported custom RLOO combinations before launch.

### Metrics added

The following rollout metrics are added:

- `rloo_shaped_reward` — per-sequence $R_i$ after KL penalty.
- `rloo_sequence_kl` — per-sequence $\text{KL}_i$ estimate.
- `rloo_baseline` — per-sequence leave-one-out baseline.
- `rloo_advantage` — per-sequence advantage.
- `rloo_advantage_abs` — absolute value of the advantage for monitoring.
- `rloo_empty_response_fraction` — fraction of empty responses in the group.

## Testing

- [ ] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [x] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

Focused test command:

```bash
pytest -q \
  tests/utils/training/test_ppo_utils_rloo.py \
  tests/backends/megatron/test_loss_rloo.py \
  tests/backends/megatron/test_model_rloo_cp.py \
  tests/backends/megatron/test_data_rloo_metrics.py \
  tests/core/test_registry_rloo.py
```

Result: `26 passed, 48 warnings in 18.99s`.

Coverage includes hand-computed elementwise baselines, advantages, masked losses and gradients; invalid `K`; incomplete and non-contiguous groups; padding; empty responses; non-finite rewards; simulated DP/CP partitioning; BSHD CP gather metadata; native CP causal masks; and CP-invariant RLOO monitoring.

The full test suite and multi-node integration suite were not run. The available validation host is one node with two RTX 5090 GPUs. Full pre-commit was attempted, but gitleaks could not download Go dependencies from `proxy.golang.org`, and docformatter 1.3.1 is incompatible with this Python 3.12 environment because `lib2to3` is unavailable. All remaining hooks pass with only those two hooks skipped.

### Matched two-GPU experiment

Configuration: Qwen3-0.6B, GSM8K, one node with 2x RTX 5090, DP=2, CP=1, four prompts per rollout, `K=4`, maximum response length 512, seed 1234, KL coefficient 0.01, and 10 training steps.

| Metric | RLOO | GRPO |
| --- | ---: | ---: |
| Raw reward, 10-step mean | 0.031250 | 0.050000 |
| Train loss, 10-step mean | -0.006706 | -8.571e-7 |
| Policy loss, 10-step mean | -0.006706 | -1.863e-9 |
| `ppo_kl`, 10-step mean | 0.000000 | 0.000000 |
| Algorithm KL monitor, 10-step mean | `rloo_sequence_kl` 0.091381 | `kl_loss` -8.557e-5 |
| Actor throughput, 10-step mean (token/s) | 4226.29 | 3653.66 |
| Actor throughput, steady steps 1-9 (token/s) | 4523.54 | 3866.38 |
| Response throughput, 10-step mean (token/s) | 581.43 | 586.18 |
| Response throughput, steady steps 1-9 (token/s) | 638.95 | 643.96 |
| Gradient norm, 10-step mean | 109.17 | 0.6976 |
| Non-finite / OOM / restart count | 0 / 0 / 0 | 0 / 0 / 0 |

The RLOO sequence KL and GRPO KL-loss fields have different definitions and should not be compared numerically as the same estimator. Likewise, RLOO uses a sequence-sum REINFORCE loss while GRPO uses a token-normalized clipped objective, so their loss and gradient-norm scales are not directly comparable.

Steady response throughput differed by -0.78% for RLOO relative to GRPO. This 10-step smoke test validates execution and metric wiring only; it does not establish convergence or algorithmic superiority.

### Static CP smoke test

A full-model `CP=2`, `DP=1` RLOO training step completed successfully on the same 2x RTX 5090 host:

| Metric | Value |
| --- | ---: |
| Raw reward | 0.125000 |
| Train / policy loss | -3.894598 |
| `ppo_kl` | 0.000000 |
| Actor train time | 14.11 s |
| Actor throughput | 644.33 token/s |
| Response throughput | 59.57 token/s |
| Actor train tokens | 9094 |
| OOM / non-finite / restart count | 0 / 0 / 0 |

The run completed actor training, optimizer update, weight synchronization, and clean shutdown. The CP sequence-monitor values in that run exposed a logging-only extra `cp_size` multiplier; the implementation now excludes replicated `rloo_*` sequence metrics from that multiplier, with a focused regression test.

On this Blackwell host, Transformer Engine flash/fused attention backends were unavailable or failed to load. The successful CP path uses Megatron local BSHD attention with the native zig-zag causal mask added here. This is a correctness fallback with quadratic attention memory, not a long-context production recommendation. Hopper hardware is not required for the demonstrated small-model CP smoke test.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Successful jobs:

- RLOO DP=2, 10 steps: `raysubmit_HiHaDm2UUqDiKjbd`
- GRPO DP=2, 10 steps: `raysubmit_GviTZSAsJuqnasuG`
- RLOO CP=2 full-model smoke: `raysubmit_rg6Y7VGXzxGNZhy4`

All three jobs completed without OOM, non-finite values, or actor restarts