### PR TITLE
[Task 24] Make Qwen3-VL SGLang router policy configurable

### DIFF
--- a/scripts/tools/benchmark_sglang_router_policy.py
+++ b/scripts/tools/benchmark_sglang_router_policy.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Inspect SGLang routing with eight CPU-only mock workers.
+
+By default each policy receives 64 prompt groups with 8 samples per group,
+matching the 512-request shape of the Qwen3-VL training entry. Requests in a
+group share the same token prefix, so the placement difference is observable
+without loading a model. This is a routing diagnostic, not a GPU performance
+benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import concurrent.futures
+import contextlib
+import http.client
+import importlib.metadata
+import importlib.util
+import json
+import os
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SUPPORTED_POLICIES = ("cache_aware", "round_robin")
+
+
+def router_available() -> bool:
+    try:
+        return importlib.util.find_spec("sglang_router.launch_router") is not None
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+
+def _router_version() -> str | None:
+    try:
+        return importlib.metadata.version("sglang-router")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def _port_is_open(port: int, timeout: float = 0.2) -> bool:
+    with socket.socket() as sock:
+        sock.settimeout(timeout)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _request_json(port: int, method: str, path: str, payload: Any | None, timeout: float) -> tuple[int, Any]:
+    body = _json_bytes(payload) if payload is not None else None
+    headers = {"content-type": "application/json"} if body is not None else {}
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+    try:
+        connection.request(method, path, body=body, headers=headers)
+        response = connection.getresponse()
+        raw = response.read()
+        if not raw:
+            value = None
+        else:
+            try:
+                value = json.loads(raw)
+            except json.JSONDecodeError:
+                value = raw.decode("utf-8", errors="replace")
+        return response.status, value
+    finally:
+        connection.close()
+
+
+class RequestRecorder:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._records: list[dict[str, Any]] = []
+
+    def add(self, record: dict[str, Any]) -> None:
+        with self._lock:
+            self._records.append(record)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [dict(record) for record in self._records]
+
+
+class _MockHTTPServer(ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+    request_queue_size = 1024
+
+
+def _make_handler(worker_index: int, recorder: RequestRecorder):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _reply(self, status: int, value: Any) -> None:
+            body = _json_bytes(value)
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path in {
+                "/health",
+                "/health_generate",
+                "/get_model_info",
+                "/get_server_info",
+                "/model_info",
+                "/v1/models",
+            }:
+                self._reply(200, {"status": "ok", "worker_index": worker_index})
+            else:
+                self._reply(404, {"error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path.rstrip("/") != "/generate":
+                self._reply(404, {"error": "not found"})
+                return
+            try:
+                size = int(self.headers.get("content-length", "0"))
+                request = json.loads(self.rfile.read(size) or b"{}")
+                rid = request["rid"]
+                input_ids = request["input_ids"]
+                if not isinstance(rid, str) or not isinstance(input_ids, list) or not input_ids:
+                    raise ValueError("rid and non-empty input_ids are required")
+                group_index = int(input_ids[0]) - 1000
+            except Exception as exc:
+                self._reply(400, {"error": f"{type(exc).__name__}: {exc}"})
+                return
+
+            recorder.add({"rid": rid, "group_index": group_index, "worker_index": worker_index})
+            self._reply(
+                200,
+                {
+                    "rid": rid,
+                    "text": "",
+                    "output_ids": [worker_index],
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                    "_task24_mock_worker": worker_index,
+                },
+            )
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+class MockWorkerPool:
+    """Own all mock worker threads and listening sockets."""
+
+    def __init__(self, workers: int, recorder: RequestRecorder | None = None) -> None:
+        if workers <= 0:
+            raise ValueError("workers must be greater than zero")
+        self.workers = workers
+        self.recorder = recorder or RequestRecorder()
+        self.servers: list[_MockHTTPServer] = []
+        self.threads: list[threading.Thread] = []
+        self.ports: list[int] = []
+        self._closed = False
+
+    def start(self) -> "MockWorkerPool":
+        if self.servers or self._closed:
+            raise RuntimeError("mock worker pool cannot be started twice")
+        try:
+            for worker_index in range(self.workers):
+                server = _MockHTTPServer(("127.0.0.1", 0), _make_handler(worker_index, self.recorder))
+                thread = threading.Thread(
+                    target=server.serve_forever,
+                    name=f"task24-mock-worker-{worker_index}",
+                    daemon=True,
+                )
+                self.servers.append(server)
+                self.threads.append(thread)
+                self.ports.append(int(server.server_address[1]))
+                thread.start()
+        except Exception:
+            self.stop()
+            raise
+        return self
+
+    @property
+    def urls(self) -> list[str]:
+        return [f"http://127.0.0.1:{port}" for port in self.ports]
+
+    def stop(self) -> None:
+        if self._closed:
+            return
+        for server, thread in zip(self.servers, self.threads, strict=True):
+            if thread.is_alive():
+                server.shutdown()
+        for server in self.servers:
+            server.server_close()
+        for thread in self.threads:
+            thread.join(timeout=5)
+        self._closed = True
+        if any(thread.is_alive() for thread in self.threads):
+            raise RuntimeError("a mock worker thread did not stop")
+
+    @property
+    def stopped(self) -> bool:
+        return (
+            self._closed
+            and all(not thread.is_alive() for thread in self.threads)
+            and all(not _port_is_open(port) for port in self.ports)
+        )
+
+    def __enter__(self) -> "MockWorkerPool":
+        return self.start()
+
+    def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        self.stop()
+
+
+class RouterProcess:
+    """Own one real SGLang router and its process group."""
+
+    def __init__(
+        self,
+        policy: str,
+        worker_urls: Sequence[str],
+        *,
+        balance_abs_threshold: int,
+        balance_rel_threshold: float,
+    ) -> None:
+        self.policy = policy
+        self.worker_urls = list(worker_urls)
+        self.balance_abs_threshold = balance_abs_threshold
+        self.balance_rel_threshold = balance_rel_threshold
+        self.port = _free_port()
+        self.process: subprocess.Popen[str] | None = None
+        self.log = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+        self._closed = False
+
+    def start(self) -> None:
+        command = [
+            sys.executable,
+            "-m",
+            "sglang_router.launch_router",
+            "--worker-urls",
+            *self.worker_urls,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(self.port),
+            "--policy",
+            self.policy,
+            "--balance-abs-threshold",
+            str(self.balance_abs_threshold),
+            "--balance-rel-threshold",
+            str(self.balance_rel_threshold),
+            "--retry-max-retries",
+            "1",
+            "--log-level",
+            "warn",
+            "--disable-health-check",
+        ]
+        self.process = subprocess.Popen(
+            command,
+            stdout=self.log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=(os.name != "nt"),
+        )
+
+    def _log_tail(self) -> str:
+        self.log.flush()
+        self.log.seek(0)
+        return self.log.read()[-4000:]
+
+    def wait_ready(self, expected_workers: int, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            assert self.process is not None
+            if self.process.poll() is not None:
+                raise RuntimeError(f"router exited with {self.process.returncode}: {self._log_tail()}")
+            try:
+                health_status, _ = _request_json(self.port, "GET", "/health", None, 0.5)
+                workers_status, value = _request_json(self.port, "GET", "/workers", None, 0.5)
+                registered = value.get("workers") if isinstance(value, dict) else None
+                if health_status == 200 and workers_status == 200 and len(registered or []) == expected_workers:
+                    time.sleep(0.1)
+                    return
+            except (ConnectionError, OSError, TimeoutError):
+                pass
+            time.sleep(0.05)
+        raise RuntimeError(f"router was not ready within {timeout}s: {self._log_tail()}")
+
+    def stop(self) -> None:
+        if self._closed:
+            return
+        process = self.process
+        if process is not None and process.poll() is None:
+            if os.name == "nt":
+                process.terminate()
+            else:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                if os.name == "nt":
+                    process.kill()
+                else:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+        elif process is not None:
+            process.wait()
+        self.log.close()
+        self._closed = True
+
+    @property
+    def stopped(self) -> bool:
+        return (
+            self._closed
+            and self.process is not None
+            and self.process.poll() is not None
+            and not _port_is_open(self.port)
+        )
+
+
+def _one_request(port: int, group_index: int, sample_index: int, timeout: float) -> dict[str, Any]:
+    rid = f"g{group_index:03d}-s{sample_index:02d}"
+    payload = {
+        "rid": rid,
+        "input_ids": [group_index + 1000, 42, 43, 44],
+        "sampling_params": {"max_new_tokens": 1},
+    }
+    status, response = _request_json(port, "POST", "/generate", payload, timeout)
+    if status != 200:
+        raise RuntimeError(f"HTTP {status}: {response}")
+    if not isinstance(response, dict) or response.get("rid") != rid:
+        raise ValueError(f"invalid response: {response!r}")
+    worker_index = response.get("_task24_mock_worker")
+    if not isinstance(worker_index, int):
+        raise ValueError("response did not identify a mock worker")
+    return {"rid": rid, "group_index": group_index, "worker_index": worker_index}
+
+
+def _send_workload(
+    port: int,
+    groups: int,
+    samples_per_group: int,
+    concurrency: int,
+    timeout: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]], float]:
+    jobs = [(group, sample) for group in range(groups) for sample in range(samples_per_group)]
+    completed: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    started = time.monotonic()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(concurrency, len(jobs))) as executor:
+        futures = {
+            executor.submit(_one_request, port, group, sample, timeout): (group, sample) for group, sample in jobs
+        }
+        for future in concurrent.futures.as_completed(futures):
+            group, sample = futures[future]
+            rid = f"g{group:03d}-s{sample:02d}"
+            try:
+                completed.append(future.result())
+            except Exception as exc:
+                failures.append({"rid": rid, "error": f"{type(exc).__name__}: {exc}"})
+    return completed, sorted(failures, key=lambda item: item["rid"]), time.monotonic() - started
+
+
+def _summarize(
+    policy: str,
+    groups: int,
+    samples_per_group: int,
+    workers: int,
+    completed: list[dict[str, Any]],
+    failures: list[dict[str, str]],
+    observations: list[dict[str, Any]],
+    elapsed_s: float,
+) -> dict[str, Any]:
+    expected = {f"g{group:03d}-s{sample:02d}": group for group in range(groups) for sample in range(samples_per_group)}
+    by_rid: dict[str, list[dict[str, Any]]] = collections.defaultdict(list)
+    for record in observations:
+        by_rid[str(record.get("rid"))].append(record)
+    completed_by_rid = {record["rid"]: record for record in completed}
+
+    missing = sorted(set(expected) - set(by_rid))
+    unexpected = sorted(set(by_rid) - set(expected))
+    duplicates = sorted(rid for rid, records in by_rid.items() if len(records) != 1)
+    integrity_errors: list[str] = []
+    worker_counts = [0] * workers
+    group_counts: collections.Counter[int] = collections.Counter()
+    group_workers: dict[int, set[int]] = collections.defaultdict(set)
+    for rid, expected_group in expected.items():
+        records = by_rid.get(rid, [])
+        if len(records) != 1:
+            continue
+        record = records[0]
+        worker = record.get("worker_index")
+        group = record.get("group_index")
+        if group != expected_group or not isinstance(worker, int) or not 0 <= worker < workers:
+            integrity_errors.append(f"{rid}: group={group}, worker={worker}")
+            continue
+        response = completed_by_rid.get(rid)
+        if response is None or response.get("worker_index") != worker:
+            integrity_errors.append(f"{rid}: response/observation worker mismatch")
+            continue
+        worker_counts[worker] += 1
+        group_counts[group] += 1
+        group_workers[group].add(worker)
+
+    spread = collections.Counter(len(group_workers[group]) for group in range(groups))
+    complete_groups = sum(group_counts[group] == samples_per_group for group in range(groups))
+    expected_requests = groups * samples_per_group
+    complete = (
+        not failures
+        and len(completed) == expected_requests
+        and len(completed_by_rid) == expected_requests
+        and len(observations) == expected_requests
+        and not missing
+        and not unexpected
+        and not duplicates
+        and not integrity_errors
+        and complete_groups == groups
+    )
+    mean = statistics.fmean(worker_counts)
+    worker_cv = statistics.pstdev(worker_counts) / mean if mean else 0.0
+    return {
+        "policy": policy,
+        "groups": groups,
+        "samples_per_group": samples_per_group,
+        "expected_requests": expected_requests,
+        "completed_requests": len(completed),
+        "failed_requests": len(failures),
+        "complete_groups": complete_groups,
+        "elapsed_s": elapsed_s,
+        "request_count_per_worker": {str(index): count for index, count in enumerate(worker_counts)},
+        "request_count_cv": worker_cv,
+        "workers_per_group": {str(width): count for width, count in sorted(spread.items())},
+        "missing_rids": missing[:20],
+        "unexpected_rids": unexpected[:20],
+        "duplicate_rids": duplicates[:20],
+        "integrity_errors": integrity_errors[:20],
+        "failures": failures[:20],
+        "complete": complete,
+    }
+
+
+def run_policy(
+    policy: str,
+    *,
+    groups: int = 64,
+    samples_per_group: int = 8,
+    workers: int = 8,
+    concurrency: int = 512,
+    balance_abs_threshold: int = 10,
+    balance_rel_threshold: float = 1.2,
+    startup_timeout: float = 20.0,
+    request_timeout: float = 20.0,
+) -> dict[str, Any]:
+    if policy not in SUPPORTED_POLICIES:
+        raise ValueError(f"unsupported policy: {policy}")
+    values = (groups, samples_per_group, workers, concurrency, startup_timeout, request_timeout)
+    if any(value <= 0 for value in values):
+        raise ValueError("workload sizes, concurrency, and timeouts must be greater than zero")
+    if not router_available():
+        raise RuntimeError("sglang_router is not installed; run this tool in the Relax runtime image")
+
+    recorder = RequestRecorder()
+    pool = MockWorkerPool(workers, recorder)
+    router: RouterProcess | None = None
+    try:
+        pool.start()
+        router = RouterProcess(
+            policy,
+            pool.urls,
+            balance_abs_threshold=balance_abs_threshold,
+            balance_rel_threshold=balance_rel_threshold,
+        )
+        router.start()
+        router.wait_ready(workers, startup_timeout)
+        completed, failures, elapsed_s = _send_workload(
+            router.port, groups, samples_per_group, concurrency, request_timeout
+        )
+        result = _summarize(
+            policy,
+            groups,
+            samples_per_group,
+            workers,
+            completed,
+            failures,
+            recorder.snapshot(),
+            elapsed_s,
+        )
+    finally:
+        try:
+            if router is not None:
+                router.stop()
+        finally:
+            pool.stop()
+
+    cleanup = {
+        "router_stopped": router is not None and router.stopped,
+        "workers_stopped": pool.stopped,
+        "router_port": router.port if router is not None else None,
+        "worker_ports": list(pool.ports),
+    }
+    result["cleanup"] = cleanup
+    result["complete"] = bool(result["complete"] and cleanup["router_stopped"] and cleanup["workers_stopped"])
+    return result
+
+
+def run_benchmark(
+    policies: Sequence[str],
+    *,
+    groups: int = 64,
+    samples_per_group: int = 8,
+    workers: int = 8,
+    concurrency: int = 512,
+    balance_abs_threshold: int = 10,
+    balance_rel_threshold: float = 1.2,
+    startup_timeout: float = 20.0,
+    request_timeout: float = 20.0,
+) -> dict[str, Any]:
+    if not policies:
+        raise ValueError("at least one policy is required")
+    runs = [
+        run_policy(
+            policy,
+            groups=groups,
+            samples_per_group=samples_per_group,
+            workers=workers,
+            concurrency=concurrency,
+            balance_abs_threshold=balance_abs_threshold,
+            balance_rel_threshold=balance_rel_threshold,
+            startup_timeout=startup_timeout,
+            request_timeout=request_timeout,
+        )
+        for policy in policies
+    ]
+    return {
+        "router_version": _router_version(),
+        "policies": list(policies),
+        "workers": workers,
+        "groups": groups,
+        "samples_per_group": samples_per_group,
+        "requests_per_policy": groups * samples_per_group,
+        "runs": runs,
+        "complete": all(run["complete"] for run in runs),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--policy",
+        action="append",
+        choices=SUPPORTED_POLICIES,
+        dest="policies",
+        help="policy to run; repeat for both (default: both)",
+    )
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--groups", type=int, default=64)
+    parser.add_argument("--samples-per-group", type=int, default=8)
+    parser.add_argument("--concurrency", type=int, default=512)
+    parser.add_argument("--balance-abs-threshold", type=int, default=10)
+    parser.add_argument("--balance-rel-threshold", type=float, default=1.2)
+    parser.add_argument("--startup-timeout", type=float, default=20.0)
+    parser.add_argument("--request-timeout", type=float, default=20.0)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    positive = (
+        args.workers,
+        args.groups,
+        args.samples_per_group,
+        args.concurrency,
+        args.startup_timeout,
+        args.request_timeout,
+    )
+    if any(value <= 0 for value in positive):
+        parser.error("workload sizes, concurrency, and timeouts must be greater than zero")
+    try:
+        result = run_benchmark(
+            args.policies or SUPPORTED_POLICIES,
+            groups=args.groups,
+            samples_per_group=args.samples_per_group,
+            workers=args.workers,
+            concurrency=args.concurrency,
+            balance_abs_threshold=args.balance_abs_threshold,
+            balance_rel_threshold=args.balance_rel_threshold,
+            startup_timeout=args.startup_timeout,
+            request_timeout=args.request_timeout,
+        )
+    except Exception as exc:
+        print(f"benchmark failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if result["complete"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh
+++ b/scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh
@@ -14,6 +14,15 @@ now=$(date "+%Y-%m-%d-%H:%M:%S")
 echo "当前时间: $now"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SGLANG_ROUTER_POLICY="${SGLANG_ROUTER_POLICY:-cache_aware}"
+case "${SGLANG_ROUTER_POLICY}" in
+    cache_aware|round_robin) ;;
+    *)
+        echo "SGLANG_ROUTER_POLICY must be cache_aware or round_robin, got: ${SGLANG_ROUTER_POLICY}" >&2
+        exit 2
+        ;;
+esac
+
 # Auto-source local environment when not launched via an external entrypoint
 if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
     source "${SCRIPT_DIR}/../../entrypoint/local.sh"
