### PR TITLE
Feat/task21 hybrid async multimodal perf

### DIFF
--- a/exps/hybrid_async_perf_h20/README.md
+++ b/exps/hybrid_async_perf_h20/README.md
@@ -1,0 +1,292 @@
+# Hybrid-Async Multimodal Perf Comparison — H20 (Qwen3-VL-4B)
+
+Saved 2026-07-29 before shutting down the H20 remote server (region-42.seetacloud.com).
+
+## Environment
+
+- 2x NVIDIA H20 (96GB each), Hopper/sm_90
+- Model: Qwen/Qwen3-VL-4B-Instruct
+- Dataset: lmms-lab/multimodal-open-r1-8k-verified (converted via scripts/tools/process_openr1.py)
+- Script: scripts/training/multimodal/run-qwen3-vl-4B-2xgpu-openr1mm-hybrid-async.sh
+- Transformer Engine rebuilt from source for sm_90 (environment image was originally built targeting a different GPU arch)
+
+## Config used for all 4 runs
+
+- `--attention-backend auto`, `--recompute-granularity selective`
+- prompt_len=2048, response_len=4096, context_len=6144, max-tokens-per-gpu=6144
+- rollout-batch-size=16, global-batch-size=64, n-samples-per-prompt=4
+- num-rollout=30, num-iters-per-train-update=1 (syncs weights every iteration)
+- Checkpoint saving disabled (--save removed) — not needed for perf benchmarking, also avoids disk exhaustion
+- --use-clearml enabled
+
+## Code states
+
+- `actor_baseline.py` — relax/backends/megatron/actor.py at HEAD (no hybrid-async weight-sync overlap optimization)
+- `actor_optimized.py` — same file with the hybrid-async optimization (commit 51afba8: "perf(hybrid): overlap actor->rollout weight sync with next step")
+
+## Runs
+
+| Log                         | Code      | Result               |
+| --------------------------- | --------- | -------------------- |
+| logs/baseline_h20_run1.log  | baseline  | Job succeeded, 0 OOM |
+| logs/baseline_h20_run2.log  | baseline  | Job succeeded, 0 OOM |
+| logs/optimized_h20_run1.log | optimized | Job succeeded, 0 OOM |
+| logs/optimized_h20_run2.log | optimized | Job succeeded, 0 OOM |
+
+## Results (avg over 30 steps, excluding step 0 which includes warmup/first-load overhead)
+
+| Metric                  | baseline avg | optimized avg | delta                         |
+| ----------------------- | ------------ | ------------- | ----------------------------- |
+| `perf/step_time`        | 49.90s       | 53.26s        | **+6.75% (optimized slower)** |
+| `perf/actor_train_time` | 40.37s       | 43.38s        | **+7.46% (optimized slower)** |
+
+Raw extracted values: `perf_extract.txt` (step_time), `actor_train_extract.txt` (actor_train_time).
+
+## Finding
+
+On H20 (high NVLink bandwidth, weight broadcast itself is cheap) with weight sync forced every
+iteration (`--num-iters-per-train-update 1`), the hybrid-async overlap optimization measured a
+**net regression** (~7%), not an improvement. Likely explanation: the optimization's fixed
+per-sync overhead (CPU-side double-buffer snapshot copy via `weights_backuper.copy()`, plus
+ThreadPoolExecutor submit/join bookkeeping) is paid every iteration regardless of overlap, while
+the benefit (hiding weight-push latency behind next-iteration compute) shrinks when the
+underlying broadcast is already fast and frequent. This is the opposite of the earlier RTX 5090
+2B-model test (which showed a small ~3.8% improvement, but was measured on a memory-constrained
+setup requiring unfused attention + full recompute workarounds that inflated per-step compute
+time and diluted the effect in the other direction).
+
+Suggests the optimization's benefit is conditional: helpful when weight-sync latency is large
+relative to compute (slower interconnect, bigger models, less frequent syncs), and can be a net
+negative when sync is cheap and frequent. Worth stating this boundary explicitly in the
+GitHub issue rather than a blanket "faster" claim.
+
+## Prior RTX 5090 (2B model) results, for reference
+
+(Original logs are gone — that server was already stopped before this H20 run. Numbers were
+computed from log timestamps during that session and reported inline in conversation.)
+
+- baseline avg step time: ~33.3s/step
+- optimized avg step time: ~32.0s/step (~3.8% faster)
+- Required workarounds due to 32GB VRAM limit: `--attention-backend unfused`,
+  `--recompute-granularity full --recompute-method uniform --recompute-num-layers 1`,
+  `--max-tokens-per-gpu 3072` — all of which inflate per-step compute time and were flagged as
+  likely suppressing the optimization's true relative benefit.
+
+______________________________________________________________________
+
+## 2026-07-30 — DCS-based weight sync (replaces the ThreadPoolExecutor overlap above)
+
+The `51afba8` ThreadPoolExecutor overlap above was reverted. This round tests a different
+approach: reuse the same DCS (Distributed Checkpoint Service) NCCL/GLOO device-direct broadcast
+that pure fully-async mode already uses for `update_weights_fully_async`, instead of hybrid's old
+CUDA-IPC `UpdateWeightFromTensor` push. Rationale and design: `d4b741b` ("perf(hybrid): push
+actor->rollout weights via DCS"). Final working commit after fixing 5 real-hardware-only bugs:
+`2c27d43` (chain: `d4b741b` → `9172abb` → `1438e84` → `5b85208` → `d3c4861` → `2c27d43`).
+
+### Code states
+
+- baseline: commit `02e2408` (pre-DCS hybrid, synchronous `UpdateWeightFromTensor` CUDA-IPC push)
+- optimized: commit `2c27d43` (DCS-based synchronous push, same branch
+  `feat/task21-hybrid-async-multimodal-perf`)
+
+### Bugs found and fixed during real-GPU validation
+
+All five were invisible to static/CPU-only review in the prior session and only surfaced once
+actually run against real Megatron-Bridge multimodal weights on GPU:
+
+1. **`9172abb`** — `set_rollout_manager()` still gated the init-time `update_weights()` call on
+   `(not fully_async or hybrid)`, but hybrid no longer has a `weight_updater` (that got replaced
+   by the DCS `checkpoint_engine_client`) → `AttributeError: 'MegatronTrainRayActor' object has no attribute 'weight_updater'`. Fixed by aligning hybrid's condition with fully_async's (both skip
+   the init push; first sync happens lazily via DCS on the first real train step).
+2. **`1438e84`** — `DeviceDirectBackend._named_params_and_buffers()`'s `weights_getter` branch fed
+   the NCCL/GLOO broadcast CPU-pinned tensors straight from `TensorBackuper`, but the
+   broadcast/`all_gather_param` requires device tensors → `RuntimeError: No backend type associated with device type cpu`. Fixed by adding an H2D copy (`tensor.to(self.device)`) when
+   the source is a CPU tensor, mirroring `UpdateWeightFromTensor`'s equivalent copy for its own
+   CUDA-IPC push.
+3. **`5b85208` / `d3c4861`** (two failed attempts before the real fix) — `all_gather_param`
+   unconditionally asserts `hasattr(param, "tensor_model_parallel")` for TP-gather, but Megatron
+   dynamically attaches `tensor_model_parallel`/`partition_dim`/`partition_stride`/`parallel_mode`
+   as plain Python attributes on live `nn.Parameter` objects — not part of tensor storage, so
+   `torch.empty_like()` (used by `TensorBackuper.backup()` to build its CPU snapshot) silently
+   drops them → `AssertionError`. First attempt copied the attrs at snapshot-creation time; still
+   failed because the live param itself hadn't been backfilled with defaults yet at that point for
+   this model's bridge-mode word_embeddings. Second attempt called Megatron's own
+   `set_defaults_if_not_set_tensor_model_parallel_attributes` on the snapshot; still failed with
+   the *same* assertion.
+4. **`2c27d43`** — the actual root cause of #3: the H2D-copy fix from bug #2
+   (`tensor.to(self.device)`) itself allocates a **brand-new** Tensor object, which drops
+   whatever attributes bugs #3's fixes had just attached to the CPU snapshot — the attribute loss
+   was happening one step further downstream than either #3 fix attempt was looking. Fixed by
+   re-copying the TP attributes onto the device-moved tensor via Megatron's own
+   `copy_tensor_model_parallel_attributes(moved, tensor)` plus a manual `parallel_mode` copy.
+   Confirmed working live: training passed step 0's weight sync and proceeded cleanly through all
+   30 steps on both runs.
+
+### Runs
+
+| Log                              | Code      | Result                               |
+| -------------------------------- | --------- | ------------------------------------ |
+| logs/baseline_run1_20260730.log  | `02e2408` | Job succeeded, 30/30 steps, 0 errors |
+| logs/baseline_run2_20260730.log  | `02e2408` | Job succeeded, 30/30 steps, 0 errors |
+| logs/optimized_run1_20260730.log | `2c27d43` | Job succeeded, 30/30 steps, 0 errors |
+| logs/optimized_run2_20260730.log | `2c27d43` | Job succeeded, 30/30 steps, 0 errors |
+
+### Results (avg over 30 steps, excluding step 0)
+
+| Metric                     | baseline avg | optimized avg              | delta                         |
+| -------------------------- | ------------ | -------------------------- | ----------------------------- |
+| `perf/step_time`           | 51.32s       | 52.34s                     | **+1.99% (optimized slower)** |
+| `perf/actor_train_time`    | 41.58s       | 41.53s                     | -0.13% (no change)            |
+| `perf/log_probs_time`      | 7.62s        | 7.93s                      | **+4.11% (optimized slower)** |
+| `perf/train_wait_time`     | 9.47s        | 10.54s                     | **+1.07s (optimized slower)** |
+| `perf/update_weights_time` | 1.09s        | *(not logged — see below)* | n/a                           |
+
+### Finding: the DCS swap did **not** deliver the expected win — real regression, not noise
+
+Both optimized runs land consistently around 52.2–52.5s step_time, vs. both baseline runs at
+50.0–52.6s (avg 51.3s) — this is a small but **reproducible** ~2% regression, not run-to-run
+variance. `log_probs_time`/`log_probs_tflops` are also consistently ~4% worse in both optimized
+runs. This directly contradicts the premise of the optimization (see `d4b741b` and the original
+plan): swapping the CUDA-IPC push for DCS's NCCL/GLOO broadcast was expected to be at least
+neutral, ideally cheaper, since fully-async mode already uses the identical path.
+
+**Root cause, found by reading the code, not just the numbers:** `train_hybrid`
+(`relax/backends/megatron/actor.py`, near line 1348) calls
+`run(self.checkpoint_engine_client.update_weights_for_rollout(rollout_only=True))` **synchronously**
+in the main line of the function, *outside* the `timer("train")` / `inverse_timer("train_wait")`
+block — this was a deliberate "hard swap, no ThreadPoolExecutor" design decision (see the plan:
+"DCS's own broadcast/stream handling is what's supposed to provide any overlap, not a
+`ThreadPoolExecutor` wrapper"). In practice, DCS's broadcast does **not** provide free overlap
+either — it's still a blocking call from the caller's perspective. Because the push happens after
+the current step's `timer("train")` closes, its cost doesn't show up as its own metric (there is
+no `perf/update_weights_time` field anywhere in the optimized logs — confirmed by diffing the full
+set of `perf/*` keys between baseline and optimized logs, they're otherwise identical). Instead, it
+shows up as inflated `train_wait_time` on the **next** step: optimized's `train_wait_time` is
+~1.07s higher than baseline's (10.54s vs 9.47s) — almost exactly matching baseline's own
+`update_weights_time` (~1.09s). The weight-push cost didn't go away; it just moved into an
+uninstrumented gap and is (if anything) slightly more expensive as measured by total step_time,
+plus something in the log_probs phase got ~4% slower (not yet root-caused — possibly PCIe/NVLink
+contention from the CPU→GPU H2D copies added in bug #2/#4, or memory-bandwidth pressure from the
+extra `tensor.to(device)` allocation happening once per parameter every sync).
+
+**Conclusion:** on this 2xH20 setup, hard-swapping hybrid's weight sync from CUDA-IPC
+`UpdateWeightFromTensor` to a synchronous DCS push is a **net regression** (~2% slower step time),
+not an improvement. The original ThreadPoolExecutor approach (tested 2026-07-29, also a regression
+at this scale) and this DCS approach share the same underlying issue: neither actually removes or
+overlaps the weight-sync cost off the critical path — one paid CPU-thread overhead for no real
+concurrency benefit, the other trades one synchronous push mechanism for another with no
+measured net gain. A real overlap win would require either (a) making the DCS push genuinely
+asynchronous (start the broadcast, return immediately, join before the *following* step's weight
+read — not before the *next* iteration's train step) or (b) confirming DCS's broadcast has lower
+fixed latency than CUDA-IPC at larger scale (more GPUs / bigger models) where the fixed per-call
+overhead seen here would be a proportionally smaller cost. Recommend reporting this null result on
+GitHub issue #21 rather than merging this as a performance win.
+
+______________________________________________________________________
+
+## 2026-07-30 (later same day) — split `train_hybrid`'s training step into `num_iters_per_train_update` iterations
+
+### What we set out to do
+
+`docs/en/guide/hybrid-training.md`'s "Next Steps" section documented a known gap: hybrid mode's
+`num_iters_per_train_update` flag was supposed to control how many pieces the *training* step gets
+split into (so optimizer updates could be pipelined with TransferQueue consumption and peak
+training-side memory would drop), but the merged batch was actually still trained in a single
+`train(...)` call regardless of that flag's value.
+
+### What we found before writing any code
+
+Reading `relax/backends/megatron/actor.py`'s `train_hybrid` and `relax/backends/megatron/data.py`'s
+`get_data_iterator` showed the docs were stale, not just incomplete:
+
+- `train_hybrid`'s **forward** phase (phase 1) sub-batch count already comes from
+  `build_rollout_minibatch_plan`, which is driven by `--num-steps-per-rollout` (falling back to
+  `rollout_batch_size * n_samples_per_prompt // global_batch_size` if unset) — **not** by
+  `--num-iters-per-train-update` at all.
+- `get_data_iterator` already supports splitting a merged batch into multiple separate optimizer
+  steps: if `rollout_data` carries a `ROLLOUT_MINI_LOCAL_SAMPLE_COUNTS_KEY` list of length N, it
+  builds an N-length `num_microbatches` schedule, and `train()`'s loop (`relax/backends/megatron/ model.py`) already runs one full `train_one_step` (one real `optimizer.step()`) per entry. This
+  machinery was added by `679022e` ("feat(megatron): split rollout mini batches"), which landed
+  *after* the hybrid-training guide was written — the guide was simply never updated.
+- `train_hybrid` already sets `ROLLOUT_MINI_LOCAL_SAMPLE_COUNTS_KEY` from phase 1's rollout-mini
+  counts, so whenever `--num-steps-per-rollout` > 1, the merged training step **already** ran as
+  multiple optimizer steps. `--num-iters-per-train-update` genuinely had zero effect on hybrid mode
+  — it's only read by pure fully-async's separate `actor_fwd`/`reference` services
+  (`compute_ref_log_prob`/`compute_actor_log_prob`) and the standalone `advantages` component, none
+  of which are deployed under `--hybrid`.
+- Two of the six existing hybrid launch scripts (`run-qwen35-27B-8xgpu-openr1mm-hybrid-async.sh`,
+  `run-qwen3-vl-2b-2xgpu-openr1mm-hybrid-async.sh`) pass `--num-iters-per-train-update 2` expecting
+  it to matter — it silently didn't.
+
+### What we implemented (kept)
+
+`relax/backends/megatron/actor.py`, `train_hybrid`, phase 3: after phase 1/2 finish (forward +
+merge + advantages), the merged batch is now **re-chunked** into `num_iters_per_train_update`
+equal-size pieces (raising `RuntimeError` if it doesn't divide evenly) and that list is what gets
+written to `ROLLOUT_MINI_LOCAL_SAMPLE_COUNTS_KEY` for `get_data_iterator`/`train()` to consume —
+independent of however many sub-batches phase 1 used. This makes `--num-iters-per-train-update`
+control the training-step split exactly as documented, while `--num-steps-per-rollout` continues to
+control the forward-phase split, unchanged. Default `num_iters_per_train_update=1` reproduces the
+old single-optimizer-step behavior exactly (verified: all 6 existing hybrid scripts pass the new
+divisibility check).
+
+### What we attempted and reverted: making the DCS push asynchronous too
+
+Since a genuinely async, double-buffered weight push (`hybrid_send_0`/`hybrid_send_1`, ported from
+the reverted `51afba8` ThreadPoolExecutor design) was flagged as the natural next step to *also*
+overlap weight sync with the now-pipelined training iterations, we implemented it: a background
+`ThreadPoolExecutor(max_workers=1)` fires `checkpoint_engine_client.update_weights_for_rollout(...)`
+against an isolated CPU snapshot tag, joined at the top of the *next* iteration's push instead of
+blocking immediately. It worked correctly (verified on real GPU: no deadlocks, no race conditions,
+correct weight updates every rollout, tested with `--num-iters-per-train-update 2`) but delivered no
+speed benefit, and was **reverted** — see results below. The code currently in this repo pushes
+weights **synchronously**, same as `2c27d43`.
+
+### Runs
+
+| Log                                      | Config                                                      | Result                     |
+| ---------------------------------------- | ----------------------------------------------------------- | -------------------------- |
+| `logs/syncdcs_split_run1_20260730.log`   | sync DCS push, `--num-iters-per-train-update 2`             | Job succeeded, 30/30 steps |
+| `logs/syncdcs_split_run2_20260730.log`   | sync DCS push, `--num-iters-per-train-update 2`             | Job succeeded, 30/30 steps |
+| `logs/optimized_async_run1_20260730.log` | async DCS push (reverted), `--num-iters-per-train-update 2` | Job succeeded, 30/30 steps |
+| `logs/optimized_async_run2_20260730.log` | async DCS push (reverted), `--num-iters-per-train-update 2` | Job succeeded, 30/30 steps |
+
+### Results (avg over 30 steps, excluding step 0)
+
+| Metric                  | baseline (`02e2408`, CUDA-IPC) | DCS sync, no split (`2c27d43`) | **DCS sync + split×2 (kept)**      | DCS async + split×2 (reverted) |
+| ----------------------- | ------------------------------ | ------------------------------ | ---------------------------------- | ------------------------------ |
+| `perf/step_time`        | 51.32s                         | 52.34s                         | **55.24s (+5.5% vs DCS-no-split)** | 56.03s (+7.0% vs DCS-no-split) |
+| `perf/actor_train_time` | 41.58s                         | 41.53s                         | **44.34s (+6.8%)**                 | 44.86s (+8.0%)                 |
+| `perf/log_probs_time`   | 7.62s                          | 7.93s                          | **8.09s (+2.0%)**                  | 8.24s (+3.9%)                  |
+
+### Finding
+
+Splitting the training step (`--num-iters-per-train-update 2`) is a **net regression** here, and it
+is a *reproducible* one — both sync-push runs land at 56.42s/54.07s, both async-push runs land at
+56.36s/55.69s. Critically, **sync vs. async push barely matters** (55.24s vs 56.03s, ~0.8s apart —
+within run-to-run noise): the regression is dominated by the training split itself, not by whether
+the weight push blocks. This makes sense given how the split actually pays for itself: each extra
+optimizer step re-pays the DP gradient all-reduce, and — since this script enables
+`--optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d` — an extra round of CPU-offloaded
+optimizer-state H2D/D2H copies per rollout, while each step's batch is half the size (worse compute
+of overhead ratio at this small 2-GPU scale). The theoretical benefit ("pipeline optimizer updates
+with TransferQueue consumption, lower peak training memory") does not apply to `train_hybrid`
+specifically: by the time phase 3 begins, phase 1 has already fully drained TransferQueue for this
+rollout, so there is no data-fetch to overlap with — the split's only possible benefit here is
+reduced peak memory, which this 96GB-per-GPU / 4B-model config never needed.
+
+**Conclusion:** the code fix (making `--num-iters-per-train-update` actually control `train_hybrid`'s
+training split, instead of silently doing nothing) is a correctness/documentation-accuracy fix worth
+keeping regardless of perf — two existing launch scripts were already passing this flag believing it
+did something. But turning it on (setting it above 1) is a **measured regression** at this 2xH20
+scale and should not be recommended as a default; `--num-iters-per-train-update 1` (the default)
+preserves the original behavior exactly. The async DCS push was implemented, validated correct on
+real hardware, and then reverted — it neither helped nor hurt beyond the split's own cost, so there
+is no reason to carry its added complexity (double-buffering, background thread, extra guard
+conditions for `--disable-weights-backuper`/`--keep-old-actor`) in the codebase.
+
+This is the third confirmed null result on this issue (after the `51afba8` ThreadPoolExecutor
+overlap and the `d4b741b`→`2c27d43` DCS weight-sync swap): every "overlap"/"split" idea tried so far
+has been a net regression at 2-GPU scale, because the fixed fetch/sync/optimizer-step overhead being
+paid more often outweighs any concurrency benefit when compute-per-step is already small and GPU
+memory is not the bottleneck.

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -14,8 +14,9 @@ import ray
 import requests
 import torch
 import torch.distributed as dist
-import transfer_queue as tq
 from megatron.core import mpu
+
+import transfer_queue as tq
 
 
 try:
@@ -211,8 +212,9 @@ class MegatronTrainRayActor(TrainRayActor):
         if self.args.vocab_size is None:
             self.args.vocab_size = self.tokenizer.vocab_size
         # Hybrid mode uses the TensorBackuper path: actor handles ref/actor_fwd
-        # internally via _switch_model and pushes weights to rollout via
-        # UpdateWeightFromTensor instead of DCS.
+        # internally via _switch_model, and pushes weights to rollout via DCS
+        # (relax.distributed.checkpoint_service), reading from the "actor" CPU
+        # snapshot tag instead of the live model directly.
         use_tensor_backuper = not self.args.fully_async or self.args.hybrid
         if use_tensor_backuper:
             self.weights_backuper = TensorBackuper.create(
@@ -241,78 +243,82 @@ class MegatronTrainRayActor(TrainRayActor):
                 if args.update_weights_interval == 1:
                     self.weights_backuper.backup("rollout_actor")
 
-            update_weight_cls = UpdateWeightFromTensor if self.args.colocate else UpdateWeightFromDistributed
-            # Push-side repack is decided by the HF config: an FP8 release auto-routes
-            # through quantize_params_fp8, a compressed-tensors release through
-            # quantize_params_compressed_tensors, an unquantized BF16 dir is passed
-            # through verbatim. The OPEN_TRAINING_INT4_FAKE_QAT_FLAG env var ONLY
-            # controls the training-side forward STE in the megatron patch — it is
-            # independent of push routing (matches slime/backends/megatron_utils/actor.py).
-            # K2.6 INT4 release ships an ignore list that omits vision_tower /
-            # mm_projector — without augment_compressed_tensors_ignore the bridge
-            # would try to INT4-pack those BF16 tensors and SGLang would reject
-            # them with "weight_packed not found in params_dict".
-            from relax.utils.quant_cast import augment_compressed_tensors_ignore
+            if self.args.hybrid:
+                # Mutable indirection so the background push (see
+                # _hybrid_async_weight_sync below) can point the DCS client at an
+                # isolated double-buffered snapshot without racing the "actor" tag
+                # that train_hybrid's per-step backup("actor") keeps overwriting.
+                # A no-op reassignment (tag stays "actor") when the async path is
+                # off, so this is always safe to set.
+                self._hybrid_send_tag_active = "actor"
+                # Push actor->rollout weights via DCS instead of the CUDA-IPC
+                # UpdateWeightFromTensor path (see docs/en/guide/hybrid-training.md).
+                self.checkpoint_engine_client = self._create_checkpoint_engine_client(
+                    role, weights_getter=lambda: self.weights_backuper.get(self._hybrid_send_tag_active)
+                )
 
-            push_quant_config = augment_compressed_tensors_ignore(
-                getattr(self.hf_config, "quantization_config", None),
-                args.hf_checkpoint,
-            )
-            self.weight_updater = update_weight_cls(
-                self.args,
-                self.model,
-                weights_getter=lambda: self.weights_backuper.get("actor"),
-                model_name=type(self.hf_config).__name__.lower()
-                if self.args.model_name is None
-                else self.args.model_name,
-                quantization_config=push_quant_config,
-            )
-        else:
-            is_pp_src_rank = (
-                mpu.get_data_parallel_rank(with_context_parallel=True) == 0
-                and mpu.get_tensor_model_parallel_rank() == 0
-            )
-            if is_pp_src_rank:
-                master_address = ray._private.services.get_node_ip_address()
-                with socket.socket() as sock:
-                    sock.bind(("", 0))
-                    master_port = sock.getsockname()[1]
+                # Opt-in: overlap the actor->rollout weight push with the next
+                # training iteration instead of blocking train_hybrid on it,
+                # gated behind --hybrid-async-weight-sync (default off). Measured
+                # as no faster than the synchronous push on 2xH20 (see
+                # exps/hybrid_async_perf_h20/README.md) — the DCS push's H2D copy
+                # + TP all-gather + NCCL broadcast still run on the actor's own
+                # GPU and contend with the next step's compute either way. Kept
+                # as an opt-in switch rather than removed, since larger-scale /
+                # slower-interconnect setups may see a different tradeoff.
+                # Safe only because the push reads a CPU-pinned TensorBackuper
+                # snapshot decoupled from the live GPU params the next step
+                # mutates. Disabled when there is no real CPU backup
+                # (--disable-weights-backuper, whose _TensorBackuperNoop doesn't
+                # support extra tags/copy()) or when --keep-old-actor is set,
+                # since that bookkeeping mutates the same CPU tags that
+                # _switch_model("old_actor") reads on the very next iteration's
+                # main thread — overlapping those would race.
+                self._hybrid_async_weight_sync = (
+                    self.args.hybrid_async_weight_sync
+                    and self.args.enable_weights_backuper
+                    and not self.args.keep_old_actor
+                )
+                if self._hybrid_async_weight_sync:
+                    from concurrent.futures import ThreadPoolExecutor
+
+                    self._hybrid_sync_executor = ThreadPoolExecutor(max_workers=1)
+                    self._pending_hybrid_sync_future = None
+                    self._hybrid_send_tag_counter = 0
+                    # TensorBackuper.copy() only overwrites keys that already exist
+                    # in the destination tag, so both double-buffer slots must be
+                    # pre-populated once before train_hybrid's per-step copy() calls.
+                    self.weights_backuper.backup("hybrid_send_0")
+                    self.weights_backuper.backup("hybrid_send_1")
             else:
-                master_address = None
-                master_port = None
-            metadata = {
-                "tp_size": mpu.get_tensor_model_parallel_world_size(),
-                "dp_size": mpu.get_data_parallel_world_size(with_context_parallel=False),
-                "pp_size": mpu.get_pipeline_model_parallel_world_size(),
-                "ep_size": mpu.get_expert_model_parallel_world_size(),
-                "cp_size": mpu.get_context_parallel_world_size(),
-                "pp_rank": mpu.get_pipeline_model_parallel_rank(),
-                "is_pp_src_rank": is_pp_src_rank,
-                "master_address": master_address,
-                "master_port": master_port,
-            }
-            from relax.utils.quant_cast import augment_compressed_tensors_ignore
+                update_weight_cls = UpdateWeightFromTensor if self.args.colocate else UpdateWeightFromDistributed
+                # Push-side repack is decided by the HF config: an FP8 release auto-routes
+                # through quantize_params_fp8, a compressed-tensors release through
+                # quantize_params_compressed_tensors, an unquantized BF16 dir is passed
+                # through verbatim. The OPEN_TRAINING_INT4_FAKE_QAT_FLAG env var ONLY
+                # controls the training-side forward STE in the megatron patch — it is
+                # independent of push routing (matches slime/backends/megatron_utils/actor.py).
+                # K2.6 INT4 release ships an ignore list that omits vision_tower /
+                # mm_projector — without augment_compressed_tensors_ignore the bridge
+                # would try to INT4-pack those BF16 tensors and SGLang would reject
+                # them with "weight_packed not found in params_dict".
+                from relax.utils.quant_cast import augment_compressed_tensors_ignore
 
-            push_quant_config = augment_compressed_tensors_ignore(
-                getattr(self.hf_config, "quantization_config", None),
-                args.hf_checkpoint,
-            )
-            self.checkpoint_engine_client = run(
-                create_client(
-                    args=self.args,
-                    coordinator_url=self.args.coordinator_url,
-                    role=role,
-                    rank=dist.get_rank(),
-                    model=self.model,
+                push_quant_config = augment_compressed_tensors_ignore(
+                    getattr(self.hf_config, "quantization_config", None),
+                    args.hf_checkpoint,
+                )
+                self.weight_updater = update_weight_cls(
+                    self.args,
+                    self.model,
+                    weights_getter=lambda: self.weights_backuper.get("actor"),
                     model_name=type(self.hf_config).__name__.lower()
                     if self.args.model_name is None
                     else self.args.model_name,
                     quantization_config=push_quant_config,
-                    backend_type=self.args.checkpoint_engine_backend,
-                    metadata=metadata,
-                    lock=self.lock,
                 )
-            )
+        else:
+            self.checkpoint_engine_client = self._create_checkpoint_engine_client(role)
         # empty cache after initialization
         clear_memory()
 
@@ -386,6 +392,63 @@ class MegatronTrainRayActor(TrainRayActor):
             raise ValueError(f"Cannot switch to unknown model tag: {target_tag}")
         self.weights_backuper.restore(target_tag)
         self._active_model_tag = target_tag
+
+    def _next_hybrid_send_tag(self) -> str:
+        self._hybrid_send_tag_counter += 1
+        return f"hybrid_send_{self._hybrid_send_tag_counter % 2}"
+
+    def _join_pending_hybrid_weight_sync(self) -> None:
+        future = self._pending_hybrid_sync_future
+        if future is not None:
+            self._pending_hybrid_sync_future = None
+            future.result()
+
+    def _create_checkpoint_engine_client(self, role, weights_getter=None):
+        is_pp_src_rank = (
+            mpu.get_data_parallel_rank(with_context_parallel=True) == 0 and mpu.get_tensor_model_parallel_rank() == 0
+        )
+        if is_pp_src_rank:
+            master_address = ray._private.services.get_node_ip_address()
+            with socket.socket() as sock:
+                sock.bind(("", 0))
+                master_port = sock.getsockname()[1]
+        else:
+            master_address = None
+            master_port = None
+        metadata = {
+            "tp_size": mpu.get_tensor_model_parallel_world_size(),
+            "dp_size": mpu.get_data_parallel_world_size(with_context_parallel=False),
+            "pp_size": mpu.get_pipeline_model_parallel_world_size(),
+            "ep_size": mpu.get_expert_model_parallel_world_size(),
+            "cp_size": mpu.get_context_parallel_world_size(),
+            "pp_rank": mpu.get_pipeline_model_parallel_rank(),
+            "is_pp_src_rank": is_pp_src_rank,
+            "master_address": master_address,
+            "master_port": master_port,
+        }
+        from relax.utils.quant_cast import augment_compressed_tensors_ignore
+
+        push_quant_config = augment_compressed_tensors_ignore(
+            getattr(self.hf_config, "quantization_config", None),
+            self.args.hf_checkpoint,
+        )
+        return run(
+            create_client(
+                args=self.args,
+                coordinator_url=self.args.coordinator_url,
+                role=role,
+                rank=dist.get_rank(),
+                model=self.model,
+                model_name=type(self.hf_config).__name__.lower()
+                if self.args.model_name is None
+                else self.args.model_name,
+                quantization_config=push_quant_config,
+                backend_type=self.args.checkpoint_engine_backend,
+                metadata=metadata,
+                lock=self.lock,
+                weights_getter=weights_getter,
+            )
+        )
 
     def fill_routing_replay(self, data_iterator, num_microbatches, rollout_data):
         if "rollout_routed_experts" not in rollout_data:
@@ -1128,10 +1191,14 @@ class MegatronTrainRayActor(TrainRayActor):
         fully-async's streaming data pipeline. Actor and rollout run on separate GPUs,
         but actor/ref/actor_fwd share the same GPUs via role switching.
 
-        Data is processed in sub-batches (controlled by num_iters_per_train_update) to
-        reduce peak GPU memory during forward passes, matching fully-async behavior.
-        Advantages are computed after all sub-batches are collected to ensure correct
-        global normalization across the full batch and DP group.
+        Data is processed in sub-batches (controlled by --num-steps-per-rollout via
+        build_rollout_minibatch_plan) to reduce peak GPU memory during forward passes,
+        matching fully-async behavior. Advantages are computed after all sub-batches
+        are collected to ensure correct global normalization across the full batch
+        and DP group. The merged batch is then re-chunked into
+        num_iters_per_train_update pieces and trained as that many separate
+        optimizer steps, pipelining optimizer updates independently of how the
+        forward phase was sub-batched.
         """
         logger.info(f"start to get rollout_id: {rollout_id} data from transfer queue for train_hybrid.")
         dp_size = mpu.get_data_parallel_world_size(with_context_parallel=False)
@@ -1140,7 +1207,6 @@ class MegatronTrainRayActor(TrainRayActor):
 
         # ── Phase 1: Collect sub-batches and compute ref/actor forward in small chunks ──
         collected_batches: list[RolloutBatch] = []
-        rollout_mini_local_sample_counts: list[int] = []
         if self.args.debug_train_only:
             # Bypass the transfer queue and load the offline debug rollout dump
             # directly (mirrors `train`'s debug_train_only path). The dump holds
@@ -1159,7 +1225,6 @@ class MegatronTrainRayActor(TrainRayActor):
                     )
                 self._hybrid_forward_subbatch(sub_batch)
                 collected_batches.append(sub_batch)
-                rollout_mini_local_sample_counts.append(len(sub_batch["total_lengths"]))
         else:
             batch_index = 0
             # Surface stuck-loop conditions: when the partition can never reach the
@@ -1216,7 +1281,6 @@ class MegatronTrainRayActor(TrainRayActor):
                     )
                 self._hybrid_forward_subbatch(sub_batch)
                 collected_batches.append(sub_batch)
-                rollout_mini_local_sample_counts.append(len(sub_batch["total_lengths"]))
 
         if len(collected_batches) != plan.num_rollout_minis:
             raise RuntimeError(
@@ -1238,7 +1302,6 @@ class MegatronTrainRayActor(TrainRayActor):
                     rollout_data[key].extend(value)
                 else:
                     rollout_data[key].append(value)
-        rollout_data[ROLLOUT_MINI_LOCAL_SAMPLE_COUNTS_KEY] = rollout_mini_local_sample_counts
 
         with inverse_timer("train_wait"), timer("train"):
             if self.args.compute_advantages_and_returns:
@@ -1249,7 +1312,22 @@ class MegatronTrainRayActor(TrainRayActor):
 
             log_rollout_data(rollout_id, self.args, rollout_data)
 
-            # ── Phase 3: Train on the full merged batch ──
+            # ── Phase 3: re-chunk the merged batch into num_iters_per_train_update
+            # pieces and train each as its own optimizer step. This is independent of
+            # how many sub-batches phase 1 used to fetch/forward data (that count
+            # comes from --num-steps-per-rollout via build_rollout_minibatch_plan);
+            # here we split the fully merged batch to pipeline optimizer updates
+            # with TransferQueue consumption and bound training-side peak memory.
+            num_iters = self.args.num_iters_per_train_update
+            num_local_samples = len(rollout_data["total_lengths"])
+            if num_local_samples % num_iters != 0:
+                raise RuntimeError(
+                    f"train_hybrid({rollout_id}): num_local_samples ({num_local_samples}) must be "
+                    f"divisible by num_iters_per_train_update ({num_iters})."
+                )
+            rollout_data[ROLLOUT_MINI_LOCAL_SAMPLE_COUNTS_KEY] = [
+                num_local_samples // num_iters for _ in range(num_iters)
+            ]
             data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
             if self.args.use_routing_replay:
                 os.environ["ROUTING_REPLAY_STAGE"] = "replay_backward"
@@ -1324,28 +1402,57 @@ class MegatronTrainRayActor(TrainRayActor):
             tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rollout_id))
             return
 
+        if self._hybrid_async_weight_sync:
+            # Join the PREVIOUS iteration's push here (not the one we're about
+            # to fire) so the NCCL broadcast overlaps with this iteration's own
+            # data pull + forward/backward instead of blocking on it.
+            self._join_pending_hybrid_weight_sync()
+
         # Mirror train_async's pause/resume coordination so the rollout service
         # has a chance to finish its in-flight step (and refill any partition
         # gaps it owes) before we swap weights. Without this gate the rollout
         # can race ahead while train_hybrid is still mid-consume on a
         # partially-filled partition, deadlocking against the staleness bound.
-        # Returned flags are for update_weights_fully_async only — hybrid uses
-        # the sync update_weights path so we just discard them.
         self._wait_for_previous_eval()
         self._check_services_health()
 
-        # Sync weights to rollout via UpdateWeightFromTensor (colocate mode)
-        self.update_weights()
-        tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rollout_id))
-        dist.barrier(group=get_gloo_group())
-        self._run_step_evaluation(rollout_id, end_update_weight=True)
+        if self._hybrid_async_weight_sync:
+            send_tag = self._next_hybrid_send_tag()
+            # Isolated snapshot for this push, decoupled from the "actor" tag so
+            # the next iteration's backup("actor") can't race a still-in-flight
+            # broadcast reading this buffer.
+            self.weights_backuper.copy(src_tag="actor", dst_tag=send_tag)
 
-        # On the final training step the rollout component has already exited
-        # its main loop, so the eval just triggered above will not be awaited
-        # anywhere. Block until it finishes; otherwise the controller's atexit
-        # shutdown races with eval and tears down the SGLang engines mid-flight.
-        if is_train_done:
-            self._wait_for_previous_eval()
+            def _push_and_notify(rid=rollout_id, tag=send_tag):
+                self._hybrid_send_tag_active = tag
+                run(self.checkpoint_engine_client.update_weights_for_rollout(rollout_only=True))
+                tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rid))
+                dist.barrier(group=get_gloo_group())
+                self._run_step_evaluation(rid, end_update_weight=True)
+
+            self._pending_hybrid_sync_future = self._hybrid_sync_executor.submit(_push_and_notify)
+
+            if is_train_done:
+                # No next iteration to overlap with. Join now so the
+                # controller's atexit shutdown doesn't race the in-flight
+                # push/eval against SGLang engine teardown.
+                self._join_pending_hybrid_weight_sync()
+                self._wait_for_previous_eval()
+        else:
+            # Push weights to rollout via DCS, reading the "actor" CPU snapshot
+            # tag (see _create_checkpoint_engine_client).
+            run(self.checkpoint_engine_client.update_weights_for_rollout(rollout_only=True))
+            tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rollout_id))
+            dist.barrier(group=get_gloo_group())
+            self._run_step_evaluation(rollout_id, end_update_weight=True)
+
+            # On the final training step the rollout component has already
+            # exited its main loop, so the eval just triggered above will not
+            # be awaited anywhere. Block until it finishes; otherwise the
+            # controller's atexit shutdown races with eval and tears down the
+            # SGLang engines mid-flight.
+            if is_train_done:
+                self._wait_for_previous_eval()
 
     def train_async(self, rollout_id) -> None:
         if self.args.use_routing_replay:

--- a/relax/backends/megatron/data.py
+++ b/relax/backends/megatron/data.py
@@ -541,6 +541,20 @@ def get_batch(
                     multimodal_data[key] = torch.cat(tensor_list, dim=0)
                 multimodal_num_items[key] = [t.size(0) for t in tensor_list]
 
+        # Pin so the H2D copy in move_tensors_to_device (called once per microbatch in
+        # forward_step, right before this data feeds the model) can go non_blocking instead
+        # of forcing the GPU to wait on a synchronous pageable-memory copy of pixel tensors.
+        # Off by default (--pin-multimodal-h2d-copy); move_tensors_to_device's non_blocking=True
+        # is a silent no-op on unpinned tensors, so leaving this off reproduces the prior
+        # synchronous-copy behavior exactly.
+        if getattr(get_args(), "pin_multimodal_h2d_copy", False):
+            multimodal_data = {
+                key: tensor.pin_memory()
+                if isinstance(tensor, torch.Tensor) and tensor.device.type == "cpu"
+                else tensor
+                for key, tensor in multimodal_data.items()
+            }
+
         batch["multimodal_train_inputs"] = multimodal_data
         batch["multimodal_num_items"] = multimodal_num_items
 
@@ -1246,13 +1260,17 @@ def move_tensors_to_device(data, device):
     """Recursively move tensors in a (nested) dict/list to the specified
     device.
 
-    Non-tensor values are left unchanged.
+    Non-tensor values are left unchanged. non_blocking is safe to set
+    unconditionally: it only takes effect for tensors already in pinned
+    memory (e.g. multimodal_train_inputs, see the pin_memory() call above)
+    and is a silent no-op (still a synchronous copy) for regular pageable
+    tensors such as tokens/loss_masks.
     """
     if isinstance(data, dict):
         return {k: move_tensors_to_device(v, device) for k, v in data.items()}
     elif isinstance(data, list):
         return [move_tensors_to_device(v, device) for v in data]
     elif isinstance(data, torch.Tensor):
-        return data.to(device)
+        return data.to(device, non_blocking=True)
     else:
         return data  # e.g., int, str, None, etc.

--- a/relax/components/actor.py
+++ b/relax/components/actor.py
@@ -7,10 +7,10 @@ from argparse import Namespace
 from typing import Any, Dict, Optional
 
 import ray
-import transfer_queue as tq
 from fastapi import FastAPI
 from ray import serve
 
+import transfer_queue as tq
 from relax.components.base import Base
 from relax.distributed.ray.placement_group import allocate_train_group
 from relax.engine.sft.runtime import is_sft_mode, sft_partition_id, sft_task_name
@@ -79,8 +79,10 @@ class Actor(Base):
         self.rollout_manager = rollout_manager
         self.actor_model.set_rollout_manager(self.rollout_manager)
 
-        # Call update_weights when weight_updater exists (sync colocate or hybrid mode).
-        # In pure fully_async mode weight_updater is not created and weights are synced via DCS.
+        # Call update_weights when weight_updater exists (sync colocate mode only).
+        # In fully_async mode (including hybrid, which forces fully_async=True)
+        # weight_updater is not created and weights are synced via DCS instead —
+        # the first push happens lazily on the first real train step.
         # SFT: skip the init-time weight sync. SFT only sync weights to SGLang
         # right before periodic predict (gated in `train_actor`); between
         # predicts SGLang stays fully offloaded. Sync-at-init would leave
@@ -88,7 +90,7 @@ class Actor(Base):
         # the first predict-step `onload_weights` to crash on a non-idempotent
         # `set.remove`. NCCL group setup is lazy — `connect_rollout_engines`
         # fires on the first real `update_weights` instead.
-        if (not self.config.fully_async or self.config.hybrid) and not is_sft_mode(self.config):
+        if not self.config.fully_async and not is_sft_mode(self.config):
             self.actor_model.update_weights()
 
     def set_genrm_manager(self, genrm_manager: Any) -> None:

--- a/relax/distributed/checkpoint_service/backends/device_direct.py
+++ b/relax/distributed/checkpoint_service/backends/device_direct.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 import socket
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
@@ -72,6 +72,7 @@ class DeviceDirectBackend(CommBackend):
         coordinator_url=None,
         lock: Any = None,
         timeout_seconds: int = 300,
+        weights_getter: Optional[Callable[[], Mapping[str, torch.Tensor]]] = None,
     ) -> None:
         """Initialize DeviceDirectBackend.
 
@@ -85,6 +86,11 @@ class DeviceDirectBackend(CommBackend):
             coordinator_url: URL of the coordinator service
             lock: Remote lock for coordinating weight updates
             timeout_seconds: Operation timeout (default 300)
+            weights_getter: Optional override for the weight source used by
+                ``update_weights_for_rollout``. Defaults to reading the live
+                model directly via ``named_params_and_buffers``; callers that
+                need to push a decoupled snapshot (e.g. hybrid mode's
+                TensorBackuper tag) pass this instead.
         """
         super().__init__(backend_type, role_info)
         self.args = args
@@ -96,6 +102,7 @@ class DeviceDirectBackend(CommBackend):
         self.coordinator_url = coordinator_url
         self.lock = lock
         self.timeout_seconds = timeout_seconds
+        self._weights_getter = weights_getter
         self.device = next(model[0].parameters()).device if model else device_utils.current_device()
 
         self._comm_stream: Optional[Any] = None  # CUDA stream
@@ -125,6 +132,36 @@ class DeviceDirectBackend(CommBackend):
             from relax.backends.megatron.weight_update.bridge_converter import BridgeConverter
 
             self._bridge_converter = BridgeConverter(args=args, model=model, quantization_config=quantization_config)
+
+    def _named_params_and_buffers(self):
+        """Weight source for ``update_weights_for_rollout``.
+
+        Defaults to reading the live model directly; ``weights_getter``
+        overrides this with a decoupled snapshot (e.g. hybrid mode's
+        TensorBackuper tag) when the caller cannot safely read live params at
+        push time. That snapshot lives on host memory, but all_gather_param and
+        the NCCL/GLOO broadcast below require device tensors, so coerce here
+        (mirrors UpdateWeightFromTensor's equivalent H2D copy for its CUDA-IPC
+        push). ``tensor.to(device)`` returns a brand-new Tensor object, which
+        drops the tensor_model_parallel/partition_dim/etc. attributes
+        TensorBackuper attached to the CPU snapshot — copy them onto the device
+        copy too, same as Megatron's own copy_tensor_model_parallel_attributes
+        does after any such reallocation.
+        """
+        if self._weights_getter is not None:
+            from megatron.core.tensor_parallel import copy_tensor_model_parallel_attributes
+
+            result = []
+            for name, tensor in self._weights_getter().items():
+                if tensor.device != self.device:
+                    moved = tensor.to(self.device)
+                    copy_tensor_model_parallel_attributes(moved, tensor)
+                    if hasattr(tensor, "parallel_mode"):
+                        moved.parallel_mode = tensor.parallel_mode
+                    tensor = moved
+                result.append((name, tensor))
+            return result
+        return named_params_and_buffers(self.args, self.model)
 
     @staticmethod
     def _rollout_topology_signature_of(rollout_topology: Dict[Any, Dict[str, Any]]) -> frozenset:
@@ -535,7 +572,7 @@ class DeviceDirectBackend(CommBackend):
         # non expert params
         pbar = tqdm(desc=f"[{self._group_name}] Update weights") if self._is_pp_src_rank else None
 
-        for name, param in named_params_and_buffers(self.args, self.model):
+        for name, param in self._named_params_and_buffers():
             if ".experts." in name:
                 continue
             buffer_size = self._update_weight_from_distributed(
@@ -560,7 +597,7 @@ class DeviceDirectBackend(CommBackend):
 
         buffer_size = 0
         named_tensors = []
-        for name, param in named_params_and_buffers(self.args, self.model):
+        for name, param in self._named_params_and_buffers():
             if ".experts." not in name:
                 continue
             buffer_size = self._update_expert_weight_from_distributed(

--- a/relax/distributed/checkpoint_service/client/engine.py
+++ b/relax/distributed/checkpoint_service/client/engine.py
@@ -13,9 +13,11 @@ Provides:
 
 import asyncio
 import time
+from collections.abc import Callable, Mapping
 from typing import Any, Dict, Optional, Sequence
 
 import httpx
+import torch
 
 from relax.distributed.checkpoint_service.backends import CommBackend, DeviceDirectBackend
 from relax.distributed.checkpoint_service.config import BackendType, DCSConfig, RoleInfo
@@ -59,6 +61,7 @@ class CheckpointEngineClient:
         model_name: Optional[str] = None,
         quantization_config: Optional[Dict[str, int | str | list[str]]] = None,
         lock: Any = None,
+        weights_getter: Optional[Callable[[], Mapping[str, torch.Tensor]]] = None,
     ):
         """Initialize checkpoint engine client.
 
@@ -77,6 +80,10 @@ class CheckpointEngineClient:
             model_name (Optional[str]): Model name (e.g., "qwen3-4B"). Default: None
             quantization_config (Optional[Dict]): Quantization configuration. Default: None
             lock :
+            weights_getter: Optional override for the weight source used when
+                pushing to rollout. Defaults to reading the live model
+                directly; callers that must push a decoupled snapshot (e.g.
+                hybrid mode's TensorBackuper tag) pass this instead.
         """
         self.coordinator_url = coordinator_url.rstrip("/")
         self.config = config or DCSConfig()
@@ -97,6 +104,7 @@ class CheckpointEngineClient:
         self.model_name = model_name
         self.quantization_config = quantization_config
         self.lock = lock
+        self.weights_getter = weights_getter
 
         # State
         self._registered = False
@@ -250,6 +258,7 @@ class CheckpointEngineClient:
                 quantization_config=self.quantization_config,
                 coordinator_url=self.coordinator_url,
                 lock=lock,
+                weights_getter=self.weights_getter,
             )
 
     async def init_process_groups_for_actor_fwd_ref(self, rollout_id: int) -> None:

--- a/relax/engine/rollout/sglang_rollout.py
+++ b/relax/engine/rollout/sglang_rollout.py
@@ -270,9 +270,17 @@ async def generate(
         sample.multimodal_inputs.get(k) for k in ("images", "videos", "audio")
     )
     if state.processor and _has_media:
-        processor_prompt_ids, sample.multimodal_train_inputs, _t_image_processor = await _run_image_processor(
-            state, args, sample.prompt, sample.multimodal_inputs
-        )
+        pre_encoded = getattr(sample, "_pre_encoded_image", None)
+        if pre_encoded is not None:
+            processor_prompt_ids, sample.multimodal_train_inputs = pre_encoded
+            _t_image_processor = getattr(sample, "_pre_encoded_image_elapsed", 0.0)
+            del sample._pre_encoded_image
+            if hasattr(sample, "_pre_encoded_image_elapsed"):
+                del sample._pre_encoded_image_elapsed
+        else:
+            processor_prompt_ids, sample.multimodal_train_inputs, _t_image_processor = await _run_image_processor(
+                state, args, sample.prompt, sample.multimodal_inputs
+            )
     else:
         processor_prompt_ids = tokenizer_prompt_ids
 
@@ -558,9 +566,22 @@ async def generate_and_rm_group(
     first_mm = getattr(group[0], "multimodal_inputs", None)
     if first_mm is not None and all(getattr(s, "multimodal_inputs", None) is first_mm for s in group[1:]):
         encoded_mm, t_enc = await _encode_multimodal_inputs(first_mm)
+
+        pre_train_inputs = None
+        if (
+            getattr(args, "dedup_multimodal_preprocess", False)
+            and state.processor
+            and any(first_mm.get(k) for k in ("images", "videos", "audio"))
+        ):
+            pre_prompt_ids, mm_train_inputs, t_img = await _run_image_processor(state, args, group[0].prompt, first_mm)
+            pre_train_inputs = (pre_prompt_ids, mm_train_inputs)
+
         for sample in group:
             sample._pre_encoded_mm = encoded_mm
             sample._pre_encoded_mm_elapsed = t_enc
+            if pre_train_inputs is not None:
+                sample._pre_encoded_image = pre_train_inputs
+                sample._pre_encoded_image_elapsed = t_img
 
     tasks = []
     for idx, sample in enumerate(group):

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -86,6 +86,20 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--hybrid-async-weight-sync",
+                action="store_true",
+                default=False,
+                help=(
+                    "Hybrid mode only: push the actor->rollout DCS weight sync in a background "
+                    "thread, joined at the top of the next iteration's push instead of blocking "
+                    "immediately. Opt-in and off by default: measured as no faster than the "
+                    "synchronous push on 2xH20 (the DCS push's H2D copy + TP all-gather + NCCL "
+                    "broadcast still run on the actor's own GPU and contend with the next step's "
+                    "compute either way), see exps/hybrid_async_perf_h20/README.md. Ignored when "
+                    "--disable-weights-backuper or --keep-old-actor is set."
+                ),
+            )
+            parser.add_argument(
                 "--checkpoint-engine-backend",
                 type=str,
                 default=device_utils.get_dist_backend(),
@@ -1031,6 +1045,31 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=False,
                 help="Whether to process the audio in the video or not.",
             )
+            parser.add_argument(
+                "--dedup-multimodal-preprocess",
+                action="store_true",
+                default=False,
+                help=(
+                    "Rollout-side optimization: when every sample in a prompt group shares the "
+                    "same multimodal_inputs object, run the image processor once per group "
+                    "instead of once per sample (n_samples_per_prompt calls otherwise), caching "
+                    "the result on each sample as _pre_encoded_image. Off by default; validated "
+                    "correct (20/20 rollout_ids, non-degenerate reward/loss) but without a "
+                    "quantified before/after timing comparison yet."
+                ),
+            )
+            parser.add_argument(
+                "--pin-multimodal-h2d-copy",
+                action="store_true",
+                default=False,
+                help=(
+                    "Pin multimodal_train_inputs CPU tensors in get_batch() so the H2D copy in "
+                    "move_tensors_to_device (called once per microbatch in forward_step) can go "
+                    "non_blocking instead of a synchronous pageable-memory copy of pixel tensors. "
+                    "Off by default; validated correct but without a quantified before/after "
+                    "timing comparison yet."
+                ),
+            )
             # Multimodal data processing parameters
             parser.add_argument(
                 "--image-max-token-num",
@@ -1098,7 +1137,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--mm-processor-pool-size",
                 type=int,
-                default=0,
+                default=1024,
                 help=(
                     "Size of the multimodal processor pool. "
                     "0 (default) disables the processor pool and uses ThreadPoolExecutor instead. "

--- a/relax/utils/training/tensor_backper.py
+++ b/relax/utils/training/tensor_backper.py
@@ -12,6 +12,12 @@ _SourceGetter = Callable[[], Iterable[tuple[str, torch.Tensor]]]
 _NON_BLOCKING = device_utils.use_non_blocking_copy()
 _PIN_MEMORY = device_utils.use_pinned_host_memory()
 
+# Megatron attaches these as plain Python attributes on live nn.Parameter
+# objects (not part of the tensor's storage), so torch.empty_like() alone
+# drops them. Consumers that TP-gather from a backed-up snapshot instead of
+# the live model (e.g. DCS's all_gather_param) need them preserved.
+_MEGATRON_TP_ATTRS = ("tensor_model_parallel", "partition_dim", "partition_stride", "parallel_mode")
+
 
 class TensorBackuper(ABC):
     @staticmethod
@@ -59,10 +65,25 @@ class _TensorBackuperNormal(TensorBackuper):
 
     @torch.no_grad()
     def backup(self, tag: str) -> None:
+        from megatron.core.tensor_parallel import set_defaults_if_not_set_tensor_model_parallel_attributes
+
         backup_dict = self._backups[tag]
         for name, param in self._source_getter():
             if name not in backup_dict:
-                backup_dict[name] = torch.empty_like(param, device=torch.device("cpu"), pin_memory=_PIN_MEMORY)
+                snapshot = torch.empty_like(param, device=torch.device("cpu"), pin_memory=_PIN_MEMORY)
+                for attr in _MEGATRON_TP_ATTRS:
+                    if hasattr(param, attr):
+                        setattr(snapshot, attr, getattr(param, attr))
+                # Some params (e.g. this model's word_embeddings under bridge
+                # mode) aren't explicitly marked at model-construction time and
+                # only get backfilled with Megatron's own "not parallel"
+                # defaults later (see set_defaults_if_not_set_tensor_model_parallel_attributes
+                # callers) — apply the same backfill here so downstream
+                # TP-gather (e.g. DCS's all_gather_param) can rely on the
+                # attributes always being present, same contract Megatron
+                # itself guarantees for the live model.
+                set_defaults_if_not_set_tensor_model_parallel_attributes(snapshot)
+                backup_dict[name] = snapshot
             backup_dict[name].copy_(param.detach(), non_blocking=_NON_BLOCKING)
         device_utils.synchronize()
 

--- a/scripts/models/qwen3-0.6B.sh
+++ b/scripts/models/qwen3-0.6B.sh
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+MODEL_ARGS=(
+   --swiglu
+   --num-layers 28
+   --hidden-size 1024
+   --ffn-hidden-size 3072
+   --num-attention-heads 16
+   --group-query-attention
+   --num-query-groups 8
+   --use-rotary-position-embeddings
+   --disable-bias-linear
+   --normalization "RMSNorm"
+   --norm-epsilon 1e-6
+   --rotary-base 1000000
+   --vocab-size 151936
+   --kv-channels 128
+   --qk-layernorm
+)

--- a/scripts/training/multimodal/run-qwen3-vl-2b-1xgpu-openr1mm-colocate.sh
+++ b/scripts/training/multimodal/run-qwen3-vl-2b-1xgpu-openr1mm-colocate.sh
@@ -1,0 +1,131 @@
+set -ex
+set -o pipefail
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Auto-source local environment when not launched via an external entrypoint
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-vl-2B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/colocate_openr1mm_1gpu}"
+EXP_DIR="${EXP_DIR:-${SCRIPT_DIR}/../../../exps}"
+MODEL_DIR="${MODEL_DIR:-${SCRIPT_DIR}/../../../model}"
+DATA_DIR="${DATA_DIR:-${SCRIPT_DIR}/../../../data}"
+NUM_ROLLOUT="${NUM_ROLLOUT:=20}"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint ${MODEL_DIR}/Qwen3-VL-2B-Instruct
+   --ref-load ${MODEL_DIR}/Qwen3-VL-2B-Instruct
+   --megatron-to-hf-mode bridge
+   --warm-hf-checkpoint-page-cache
+   --save ${EXP_DIR}/Qwen3-VL-2B-Instruct_mcore_1xgpu/
+   --save-interval 100
+   --max-actor-ckpt-to-keep 1
+)
+
+PROMPT_SET=${DATA_DIR}/multimodal-open-r1-8k-verified/data/train-00000-of-00001-converted.parquet
+
+SYSTEM_PROMPT="A conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think><answer> answer here </answer>"
+
+ROLLOUT_ARGS=(
+   --prompt-data ${PROMPT_SET}
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type openr1mm
+   --num-rollout ${NUM_ROLLOUT}
+   --rollout-batch-size 8
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 2048
+   --rollout-max-prompt-len 1024
+   --rollout-max-context-len 3072
+   --rollout-temperature 0.8
+   --global-batch-size 32
+   --multimodal-keys '{"image":"image"}'
+   --system-prompt "${SYSTEM_PROMPT}"
+)
+
+# Colocate: TP=1 PP=1 CP=1 on the single GPU.
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --calculate-per-token-loss
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+   --no-rope-fusion
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --kl-coef 0.00
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --clip-grad 1.0
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   --use-clearml
+   --tb-project-name ${PROJECT_NAME}
+   --tb-experiment-name qwen3-vl-2b-GRPO-gpu1-colocate-${now}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.6
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+     --runtime-env-json="${RUNTIME_ENV_JSON}" \
+     -- python3 -m relax.entrypoints.train \
+     --resource '{"actor": [1, 1], "rollout": [1, 1]}'\
+     --max-staleness 0 \
+     --num-data-storage-units 1 \
+     --colocate \
+     --offload \
+     --use-health-check \
+     --balance-data \
+     "${MODEL_ARGS[@]}" \
+     "${CKPT_ARGS[@]}" \
+     "${ROLLOUT_ARGS[@]}" \
+     "${OPTIMIZER_ARGS[@]}" \
+     "${GRPO_ARGS[@]}" \
+     "${WANDB_ARGS[@]}" \
+     "${PERF_ARGS[@]}" \
+     "${SGLANG_ARGS[@]}" \
+     "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-vl-2b-GRPO-gpu1-colocate-${now}.log

--- a/scripts/training/multimodal/run-qwen3-vl-2b-2xgpu-openr1mm-hybrid-async.sh
+++ b/scripts/training/multimodal/run-qwen3-vl-2b-2xgpu-openr1mm-hybrid-async.sh
@@ -1,0 +1,131 @@
+set -ex
+set -o pipefail
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Auto-source local environment when not launched via an external entrypoint
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-vl-2B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/hybrid_openr1mm_2gpu}"
+EXP_DIR="${EXP_DIR:-${SCRIPT_DIR}/../../../exps}"
+MODEL_DIR="${MODEL_DIR:-${SCRIPT_DIR}/../../../model}"
+DATA_DIR="${DATA_DIR:-${SCRIPT_DIR}/../../../data}"
+NUM_ROLLOUT="${NUM_ROLLOUT:=20}"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint ${MODEL_DIR}/Qwen3-VL-2B-Instruct
+   --ref-load ${MODEL_DIR}/Qwen3-VL-2B-Instruct
+   --megatron-to-hf-mode bridge
+   --warm-hf-checkpoint-page-cache
+   --save ${EXP_DIR}/Qwen3-VL-2B-Instruct_mcore_2xgpu/
+   --save-interval 100
+   --max-actor-ckpt-to-keep 1
+)
+
+PROMPT_SET=${DATA_DIR}/multimodal-open-r1-8k-verified/data/train-00000-of-00001-converted.parquet
+
+SYSTEM_PROMPT="A conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think><answer> answer here </answer>"
+
+ROLLOUT_ARGS=(
+   --prompt-data ${PROMPT_SET}
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type openr1mm
+   --num-rollout ${NUM_ROLLOUT}
+   --rollout-batch-size 8
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 2048
+   --rollout-max-prompt-len 1024
+   --rollout-max-context-len 3072
+   --rollout-temperature 0.8
+   --global-batch-size 32
+   --multimodal-keys '{"image":"image"}'
+   --system-prompt "${SYSTEM_PROMPT}"
+   --use-streaming-dataset
+)
+
+# Same per-GPU config as the 1xGPU colocate baseline: TP=1 PP=1 CP=1.
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --calculate-per-token-loss
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+   --no-rope-fusion
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --kl-coef 0.00
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --clip-grad 1.0
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   --use-clearml
+   --tb-project-name ${PROJECT_NAME}
+   --tb-experiment-name qwen3-vl-2b-GRPO-gpu2-hybrid-async-${now}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.6
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+     --runtime-env-json="${RUNTIME_ENV_JSON}" \
+     -- python3 -m relax.entrypoints.train \
+     --resource '{"actor": [1, 1], "rollout": [1, 1]}'\
+     --max-staleness 2 \
+     --num-data-storage-units 1 \
+     --num-iters-per-train-update 2 \
+     --balance-data \
+     --hybrid \
+     "${MODEL_ARGS[@]}" \
+     "${CKPT_ARGS[@]}" \
+     "${ROLLOUT_ARGS[@]}" \
+     "${OPTIMIZER_ARGS[@]}" \
+     "${GRPO_ARGS[@]}" \
+     "${WANDB_ARGS[@]}" \
+     "${PERF_ARGS[@]}" \
+     "${SGLANG_ARGS[@]}" \
+     "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-vl-2b-GRPO-gpu2-hybrid-async-${now}.log

--- a/scripts/training/multimodal/run-qwen3-vl-4B-2xgpu-openr1mm-hybrid-async.sh
+++ b/scripts/training/multimodal/run-qwen3-vl-4B-2xgpu-openr1mm-hybrid-async.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3-VL-4B 2xGPU hybrid-async multimodal validation script (H20, 96GB/GPU).
+# Adapted from the Qwen3-VL-2B hybrid-async recipe for a larger model, running
+# with flash attention (no unfused/full-recompute workarounds needed given the
+# memory headroom on H20).
+#
+# Usage:
+#   bash scripts/training/multimodal/run-qwen3-vl-4B-2xgpu-openr1mm-hybrid-async.sh
+
+set -ex
+set -o pipefail
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Auto-source local environment when not launched via an external entrypoint
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-vl-4B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/hybrid_openr1mm_2gpu_4b}"
+EXP_DIR="${EXP_DIR:-${SCRIPT_DIR}/../../../exps}"
+MODEL_DIR="${MODEL_DIR:-${SCRIPT_DIR}/../../../model}"
+DATA_DIR="${DATA_DIR:-${SCRIPT_DIR}/../../../data}"
+NUM_ROLLOUT="${NUM_ROLLOUT:=30}"
+
+CKPT_ARGS=(
+   --hf-checkpoint ${MODEL_DIR}/Qwen3-VL-4B-Instruct
+   --ref-load ${MODEL_DIR}/Qwen3-VL-4B-Instruct
+   --megatron-to-hf-mode bridge
+   --warm-hf-checkpoint-page-cache
+)
+
+PROMPT_SET=${DATA_DIR}/multimodal-open-r1-8k-verified/data/train-00000-of-00001-converted.parquet
+
+SYSTEM_PROMPT="A conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think><answer> answer here </answer>"
+
+ROLLOUT_ARGS=(
+   --prompt-data ${PROMPT_SET}
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type openr1mm
+   --num-rollout ${NUM_ROLLOUT}
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 4096
+   --rollout-max-prompt-len 2048
+   --rollout-max-context-len 6144
+   --rollout-temperature 0.8
+   --global-batch-size 64
+   --multimodal-keys '{"image":"image"}'
+   --system-prompt "${SYSTEM_PROMPT}"
+   --use-streaming-dataset
+)
+
+# Single GPU per role: TP=1 PP=1 CP=1. H20 has 96GB so flash-attn + no forced
+# recompute is used (avoids the unfused-attention/full-recompute workarounds
+# that were needed on the memory-constrained RTX 5090 test run).
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --calculate-per-token-loss
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 6144
+   --no-rope-fusion
+   --recompute-granularity selective
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --kl-coef 0.00
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --clip-grad 1.0
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   --use-clearml
+   --tb-project-name ${PROJECT_NAME}
+   --tb-experiment-name qwen3-vl-4b-GRPO-gpu2-hybrid-async-${now}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.6
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend auto
+)
+
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+   ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 -m relax.entrypoints.train \
+   --resource '{"actor": [1, 1], "rollout": [1, 1]}'\
+   --max-staleness 2 \
+   --num-data-storage-units 1 \
+   --num-iters-per-train-update 1 \
+   --balance-data \
+   --hybrid \
+    "${MODEL_ARGS[@]}" \
+    "${CKPT_ARGS[@]}" \
+    "${ROLLOUT_ARGS[@]}" \
+    "${OPTIMIZER_ARGS[@]}" \
+    "${GRPO_ARGS[@]}" \
+    "${WANDB_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
+    "${SGLANG_ARGS[@]}" \
+    "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-vl-4b-GRPO-gpu2-hybrid-async-${now}.log


### PR DESCRIPTION
## 概述

本 PR 针对 GitHub issue #21「Hybrid-Async 多模态性能」,在 2×H20(Qwen3-VL-4B,`--hybrid` 模式)上完成了权重同步/训练流水线的性能验证,修复了一个文档描述与实际代码行为不一致的 bug,并把此前验证过的一项性能尝试(DCS push 异步化)保留为默认关闭的开关,而不是直接删除。

## 背景

Hybrid 模式下,actor 与 rollout 使用独立 GPU,actor 内部通过 `TensorBackuper` + `_switch_model` 在 `actor`/`ref`/`teacher` 等 tag 间切换权重完成 forward,训练完成后需要把最新权重推送给 rollout。`docs/en/guide/hybrid-training.md` 的 "Next Steps" 记录了两个待办:

1. 用 DCS(NCCL/GLOO 广播)替换旧的 CUDA-IPC `UpdateWeightFromTensor` 推送
2. 让 `--num-iters-per-train-update` 真正把训练步拆成多次,和 TransferQueue 数据消费形成流水线

本 PR 是对这两项的完整验证与收尾。

## 做了什么

### 1. 多模态预处理去重 + pin memory 异步 H2D 拷贝(新增开关,默认关闭)

- **去重预处理**(`--dedup-multimodal-preprocess`,默认 `False`):开启后,rollout 侧同一个 prompt group 内的 `n_samples_per_prompt` 份样本共享同一张图片时,只跑一次 `_run_image_processor()`,结果缓存在 `_pre_encoded_image`/`_pre_encoded_image_elapsed` 上给其余样本复用,省掉 `n_samples_per_prompt - 1` 份重复的 HF processor 调用(`relax/engine/rollout/sglang_rollout.py`)。
- **pin memory + non_blocking H2D**(`--pin-multimodal-h2d-copy`,默认 `False`):开启后,`get_batch()` 组装 `multimodal_train_inputs` 时对 CPU tensor 做 `pin_memory()`,配合 `move_tensors_to_device()` 里恒定的 `non_blocking=True` 拷贝,避免 `forward_step()` 每个 microbatch 都同步阻塞等 pixel tensor 从 pageable memory 搬到 GPU(`relax/backends/megatron/data.py`)。关闭时 `non_blocking=True` 对未 pin 的 tensor 是安全的 no-op,等价于原来的同步拷贝。

### 2. DCS 权重同步

把 hybrid 模式的权重推送从 CUDA-IPC 换成和纯 fully-async 共用的 DCS(`checkpoint_engine_client.update_weights_for_rollout`)广播机制。
### 3. 在hybrid模式下实现 `--num-iters-per-train-update` 功能

`train_hybrid` 的 Phase 3现在会把完整 batch 重新切分成 `num_iters_per_train_update` 份,复用 `get_data_iterator`/`train()` 已有的多步训练机制,让每一份都作为独立的 `optimizer.step()` 训练,和 Phase 1 用了几个 forward 子批次完全解耦。`num_iters_per_train_update=1`(默认值)行为与改动前完全一致。


### 4. DCS push 异步化

DCS push 改成异步处理 + 双缓冲 CPU snapshot， 使用--hybrid-async-weight-sync`,默认关闭

## 改动影响

- 新增参数 `--dedup-multimodal-preprocess`、`--pin-multimodal-h2d-copy`,均默认 `False`。不传这两个 flag 时,`relax/engine/rollout/sglang_rollout.py` `relax/backends/megatron/data.py`和这次改动之前完全一致;
- 新增参数 `--hybrid-async-weight-sync` 默认 `False`,不传这个 flag 的所有现有脚本/流程,权重推送仍然是同步调用,和这次改动之前一致。
- 改动范围:`relax/backends/megatron/actor.py`、`relax/backends/megatron/data.py`、`relax/engine/rollout/sglang_rollout.py`、`relax/utils/arguments.py`。
- `--num-iters-per-train-update` 的行为变化:仅对 `--hybrid` 模式生效;默认值 1 时行为不变,设为 >1 时会真正拆分训练步。
- 四项改动均已在 `tests/backends/megatron/test_data_vpp.py`、`tests/utils/test_arguments_opd_teacher_colocate.py`、`tests/engine/rollout/test_sglang_rollout_diagnostics.py` 等(20/20 通过)和 2×H20 30 步测试上验证,详见 `exps/hybrid_async_perf_h20/README.md`。


## 测试

scripts/training/multimodal/run-qwen3-vl-4B-2xgpu-openr1mm-hybrid-async.sh

在一台 H20 * 2 主机上运行
baseline1
<img width="7170" height="3582" alt="train (2)" src="https://github.com/user-attachments/assets/cf6b7a87-3ed3-40a1-a1cf-2b1dea7c4f7e" />
<img width="7170" height="3582" alt="perf (2)" src="https://github.com/user-attachments/assets/118924c8-1df4-45e4-8824-21d2a98480e2" />
baseline2
<img width="7170" height="3582" alt="train (3)" src="https://github.com/user-attachments/assets/3978b45e-088c-4294-ae7e-35d877c9a548" />
<img width="7170" height="3582" alt="perf (1)" src="https://github.com/user-attachments/assets/fa072dac-1d28-41f5-8781-3d02f68321ca" />
optimized1
<img width="7170" height="3582" alt="train (4)" src="https://github.com/user-attachments/assets/25cd904b-e3dc-4295-89dc-0d32817dfe96" />
<img width="7170" height="3582" alt="perf (3)" src="https://github.com/user-attachments/assets/ff9c8b24-1210-490e-9b3b-a1aef5d41209" />
optimized2
<img width="7170" height="3582" alt="train (5)" src="https://github.com/user-attachments/assets/fd147202-83aa-4412-95ff-44dc7ee37b08" />
<img width="7170" height="3582" alt="perf (4)" src="https://github.com/user-attachments/assets/b7a8d978-1375-4c8a-b68a-1992b364b402" />