@@ -102,6 +111,7 @@ OPTIMIZER_ARGS=(
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 1
    --sglang-mem-fraction-static 0.8
+   --sglang-router-policy "${SGLANG_ROUTER_POLICY}"
 )
 
 WANDB_ARGS=(
@@ -141,4 +151,5 @@ ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
    "${WANDB_ARGS[@]}" \
    "${PERF_ARGS[@]}" \
    "${SGLANG_ARGS[@]}" \
-   "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-vl-4b-GRPO-gpu8-${now}.log
+   "${MISC_ARGS[@]}" \
+   "$@" 2>&1 | tee log/qwen3-vl-4b-GRPO-gpu8-${now}.log

--- a/tests/tools/test_benchmark_sglang_router_policy.py
+++ b/tests/tools/test_benchmark_sglang_router_policy.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import importlib.util
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "tools" / "benchmark_sglang_router_policy.py"
+_ENTRY_PATH = _REPO_ROOT / "scripts" / "training" / "multimodal" / "run-qwen3-vl-4B-8xgpu.sh"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("benchmark_sglang_router_policy", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = _load_module()
+
+
+def _port_is_open(port: int) -> bool:
+    with socket.socket() as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _run_entry_script(tmp_path, *, policy=None, extra_args=()):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ray = fake_bin / "ray"
+    fake_ray.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "with open(os.environ['TASK24_RAY_ARGS_FILE'], 'w', encoding='utf-8') as stream:\n"
+        "    json.dump(sys.argv[1:], stream)\n",
+        encoding="utf-8",
+    )
+    fake_ray.chmod(0o755)
+
+    model_config_dir = tmp_path / "model-config"
+    model_config_dir.mkdir()
+    (model_config_dir / "qwen3-vl-4B.sh").write_text("MODEL_ARGS=()\n", encoding="utf-8")
+
+    args_file = tmp_path / "ray-args.json"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "EXP_DIR": str(tmp_path / "exp"),
+            "MODEL_CONFIG_DIR": str(model_config_dir),
+            "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+            "RELAX_ENTRYPOINT_MODE": "1",
+            "RUNTIME_ENV_JSON": "{}",
+            "TASK24_RAY_ARGS_FILE": str(args_file),
+        }
+    )
+    if policy is None:
+        environment.pop("SGLANG_ROUTER_POLICY", None)
+    else:
+        environment["SGLANG_ROUTER_POLICY"] = policy
+
+    result = subprocess.run(
+        ["bash", str(_ENTRY_PATH), *extra_args],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    args = json.loads(args_file.read_text(encoding="utf-8")) if args_file.exists() else []
+    return result, args
+
+
+def test_default_workload_matches_rollout_shape():
+    args = benchmark.build_parser().parse_args([])
+    assert args.workers == 8
+    assert args.groups == 64
+    assert args.samples_per_group == 8
+    assert args.concurrency == 512
+    assert args.groups * args.samples_per_group == 512
+    assert args.policies is None
+
+
+def test_parser_rejects_unknown_policy():
+    with pytest.raises(SystemExit, match="2"):
+        benchmark.build_parser().parse_args(["--policy", "least_busy"])
+
+
+def test_entry_script_rejects_unknown_policy_before_setup():
+    if shutil.which("bash") is None:
+        pytest.skip("bash is not available")
+    environment = os.environ.copy()
+    environment["SGLANG_ROUTER_POLICY"] = "least_busy"
+    result = subprocess.run(
+        ["bash", str(_ENTRY_PATH)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert "SGLANG_ROUTER_POLICY must be cache_aware or round_robin" in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash is not available")
+def test_entry_script_defaults_to_cache_aware(tmp_path):
+    result, args = _run_entry_script(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    policy_index = args.index("--sglang-router-policy")
+    assert args[policy_index + 1] == "cache_aware"
+    assert args.count("--sglang-router-policy") == 1
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash is not available")
+def test_entry_script_forwards_round_robin_and_extra_args(tmp_path):
+    extra_args = ["--rollout-seed", "7", "--sglang-enable-deterministic-inference"]
+    result, args = _run_entry_script(tmp_path, policy="round_robin", extra_args=extra_args)
+
+    assert result.returncode == 0, result.stderr
+    policy_index = args.index("--sglang-router-policy")
+    assert args[policy_index + 1] == "round_robin"
+    assert args.count("--sglang-router-policy") == 1
+    assert args[-len(extra_args) :] == extra_args
+
+
+def test_mock_workers_are_closed_when_context_exits_with_error():
+    pool = benchmark.MockWorkerPool(2)
+    with pytest.raises(RuntimeError, match="stop now"):
+        with pool:
+            ports = list(pool.ports)
+            for port in ports:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=1) as response:
+                    assert response.status == 200
+            raise RuntimeError("stop now")
+
+    assert pool.stopped
+    assert all(not thread.is_alive() for thread in pool.threads)
+    assert all(not _port_is_open(port) for port in ports)
+
+
+def test_worker_cleanup_runs_when_router_cleanup_raises(monkeypatch):
+    events = []
+
+    class FakeRecorder:
+        def snapshot(self):
+            return []
+
+    class FakePool:
+        def __init__(self, _workers, _recorder):
+            self.urls = ["http://127.0.0.1:1"]
+            self.ports = []
+            self.stopped = False
+
+        def start(self):
+            return self
+
+        def stop(self):
+            events.append("workers")
+            self.stopped = True
+
+    class FakeRouter:
+        def __init__(self, *_args, **_kwargs):
+            self.port = 1
+            self.stopped = False
+
+        def start(self):
+            return None
+
+        def wait_ready(self, _workers, _timeout):
+            return None
+
+        def stop(self):
+            events.append("router")
+            raise RuntimeError("router cleanup failed")
+
+    monkeypatch.setattr(benchmark, "router_available", lambda: True)
+    monkeypatch.setattr(benchmark, "RequestRecorder", FakeRecorder)
+    monkeypatch.setattr(benchmark, "MockWorkerPool", FakePool)
+    monkeypatch.setattr(benchmark, "RouterProcess", FakeRouter)
+    monkeypatch.setattr(benchmark, "_send_workload", lambda *_args: ([], [], 0.0))
+    monkeypatch.setattr(
+        benchmark,
+        "_summarize",
+        lambda *_args: {"complete": True},
+    )
+
+    with pytest.raises(RuntimeError, match="router cleanup failed"):
+        benchmark.run_policy("cache_aware", groups=1, samples_per_group=1, workers=1, concurrency=1)
+
+    assert events == ["router", "workers"]
+
+
+@pytest.mark.skipif(not benchmark.router_available(), reason="sglang_router is not installed")
+def test_real_router_runs_both_policies_and_leaves_no_listeners():
+    result = benchmark.run_benchmark(
+        ["cache_aware", "round_robin"],
+        groups=8,
+        samples_per_group=8,
+        workers=8,
+        concurrency=64,
+    )
+
+    assert result["complete"]
+    assert [run["policy"] for run in result["runs"]] == ["cache_aware", "round_robin"]
+    for run in result["runs"]:
+        assert run["expected_requests"] == 64
+        assert run["completed_requests"] == 64
+        assert run["failed_requests"] == 0
+        assert run["complete_groups"] == 8
+        assert sum(run["request_count_per_worker"].values()) == 64
+        assert run["cleanup"]["router_stopped"]
+        assert run["cleanup"]["workers_stopped"]
+        ports = [run["cleanup"]["router_port"], *run["cleanup"]["worker_ports"]]
+        assert all(not _port_is_open(port) for port in ports)
+
+    round_robin = result["runs"][1]
+    assert list(round_robin["request_count_per_worker"].values()) == [8] * 8


### PR DESCRIPTION
#### Summary

Closes #147

这次我们给 Qwen3-VL 8 卡 colocate 训练入口增加了可显式选择的 SGLang Router policy，并保留 `cache_aware` 作为默认值。需要对比请求分配策略时，可以通过 `SGLANG_ROUTER_POLICY=round_robin` 开启实验策略；不设置这个环境变量时，原有启动方式和行为不变。

我们同时补了一个 CPU mock worker 路由诊断工具，使用 8 个 worker 和 64 × 8 的请求形状检查两种 policy 的请求分配、512 个请求的完整性、异常处理和退出清理。

正式实验按 A1 → B1 → B2 → A2 的顺序进行，baseline 和实验各运行两次，seed 分别为 42、43。每次运行 35 steps，前 5 steps 用于预热，固定统计 5–14、15–24、25–34 三个窗口。

#### Changes

- `scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh`
  - 新增 `SGLANG_ROUTER_POLICY` 环境变量。
  - 默认值为 `cache_aware`。
  - 只接受 `cache_aware` 和 `round_robin`，其他值在环境初始化前退出。
  - 将最终值传给 `--sglang-router-policy`。
  - 保留调用方附加参数的 `"$@"` 透传。
- `scripts/tools/benchmark_sglang_router_policy.py`
  - 使用真实 SGLang Router 和 8 个 CPU mock worker 比较两种 policy。
  - 默认生成 64 组、每组 8 个请求，共 512 个请求。
  - 检查缺失、重复、失败请求以及 Router/worker/监听端口清理。
- `tests/tools/test_benchmark_sglang_router_policy.py`
  - 覆盖默认值、显式切换、非法值、额外参数透传、异常清理和真实 Router 两种 policy。

#### Verification

固定环境：

- baseline commit：`c95f580cda01362fddb5a16f0fdbb461345c9b8e`
- image：`ghcr.io/redai-infra/relaxrl@sha256:3fa8ce578acda6c829b83016bde42c38fa892681e4f36ca330f545616fe578e2`
- hardware：8 × NVIDIA A100-SXM4-80GB，MIG disabled
- workload：Qwen3-VL-4B、64 prompts/step、8 samples/prompt、512 samples/step
- VLM embedding cache：关闭
- 正式性能实验：未启用 profiler

CPU 测试：

```text
tests/tools/test_benchmark_sglang_router_policy.py
8 passed in 7.89s
```

`py_compile`、shell syntax、Ruff 0.15.9 check/format 和 `git diff --check` 均通过。

正式实验主指标：

| seed | `cache_aware` samples/s | `round_robin` samples/s | 变化 |
| ---: | ---: | ---: | ---: |
| 42 | 1.22756 | 1.24527 | +1.4434% |
| 43 | 1.25410 | 1.26406 | +0.7942% |
| 两组均值 | 1.24083 | 1.25467 | +1.1154% |

三个固定窗口：

| rollout IDs | `cache_aware` samples/s | `round_robin` samples/s | 变化 |
| --- | ---: | ---: | ---: |
| 5–14 | 1.23563 | 1.24988 | +1.1537% |
| 15–24 | 1.21881 | 1.23977 | +1.7191% |
| 25–34 | 1.26975 | 1.27610 | +0.5000% |

工作量与 token throughput：

| seed | response-token 工作量比 | response-token/s 变化 |
| ---: | ---: | ---: |
| 42 | 0.97706 | -0.8834% |
| 43 | 0.95825 | -3.4137% |

GPU、显存和阶段占比：

| arm | 平均 GPU 利用率 | 峰值显存 | rollout/wait 时间占比 | train 时间占比 |
| --- | ---: | ---: | ---: | ---: |
| `task24-a1-ca-s42` | 89.581% | 70.122 GiB | 75.790% | 24.210% |
| `task24-b1-rr-s42` | 92.885% | 69.511 GiB | 75.600% | 24.400% |
| `task24-b2-rr-s43` | 91.729% | 69.466 GiB | 76.780% | 23.220% |
| `task24-a2-ca-s43` | 88.611% | 70.120 GiB | 76.510% | 23.490% |

模型切换相关子计时：

| arm | sleep | wake_up | update_weights |
| --- | ---: | ---: | ---: |
| `task24-a1-ca-s42` | 163.229s | 97.743s | 143.483s |
| `task24-b1-rr-s42` | 172.973s | 107.852s | 130.117s |
| `task24-b2-rr-s43` | 164.159s | 95.711s | 135.521s |
| `task24-a2-ca-s43` | 166.471s | 99.898s | 131.865s |

四次运行均完成 35/35 steps，逐 step 样本数均为 512。loss、reward、KL 和 grad norm 均为有限值；未出现 OOM、NaN/Inf、silent fallback 或丢样本。每臂结束后，我们都检查了 Ray、Router、SGLang、容器、网络和 GPU 计算进程，没有发现 Task24 残留。

完整逐 step 曲线、CSV、指标说明和 SHA256 manifest 已随 Issue 实验结果提供：

- [完整实验报告](https://github.com/huxy1225-cloud/Relax/blob/5e81fe36c116faae8a126a893928cb795bf14d79/task24-results/TASK24_PERFORMANCE_REPORT.md)
- [公开实验材料与 SHA256 清单](https://github.com/huxy1225-cloud/Relax/tree/5e81fe36c116faae8a126a893928cb795bf14d79/task24-results)

![逐 step 吞吐曲线](https://raw.githubusercontent.com/huxy1225-cloud/Relax/5e81fe36c116faae8a126a893928cb795bf14d79/task24-results/throughput_curves.png)

![GPU 与阶段指标](https://raw.githubusercontent.com/huxy1225-cloud/Relax/5e81fe36c116faae8a126a893928cb795bf14d79/task24-results/gpu_and_phase.png)

![模型切换子计时](https://raw.githubusercontent.com/huxy1225-cloud/Relax/5e81fe36c116faae8a126a893928cb795bf14d79/task24-results/switching_overhead.png)

复现命令模板：

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
NUM_GPUS=8 \
NUM_ROLLOUT=35 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
SGLANG_ROUTER_POLICY=cache_aware \
bash scripts/training/multimodal/run-qwen3-vl-4B-8xgpu.sh \
  --rollout-seed 42 \
  --tb-experiment-name task24-a1-ca-s42
```

实验组只需要把 `SGLANG_ROUTER_POLICY` 改为 `round_robin` 并使用对应的实验名；第二组配对再把 seed 改为 43。

#### Risk & Rollback

- 默认行为不变，没有设置环境变量时仍使用 `cache_aware`。
- Router policy 的效果依赖实际 prompt、response length 和 cache locality 分布。
- CPU benchmark 只用于确认路由行为，性能结论来自 8 × A100 正式实验。
- 删除 `SGLANG_ROUTER_POLICY` 或将它设置回 `cache_aware` 即可回退。

#### Checklist

- [x] Diff 只包含 Task24 的 3 个必要文件
- [x] 新增和相关测试通过
- [x] 默认值、开关和回退方式已说明
- [x] baseline/实验各运行 2 次
- [x] 提供 3 个固定统计窗口
- [x] 提供吞吐、GPU 利用率、峰值显存和阶段占比
- [x] 检查 OOM、异常、丢样本和残留进程
- [x] 公开材料不含密钥、数据、checkpoint、机器绝对路径或 GPU UUID
- [ ] GitHub CI 通过
- [ ] 阻塞性 review 已逐条处理
