### PR TITLE
【No.28】feat(algorithms): add synchronous RLOO advantage estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ______________________________________________________________________
 - 🔁 **Hybrid Mode** — Separate Actor/Rollout placement groups with TransferQueue streaming, while ref / actor_fwd / advantages run in-process on the actor — pairs `--balance-data` with sub-batched forward to minimize GPU waste
 - 🤖 **Agentic RL** — Multi-turn interaction, loss masking, flexible termination, and VLM multimodal context carry-over for closed-loop "execute → observe → decide" training
 - 🔀 **Elastic Rollout Scaling** — Dynamically grow/shrink inference engines mid-training via HTTP REST API, with same-cluster (`ray_native`) and cross-cluster (`external`) federation modes
-- 🧠 **Rich Algorithm Suite** — PPO, GRPO, GSPO, SAPO, CISPO, and On-Policy Distillation out of the box, with pluggable rewards and built-in **GenRM** (LLM-as-judge) mode
+- 🧠 **Rich Algorithm Suite** — PPO, GRPO, GSPO, SAPO, CISPO, RLOO, and On-Policy Distillation out of the box, with pluggable rewards and built-in **GenRM** (LLM-as-judge) mode
 - 🚀 **Megatron + SGLang Backends** — Megatron-LM (TP/PP/CP/EP) for MoE and deep models, SGLang for high-throughput inference, DCS for NCCL-broadcast weight sync
 - 📦 **Production-Ready Ops** — HealthManager auto-recovery, centralized Metrics Service (WandB / TensorBoard / ClearML), and Apprise real-time notifications
 
@@ -98,6 +98,7 @@ ______________________________________________________________________
 | **GSPO**                   | Policy Optimization | Group-wise Sequence-level Policy Optimization     |
 | **SAPO**                   | Policy Optimization | Soft Adaptive Policy Optimization                 |
 | **CISPO**                  | Policy Optimization | Clipped Importance-ratio Soft Policy Optimization |
+| **RLOO**                   | Policy Optimization | REINFORCE Leave-One-Out                           |
 | **On-Policy Distillation** | Knowledge Transfer  | Teacher-student KL penalty distillation           |
 
 > 📖 Adding a new algorithm is straightforward — implement a service class, register it in the `ALGOS` registry, and you're done.

--- a/README_zh.md
+++ b/README_zh.md
@@ -46,7 +46,7 @@ ______________________________________________________________________
 - 🔁 **Hybrid 混合模式** — Actor 与 Rollout 独立 Placement Group + TransferQueue 流式数据，ref / actor_fwd / advantages 在 Actor 本机进程内完成；配合 `--balance-data` 与子批 forward，避免独立 ref/actor_fwd 服务的 GPU 浪费
 - 🤖 **Agentic RL** — 多轮交互、loss masking、灵活的终止条件以及 VLM 多模态上下文累积，构建"执行 → 观察 → 决策"闭环训练
 - 🔀 **Rollout 弹性扩缩容** — 通过 HTTP REST API 在训练过程中动态增减推理引擎，支持同集群（`ray_native`）和跨集群联邦（`external`）两种模式
-- 🧠 **丰富的算法矩阵** — 开箱即用的 PPO、GRPO、GSPO、SAPO、CISPO 与 On-Policy Distillation，配合可插拔奖励函数和内置 **GenRM**（LLM-as-judge）模式
+- 🧠 **丰富的算法矩阵** — 开箱即用的 PPO、GRPO、GSPO、SAPO、CISPO、RLOO 与 On-Policy Distillation，配合可插拔奖励函数和内置 **GenRM**（LLM-as-judge）模式
 - 🚀 **Megatron + SGLang 后端** — Megatron-LM（TP/PP/CP/EP）训练 MoE 和深层模型，SGLang 提供高吞吐推理，DCS 基于 NCCL 广播同步权重
 - 📦 **生产级运维** — HealthManager 自动恢复、中心化 Metrics Service（WandB / TensorBoard / ClearML）、Apprise 实时告警
 
@@ -98,6 +98,7 @@ ______________________________________________________________________
 | **GSPO**                   | 策略优化     | Group-wise Sequence-level Policy Optimization     |
 | **SAPO**                   | 策略优化     | Soft Adaptive Policy Optimization                 |
 | **CISPO**                  | 策略优化     | Clipped Importance-ratio Soft Policy Optimization |
+| **RLOO**                   | 策略优化     | REINFORCE Leave-One-Out                           |
 | **On-Policy Distillation** | 知识迁移     | 基于 KL 惩罚的师生蒸馏                            |
 
 > 📖 添加新算法非常简单 — 实现一个服务类，注册到 `ALGOS` 注册表即可。

--- a/docs/en/examples/algorithms.md
+++ b/docs/en/examples/algorithms.md
@@ -241,7 +241,17 @@ RLOO's advantages are smaller in magnitude than default GRPO's, because the grou
 
 Adam is largely invariant to a constant gradient rescale, so this is mostly *not* a reason to retune `--lr`. It does matter for `--clip-grad`, which breaks that invariance: at Megatron's default `--clip-grad 1.0`, the same run clipped **68% of steps under GRPO but only 2% under RLOO**. Revisit `--clip-grad` rather than `--lr` when switching.
 
-Everything downstream — the PPO-Clip policy loss, KL loss, TIS, DP/CP splitting — is unchanged.
+#### The loss is REINFORCE, not PPO-Clip
+
+RLOO's objective is plain REINFORCE against the leave-one-out baseline, with no trust region:
+
+$$L_i = -\operatorname{sg}(\hat{A}_i)\,\log \pi_\theta(y_i)$$
+
+This is a deliberate departure from the other group-relative estimators here, which all wrap PPO-Clip. Reusing the clipped objective would make this "GRPO with a leave-one-out baseline" rather than RLOO as published, and the clipping would bias an estimator chosen precisely for being unbiased. Consequently **`--eps-clip` and `--eps-clip-high` have no effect under RLOO**, and `train/pg_clipfrac` is always 0.
+
+Because there is no importance-ratio correction, RLOO assumes the sampling policy equals the training policy. That holds with one optimizer step per rollout; with several inner epochs the estimator becomes off-policy and the paper's guarantees no longer apply. The provided recipe keeps one step per rollout.
+
+Everything else downstream — KL loss, TIS, DP/CP splitting, the reduction — is unchanged.
 
 ### Key Parameters
 
@@ -251,7 +261,8 @@ Everything downstream — the PPO-Clip policy loss, KL loss, TIS, DP/CP splittin
 | `--n-samples-per-prompt` | `1` | Must be $\geq 2$; a group of one has no leave-one-out baseline and gets a zero advantage |
 | `--disable-rewards-normalization` | off | Leave off. This flag skips the group baseline entirely, leaving the raw reward as the advantage |
 | `--disable-grpo-std-normalization` | off | No effect under RLOO — the std branch is GRPO-family only, so there is nothing to disable |
-| `--eps-clip` | `0.2` | Clipping margin, same as GRPO |
+| `--eps-clip` | `0.2` | **No effect** — RLOO does not clip; `train/pg_clipfrac` stays 0 |
+| `--fully-async` / `--hybrid` | off | **Rejected at startup.** RLOO is synchronous-only and asynchronous RLOO was never validated |
 
 ### Quick Start
 
@@ -273,16 +284,9 @@ bash examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
 ```
 
 ::: warning
-RLOO has only been **run** in colocate (synchronous) mode. Fully-async needs at
-least two GPUs — `Controller._validate_gpu_resources` sums per-role GPU counts in
-non-colocate mode (`relax/core/controller.py:330`), and the minimum fully-async
-role set is actor + rollout — so no async run was possible on the single-GPU host
-used here.
-
-That said, RLOO is not expected to behave differently: the only code it changes on
-this axis is the group baseline inside `post_process_rewards`, which is the single
-normalization funnel for both modes (every caller reaches it through
-`convert_samples_to_train_data`). Nothing in the async path recomputes advantages.
+RLOO is **synchronous-only and enforced as such**: `--fully-async` and `--hybrid` are
+rejected at startup rather than silently allowed, because asynchronous RLOO is out of
+scope and was never validated. Use `--colocate`.
 :::
 
 ### When to Use
@@ -306,7 +310,7 @@ Against `--disable-grpo-std-normalization`, the difference is only the constant 
 | **CISPO** | Group-relative reward | Stop-gradient coefficient | Recommended KL loss |
 | **GSPO** | Group-relative reward | PPO-Clip + sequence-level KL | Sequence-level ratio |
 | **SAPO** | Group-relative reward | Sigmoid gate | Temperature-controlled |
-| **RLOO** | Leave-one-out baseline, no std scaling | PPO-Clip (hard clip) | Optional KL loss |
+| **RLOO** | Leave-one-out baseline, no std scaling | **Unclipped REINFORCE** | Optional KL loss |
 
 ## Next Steps
 

--- a/docs/en/examples/algorithms.md
+++ b/docs/en/examples/algorithms.md
@@ -2,7 +2,7 @@
 
 Relax supports multiple policy gradient algorithms, all selected via the `--advantage-estimator` flag. This document covers PPO and the primary GRPO-family algorithms (for On-Policy Distillation, see the [dedicated page](./on-policy-distillation.md)).
 
-GRPO, CISPO, GSPO, and SAPO share the same service topology, so their argument blocks can be swapped in existing scripts. PPO additionally requires a Critic model and an Advantages service; start from the [PPO training recipe](../guide/ppo-training.md) instead of only replacing `GRPO_ARGS`.
+GRPO, CISPO, GSPO, SAPO, and RLOO share the same service topology, so their argument blocks can be swapped in existing scripts. PPO additionally requires a Critic model and an Advantages service; start from the [PPO training recipe](../guide/ppo-training.md) instead of only replacing `GRPO_ARGS`.
 
 ---
 
@@ -202,6 +202,101 @@ SAPO_ARGS=(
 
 ---
 
+## RLOO
+
+RLOO (REINFORCE Leave-One-Out) keeps GRPO's group sampling but changes the baseline: each sample is scored against the mean of the **other** samples in its group rather than against the group mean including itself.
+
+Reference: [Back to Basics: Revisiting REINFORCE-Style Optimization for Learning from Human Feedback in LLMs](https://arxiv.org/abs/2402.14740).
+
+### How It Works
+
+For a group of $k$ responses to the same prompt with rewards $R_1 \dots R_k$:
+
+$$\hat{A}_i = R_i - \frac{1}{k-1}\sum_{j \neq i} R_j$$
+
+Because the baseline excludes $R_i$, it is statistically independent of the sample it evaluates, which makes the estimator unbiased. GRPO's baseline includes $R_i$, so baseline and sample are **positively** correlated ($\operatorname{Cov}(R_i, \bar{R}) = \operatorname{Var}(R)/k$). That correlation shrinks the advantage: $R_i - \bar{R}$ is exactly $\frac{k-1}{k}$ times the leave-one-out value, which is what the $k/(k-1)$ factor below undoes.
+
+The two forms are algebraically related:
+
+$$\hat{A}_i = \frac{k}{k-1}\left(R_i - \bar{R}\right)$$
+
+so RLOO is the group-centered reward rescaled by $k/(k-1)$. Two consequences follow:
+
+- **No standard-deviation scaling.** GRPO divides by the group standard deviation, which reweights groups against each other: a group whose rewards are nearly identical gets its small differences amplified. RLOO applies a single factor that does not depend on the group's spread, so groups keep their relative weight. This is the same concern Dr. GRPO raises about std normalization.
+- **Advantages still sum to zero** within each group, so the reduction and logging behaviour is identical to GRPO.
+
+#### Relationship to `--disable-grpo-std-normalization`
+
+Worth being explicit, because the two are closely related: with std normalization disabled, GRPO produces exactly $R_i - \bar{R}$, so
+
+$$\hat{A}^\text{RLOO}_i = \frac{k}{k-1}\,\hat{A}^{\text{GRPO,\,no-std}}_i$$
+
+element-wise. Relax requires every group to have exactly `--n-samples-per-prompt` samples, so $k$ is constant within a run and that factor is a **global constant**. RLOO is therefore not a different reweighting from `--disable-grpo-std-normalization`; it is that estimator with the specific constant that makes the leave-one-out baseline unbiased. Under Adam a global constant on the loss largely cancels in the update, so choose RLOO when you want the named, unbiased estimator — not in the expectation of a different gradient direction.
+
+The comparison that does differ is against **default** GRPO, which divides by the per-group std and so does reweight groups relative to each other.
+
+#### Effect on gradient clipping
+
+RLOO's advantages are smaller in magnitude than default GRPO's, because the group std for binary rewards is typically well below 1. Measured on Qwen3-0.6B / GSM8K at $k = 8$ and identical `--lr`, `train/grad_norm` averaged 0.47 for RLOO versus 1.04 for GRPO.
+
+Adam is largely invariant to a constant gradient rescale, so this is mostly *not* a reason to retune `--lr`. It does matter for `--clip-grad`, which breaks that invariance: at Megatron's default `--clip-grad 1.0`, the same run clipped **68% of steps under GRPO but only 2% under RLOO**. Revisit `--clip-grad` rather than `--lr` when switching.
+
+Everything downstream — the PPO-Clip policy loss, KL loss, TIS, DP/CP splitting — is unchanged.
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--advantage-estimator rloo` | — | Enable RLOO |
+| `--n-samples-per-prompt` | `1` | Must be $\geq 2$; a group of one has no leave-one-out baseline and gets a zero advantage |
+| `--disable-rewards-normalization` | off | Leave off. This flag skips the group baseline entirely, leaving the raw reward as the advantage |
+| `--disable-grpo-std-normalization` | off | No effect under RLOO — the std branch is GRPO-family only, so there is nothing to disable |
+| `--eps-clip` | `0.2` | Clipping margin, same as GRPO |
+
+### Quick Start
+
+Replace `GRPO_ARGS` with `RLOO_ARGS` in any GRPO script:
+
+```bash
+RLOO_ARGS=(
+   --advantage-estimator rloo
+   --eps-clip 0.2
+)
+```
+
+A complete single-GPU recipe on GSM8K is provided:
+
+```bash
+MODEL_DIR=/path/to/models \
+DATA_DIR=/path/to/data \
+bash examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+```
+
+::: warning
+RLOO has only been **run** in colocate (synchronous) mode. Fully-async needs at
+least two GPUs — `Controller._validate_gpu_resources` sums per-role GPU counts in
+non-colocate mode (`relax/core/controller.py:330`), and the minimum fully-async
+role set is actor + rollout — so no async run was possible on the single-GPU host
+used here.
+
+That said, RLOO is not expected to behave differently: the only code it changes on
+this axis is the group baseline inside `post_process_rewards`, which is the single
+normalization funnel for both modes (every caller reaches it through
+`convert_samples_to_train_data`). Nothing in the async path recomputes advantages.
+:::
+
+### When to Use
+
+Against **default** GRPO, the substantive difference is that RLOO does not divide by the per-group standard deviation:
+
+- Reward distributions where the group std is small and unstable, so dividing by it reweights groups by how uniform they happen to be rather than by how informative they are
+- Workloads where `--clip-grad` binds often under GRPO — RLOO's smaller advantage magnitudes leave more steps unclipped (see above)
+- As a named, unbiased reference point when diagnosing whether the advantage estimator is implicated in a training pathology
+
+Against `--disable-grpo-std-normalization`, the difference is only the constant $k/(k-1)$, which is what makes the leave-one-out baseline unbiased. That correction is larger for small groups ($1.33$ at $k = 4$, $1.07$ at $k = 16$), but it is still a constant, so do not expect a behavioural change from it under Adam.
+
+---
+
 ## Algorithm Comparison
 
 | Algorithm | Advantage Computation | Policy Loss | KL Constraint |
@@ -211,6 +306,7 @@ SAPO_ARGS=(
 | **CISPO** | Group-relative reward | Stop-gradient coefficient | Recommended KL loss |
 | **GSPO** | Group-relative reward | PPO-Clip + sequence-level KL | Sequence-level ratio |
 | **SAPO** | Group-relative reward | Sigmoid gate | Temperature-controlled |
+| **RLOO** | Leave-one-out baseline, no std scaling | PPO-Clip (hard clip) | Optional KL loss |
 
 ## Next Steps
 

--- a/docs/en/examples/algorithms.md
+++ b/docs/en/examples/algorithms.md
@@ -241,6 +241,15 @@ RLOO's advantages are smaller in magnitude than default GRPO's, because the grou
 
 Adam is largely invariant to a constant gradient rescale, so this is mostly *not* a reason to retune `--lr`. It does matter for `--clip-grad`, which breaks that invariance: at Megatron's default `--clip-grad 1.0`, the same run clipped **68% of steps under GRPO but only 2% under RLOO**. Revisit `--clip-grad` rather than `--lr` when switching.
 
+#### Reading the reported loss
+
+Two things about `train/pg_loss` differ from the clipped estimators and are expected rather than symptoms:
+
+- **It is routinely negative.** PPO-Clip takes a maximum of two negated terms, which biases it positive. RLOO reports `-A · log π`, and since `log π < 0` this equals `A · |log π|`; a negative mean simply says that positive-advantage tokens carry smaller `|log π|`, i.e. the model is already more confident on the responses that scored well. Measured on Qwen3-0.6B / GSM8K: `-0.026` for RLOO against `+0.045` for GRPO on the same data.
+- **It is unbounded below.** For a token with `A < 0`, minimising `-A · log π` pushes `log π` toward `-∞`; nothing caps it, because there is no trust region. This is the property clipping was introduced to remove, and it is intrinsic to unclipped REINFORCE rather than specific to this implementation. In a 60-step run it stayed well behaved (`grad_norm` 0.45, entropy 0.49, no divergence), but **watch `train/entropy_loss` and `train/grad_norm` rather than `pg_loss` for stability**, and reach for `--clip-grad` if either drifts.
+
+Relatedly, `rloo_no_signal_fraction` is worth watching from the first step. On the same run it averaged **0.48 and rose to 0.65** over 60 rollouts, reaching 1.0 on individual steps: roughly half the tokens sat in groups that scored identically and therefore contributed no gradient. That is reward saturation, visible long before the reward curve flattens.
+
 #### The loss is REINFORCE, not PPO-Clip
 
 RLOO's objective is plain REINFORCE against the leave-one-out baseline, with no trust region:

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -272,7 +272,7 @@ Recomputation parameters use native Megatron parameters. For details, refer to M
 
 | Parameter | Type | Default | Options | Description |
 |-----------|------|---------|---------|-------------|
-| `--advantage-estimator` | str | grpo | `grpo`, `gspo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `ppo`, `sapo`, `cispo` | Advantage estimator. OPD is independent of this choice; enable it with `--use-opd` and its KL/loss coefficient |
+| `--advantage-estimator` | str | grpo | `grpo`, `gspo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `ppo`, `sapo`, `cispo`, `rloo` | Advantage estimator. OPD is independent of this choice; enable it with `--use-opd` and its KL/loss coefficient |
 | `--normalize-advantages` | flag | False | - | Whether to normalize advantages |
 | `--disable-grpo-std-normalization` | flag | - | - | Disable GRPO standard deviation normalization (from [Dr.GRPO](https://arxiv.org/pdf/2503.20783)) |
 | `--disable-rewards-normalization` | flag | - | - | Disable reward normalization |

--- a/docs/zh/examples/algorithms.md
+++ b/docs/zh/examples/algorithms.md
@@ -2,7 +2,7 @@
 
 Relax 支持多种策略梯度算法，均通过 `--advantage-estimator` 参数选择。本文档覆盖 PPO 与主要 GRPO-family 算法（OPD 在线策略蒸馏请参阅[单独文档](./on-policy-distillation.md)）。
 
-GRPO、CISPO、GSPO 与 SAPO 使用相同的服务拓扑，可以直接在现有脚本中替换算法参数块。PPO 还需要 Critic 模型与 Advantages 服务，因此应从 [PPO 训练配置](../guide/ppo-training.md)开始，而不是只替换 `GRPO_ARGS`。
+GRPO、CISPO、GSPO、SAPO 与 RLOO 使用相同的服务拓扑，可以直接在现有脚本中替换算法参数块。PPO 还需要 Critic 模型与 Advantages 服务，因此应从 [PPO 训练配置](../guide/ppo-training.md)开始，而不是只替换 `GRPO_ARGS`。
 
 ---
 
@@ -202,6 +202,99 @@ SAPO_ARGS=(
 
 ---
 
+## RLOO
+
+RLOO（REINFORCE Leave-One-Out）保留 GRPO 的组内采样，但改变 baseline 的构造方式：每个样本与组内**其他**样本的均值比较，而不是与包含自身的组均值比较。
+
+参考文献：[Back to Basics: Revisiting REINFORCE-Style Optimization for Learning from Human Feedback in LLMs](https://arxiv.org/abs/2402.14740)。
+
+### 算法原理
+
+对同一 prompt 的 $k$ 条回复，奖励为 $R_1 \dots R_k$：
+
+$$\hat{A}_i = R_i - \frac{1}{k-1}\sum_{j \neq i} R_j$$
+
+由于 baseline 不含 $R_i$，它与被评估的样本统计独立，因此该估计量是无偏的。GRPO 的 baseline 包含 $R_i$，因此 baseline 与样本**正相关**（$\operatorname{Cov}(R_i, \bar{R}) = \operatorname{Var}(R)/k$）。这一相关性会收缩 advantage：$R_i - \bar{R}$ 恰好是留一法取值的 $\frac{k-1}{k}$ 倍，而下面的 $k/(k-1)$ 因子正是把它抵消回来。
+
+两种形式在代数上等价：
+
+$$\hat{A}_i = \frac{k}{k-1}\left(R_i - \bar{R}\right)$$
+
+即 RLOO 等于组内中心化奖励乘以 $k/(k-1)$。由此有两点推论：
+
+- **不做标准差缩放。** GRPO 除以组内标准差，这会让各组之间相互重新加权：奖励接近一致的组，其微小差异会被放大。RLOO 用的因子与组内离散度无关，因此各组保持原有的相对权重。这正是 Dr. GRPO 对 std 归一化提出的质疑。
+- **组内 advantage 仍然和为零**，因此 reduction 与日志行为与 GRPO 完全一致。
+
+#### 与 `--disable-grpo-std-normalization` 的关系
+
+这一点值得明说，因为两者关系很近：关闭 std 归一化后，GRPO 给出的正是 $R_i - \bar{R}$，于是
+
+$$\hat{A}^\text{RLOO}_i = \frac{k}{k-1}\,\hat{A}^{\text{GRPO,\,no-std}}_i$$
+
+逐元素成立。Relax 要求每组样本数严格等于 `--n-samples-per-prompt`，因此 $k$ 在一次运行内恒定，该因子是一个**全局常数**。也就是说，RLOO 并非与 `--disable-grpo-std-normalization` 不同的加权方式，而是该估计量配上使 leave-one-out 基线无偏的那个特定常数。在 Adam 下，loss 上的全局常数在参数更新中基本被抵消 —— 所以选 RLOO 的理由是"要那个有名字的无偏估计量"，而不是期待得到不同的梯度方向。
+
+真正有差别的比较对象是**默认的** GRPO：它除以每组各自的标准差，确实会改变各组之间的相对权重。
+
+#### 对梯度裁剪的影响
+
+RLOO 的 advantage 量级小于默认 GRPO，因为二值 reward 下组内标准差通常远小于 1。在 Qwen3-0.6B / GSM8K、$k = 8$、`--lr` 相同的实测中，`train/grad_norm` 均值 RLOO 为 0.47、GRPO 为 1.04。
+
+Adam 对梯度的常数缩放基本不敏感，所以这**基本不构成**重调 `--lr` 的理由。但它对 `--clip-grad` 有影响 —— 裁剪会破坏这种不变性：在 Megatron 默认的 `--clip-grad 1.0` 下，同一组实验里 GRPO 有 **68% 的 step 被裁剪，RLOO 只有 2%**。切换算法时应重新审视 `--clip-grad`，而不是 `--lr`。
+
+下游的 PPO-Clip 策略损失、KL loss、TIS 以及 DP/CP 切分均保持不变。
+
+### 关键参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--advantage-estimator rloo` | — | 启用 RLOO |
+| `--n-samples-per-prompt` | `1` | 必须 $\geq 2$；组内只有 1 个样本时没有 leave-one-out baseline，advantage 记为 0 |
+| `--disable-rewards-normalization` | 关闭 | 保持关闭。该开关会完全跳过组内 baseline，直接把原始 reward 当作 advantage |
+| `--disable-grpo-std-normalization` | 关闭 | 对 RLOO 无效 —— std 分支只针对 GRPO 家族，没有可禁用的对象 |
+| `--eps-clip` | `0.2` | 裁剪边距，与 GRPO 相同 |
+
+### 快速开始
+
+在任意 GRPO 脚本中把 `GRPO_ARGS` 替换为 `RLOO_ARGS`：
+
+```bash
+RLOO_ARGS=(
+   --advantage-estimator rloo
+   --eps-clip 0.2
+)
+```
+
+仓库提供了一份完整的单卡 GSM8K 配置：
+
+```bash
+MODEL_DIR=/path/to/models \
+DATA_DIR=/path/to/data \
+bash examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+```
+
+::: warning
+RLOO 目前仅在 colocate（同步）模式下**实际运行过**。fully-async 至少需要 2 张 GPU
+—— 非 colocate 模式下 `Controller._validate_gpu_resources` 会把各角色的 GPU 数求和
+（`relax/core/controller.py:330`），而 fully-async 的最小角色集是 actor + rollout ——
+因此在本次使用的单卡机器上无法进行异步实测。
+
+不过 RLOO 在这一维度上预期没有差异：它唯一改动的是 `post_process_rewards` 里的组内
+baseline，而这里是同步与异步**共用的唯一**归一化入口（所有调用方都经
+`convert_samples_to_train_data` 到达）。异步路径不会重新计算 advantage。
+:::
+
+### 适用场景
+
+与**默认** GRPO 相比，实质差异在于 RLOO 不除以每组各自的标准差：
+
+- 组内标准差小且不稳定的奖励分布 —— 此时除以它，等于按"这组恰好有多整齐"而不是"这组有多少信息量"来重新加权
+- GRPO 下 `--clip-grad` 频繁触发的场景 —— RLOO 的 advantage 量级更小，被裁剪的步数更少（见上文）
+- 排查训练异常时，作为有名字的无偏参照点，判断问题是否来自 advantage 估计器
+
+与 `--disable-grpo-std-normalization` 相比，差异只是那个常数 $k/(k-1)$，它的作用是让 leave-one-out 基线无偏。该修正在小组规模下更大（$k = 4$ 时为 $1.33$，$k = 16$ 时为 $1.07$），但它终究是常数，因此在 Adam 下不要期待由它带来行为变化。
+
+---
+
 ## 算法对比
 
 | 算法 | Advantage 计算 | 策略损失 | KL 约束方式 |
@@ -211,6 +304,7 @@ SAPO_ARGS=(
 | **CISPO** | 组相对奖励 | Stop-gradient 系数 | 推荐 KL loss |
 | **GSPO** | 组相对奖励 | PPO-Clip + 序列级 KL | 序列级 ratio |
 | **SAPO** | 组相对奖励 | Sigmoid 门控 | 温度控制 |
+| **RLOO** | Leave-one-out baseline，不做 std 缩放 | PPO-Clip（硬裁剪） | 可选 KL loss |
 
 ## 下一步
 

--- a/docs/zh/examples/algorithms.md
+++ b/docs/zh/examples/algorithms.md
@@ -241,7 +241,17 @@ RLOO 的 advantage 量级小于默认 GRPO，因为二值 reward 下组内标准
 
 Adam 对梯度的常数缩放基本不敏感，所以这**基本不构成**重调 `--lr` 的理由。但它对 `--clip-grad` 有影响 —— 裁剪会破坏这种不变性：在 Megatron 默认的 `--clip-grad 1.0` 下，同一组实验里 GRPO 有 **68% 的 step 被裁剪，RLOO 只有 2%**。切换算法时应重新审视 `--clip-grad`，而不是 `--lr`。
 
-下游的 PPO-Clip 策略损失、KL loss、TIS 以及 DP/CP 切分均保持不变。
+#### 损失是 REINFORCE，不是 PPO-Clip
+
+RLOO 的目标函数是针对 leave-one-out baseline 的原始 REINFORCE，没有信任域：
+
+$$L_i = -\operatorname{sg}(\hat{A}_i)\,\log \pi_\theta(y_i)$$
+
+这是与本页其他组相对估计器（它们都包在 PPO-Clip 外）的**有意分歧**。复用裁剪目标会让它变成「带 leave-one-out baseline 的 GRPO」而非论文里的 RLOO，而裁剪本身会给一个正是因无偏才被选用的估计器引入偏差。因此 **`--eps-clip` 与 `--eps-clip-high` 对 RLOO 无效**，`train/pg_clipfrac` 恒为 0。
+
+由于没有重要性比值校正，RLOO 假定采样策略等于训练策略。这在每轮 1 个 optimizer step 时成立；若用多个内层 epoch，估计量就变成 off-policy，论文的保证不再适用。仓库提供的 recipe 保持每轮 1 步。
+
+下游其余部分 —— KL loss、TIS、DP/CP 切分、归约 —— 均保持不变。
 
 ### 关键参数
 
@@ -251,7 +261,8 @@ Adam 对梯度的常数缩放基本不敏感，所以这**基本不构成**重�
 | `--n-samples-per-prompt` | `1` | 必须 $\geq 2$；组内只有 1 个样本时没有 leave-one-out baseline，advantage 记为 0 |
 | `--disable-rewards-normalization` | 关闭 | 保持关闭。该开关会完全跳过组内 baseline，直接把原始 reward 当作 advantage |
 | `--disable-grpo-std-normalization` | 关闭 | 对 RLOO 无效 —— std 分支只针对 GRPO 家族，没有可禁用的对象 |
-| `--eps-clip` | `0.2` | 裁剪边距，与 GRPO 相同 |
+| `--eps-clip` | `0.2` | **无效** —— RLOO 不裁剪，`train/pg_clipfrac` 恒为 0 |
+| `--fully-async` / `--hybrid` | 关闭 | **启动即拒绝。** RLOO 仅支持同步，异步从未验证 |
 
 ### 快速开始
 
@@ -273,14 +284,8 @@ bash examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
 ```
 
 ::: warning
-RLOO 目前仅在 colocate（同步）模式下**实际运行过**。fully-async 至少需要 2 张 GPU
-—— 非 colocate 模式下 `Controller._validate_gpu_resources` 会把各角色的 GPU 数求和
-（`relax/core/controller.py:330`），而 fully-async 的最小角色集是 actor + rollout ——
-因此在本次使用的单卡机器上无法进行异步实测。
-
-不过 RLOO 在这一维度上预期没有差异：它唯一改动的是 `post_process_rewards` 里的组内
-baseline，而这里是同步与异步**共用的唯一**归一化入口（所有调用方都经
-`convert_samples_to_train_data` 到达）。异步路径不会重新计算 advantage。
+RLOO **仅支持同步，且在启动时强制**：`--fully-async` 与 `--hybrid` 会被直接拒绝而非
+静默放行 —— 异步 RLOO 不在范围内且从未验证。请使用 `--colocate`。
 :::
 
 ### 适用场景
@@ -304,7 +309,7 @@ baseline，而这里是同步与异步**共用的唯一**归一化入口（所�
 | **CISPO** | 组相对奖励 | Stop-gradient 系数 | 推荐 KL loss |
 | **GSPO** | 组相对奖励 | PPO-Clip + 序列级 KL | 序列级 ratio |
 | **SAPO** | 组相对奖励 | Sigmoid 门控 | 温度控制 |
-| **RLOO** | Leave-one-out baseline，不做 std 缩放 | PPO-Clip（硬裁剪） | 可选 KL loss |
+| **RLOO** | Leave-one-out baseline，不做 std 缩放 | **无裁剪 REINFORCE** | 可选 KL loss |
 
 ## 下一步
 

--- a/docs/zh/examples/algorithms.md
+++ b/docs/zh/examples/algorithms.md
@@ -241,6 +241,15 @@ RLOO 的 advantage 量级小于默认 GRPO，因为二值 reward 下组内标准
 
 Adam 对梯度的常数缩放基本不敏感，所以这**基本不构成**重调 `--lr` 的理由。但它对 `--clip-grad` 有影响 —— 裁剪会破坏这种不变性：在 Megatron 默认的 `--clip-grad 1.0` 下，同一组实验里 GRPO 有 **68% 的 step 被裁剪，RLOO 只有 2%**。切换算法时应重新审视 `--clip-grad`，而不是 `--lr`。
 
+#### 如何读报告出来的 loss
+
+`train/pg_loss` 有两点与裁剪类估计器不同，都是预期行为而非异常：
+
+- **它经常是负数。** PPO-Clip 取两个取负项的最大值，天然偏正。RLOO 报的是 `-A · log π`，而 `log π < 0`，所以等于 `A · |log π|`；均值为负只是说明正 advantage 的 token 其 `|log π|` 更小，即模型对得分高的回复本来就更有信心。Qwen3-0.6B / GSM8K 实测：同一批数据下 RLOO 为 `-0.026`，GRPO 为 `+0.045`。
+- **它下无界。** 对 `A < 0` 的 token，最小化 `-A · log π` 会把 `log π` 推向 `-∞`，而且没有任何东西约束它 —— 因为没有信任域。这正是裁剪被引入所要消除的性质，属于无裁剪 REINFORCE 固有，而非本实现特有。60 步的实测中表现稳定（`grad_norm` 0.45、entropy 0.49、未发散），但**判断稳定性应看 `train/entropy_loss` 与 `train/grad_norm`，而不是 `pg_loss`**；两者中任一出现漂移时应启用 `--clip-grad`。
+
+与此相关，`rloo_no_signal_fraction` 值得从第一步就盯。同一组实验中它全程均值 **0.48，并在 60 个 rollout 内升到 0.65**，个别 step 达到 1.0：约一半的 token 落在全同分的组里，因而不贡献梯度。这就是 reward 饱和，而且远在 reward 曲线走平之前就能看到。
+
 #### 损失是 REINFORCE，不是 PPO-Clip
 
 RLOO 的目标函数是针对 leave-one-out baseline 的原始 REINFORCE，没有信任域：

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -272,7 +272,7 @@
 
 | 参数 | 类型 | 默认值 | 可选值 | 说明 |
 |------|------|--------|--------|------|
-| `--advantage-estimator` | str | grpo | `grpo`, `gspo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `ppo`, `sapo`, `cispo` | 优势估计器。OPD 独立于该选项，使用 `--use-opd` 及对应 KL/loss 系数启用 |
+| `--advantage-estimator` | str | grpo | `grpo`, `gspo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `ppo`, `sapo`, `cispo`, `rloo` | 优势估计器。OPD 独立于该选项，使用 `--use-opd` 及对应 KL/loss 系数启用 |
 | `--normalize-advantages` | flag | False | - | 是否归一化优势 |
 | `--disable-grpo-std-normalization` | flag | - | - | 禁用 GRPO 标准差归一化（来自 [Dr.GRPO](https://arxiv.org/pdf/2503.20783)） |
 | `--disable-rewards-normalization` | flag | - | - | 禁用 reward 归一化 |

--- a/examples/algorithms/README.md
+++ b/examples/algorithms/README.md
@@ -4,7 +4,7 @@
 
 ## 概述
 
-Relax 框架集成了多种策略梯度算法，均通过 `--advantage-estimator` 参数选择。GRPO、CISPO、GSPO 与 SAPO 共享同一套服务拓扑，可以通过替换算法参数块（`*_ARGS`）切换；PPO 还需要 Critic 与 Advantages 服务，应使用专用启动脚本。
+Relax 框架集成了多种策略梯度算法，均通过 `--advantage-estimator` 参数选择。GRPO、CISPO、GSPO、SAPO 与 RLOO 共享同一套服务拓扑，可以通过替换算法参数块（`*_ARGS`）切换；PPO 还需要 Critic 与 Advantages 服务，应使用专用启动脚本。
 
 ## 支持的算法
 
@@ -15,6 +15,7 @@ Relax 框架集成了多种策略梯度算法，均通过 `--advantage-estimator
 | **CISPO** | `--advantage-estimator cispo` | 保留梯度方向、需要更高精度 |
 | **GSPO**  | `--advantage-estimator gspo`  | 序列级约束、稳定训练       |
 | **SAPO**  | `--advantage-estimator sapo`  | 平滑优化、soft 信任域      |
+| **RLOO**  | `--advantage-estimator rloo`  | 无偏 baseline、小组规模    |
 
 ## 选择建议
 
@@ -50,11 +51,19 @@ Relax 框架集成了多种策略梯度算法，均通过 `--advantage-estimator
 - 梯度流更平滑，避免梯度突变
 - 适合对稳定性要求高的场景
 
+### RLOO（无偏 baseline）
+
+- baseline 取组内**其他** k-1 个样本的均值，与被评估样本统计独立，因此无偏
+- 不除以组内标准差，各组之间不会因离散度不同而被重新加权
+- 与 `--disable-grpo-std-normalization` 的关系：两者逐元素只差一个恒定的 `k/(k-1)`（组大小固定，故为全局常数）。RLOO 就是该估计量配上使 leave-one-out 无偏的那个常数，而非另一种加权方式
+- 适合小组规模（k=4~8），此时 GRPO 的 O(1/k) baseline 偏差最明显
+- 单卡示例：`examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh`
+
 ## 快速开始
 
 ### 基础操作：修改算法参数
 
-GRPO-like 脚本采用统一的参数块设计。要在 GRPO、CISPO、GSPO 与 SAPO 之间切换，只需修改相应 `*_ARGS` 数组：
+GRPO-like 脚本采用统一的参数块设计。要在 GRPO、CISPO、GSPO、SAPO 与 RLOO 之间切换，只需修改相应 `*_ARGS` 数组：
 
 ```bash
 # 例如：在任意训练脚本中，将 GRPO_ARGS 替换为 CISPO_ARGS
@@ -123,13 +132,13 @@ bash scripts/training/text/run-qwen3-4B-8xgpu.sh
 
 ### 通用参数
 
-| 参数                    | 默认值               | 说明                                                                                                    |
-| ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------- |
-| `--advantage-estimator` | `grpo`               | 算法类型：`grpo`, `cispo`, `gspo`, `sapo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline` |
-| `--eps-clip`            | `0.2`                | 下方裁剪边距（ratio 下界 = `1 - eps_clip`）                                                             |
-| `--eps-clip-high`       | 与 `--eps-clip` 相同 | 上方裁剪边距（ratio 上界 = `1 + eps_clip_high`）                                                        |
-| `--clip-grad`           | —                    | 梯度裁剪范数，CISPO 下推荐设为 `1.0`                                                                    |
-| `--kl-coef`             | `0.0`                | KL 惩罚系数；当前同步 PPO 会将非零值重置为 `0.0`，REINFORCE++ 等算法可使用                              |
+| 参数                    | 默认值               | 说明                                                                                                            |
+| ----------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `--advantage-estimator` | `grpo`               | 算法类型：`grpo`, `cispo`, `gspo`, `sapo`, `rloo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline` |
+| `--eps-clip`            | `0.2`                | 下方裁剪边距（ratio 下界 = `1 - eps_clip`）                                                                     |
+| `--eps-clip-high`       | 与 `--eps-clip` 相同 | 上方裁剪边距（ratio 上界 = `1 + eps_clip_high`）                                                                |
+| `--clip-grad`           | —                    | 梯度裁剪范数，CISPO 下推荐设为 `1.0`                                                                            |
+| `--kl-coef`             | `0.0`                | KL 惩罚系数；当前同步 PPO 会将非零值重置为 `0.0`，REINFORCE++ 等算法可使用                                      |
 
 ### CISPO 专用参数
 
@@ -194,7 +203,23 @@ GSPO_ARGS=(
 
 **为什么**：GSPO 使用序列级 KL，序列内 token 约束一致，减少长序列训练的振荡。
 
-### 3. 异步 vs 同步模式选择
+### 3. RLOO：保持 reward normalization 开启
+
+```bash
+RLOO_ARGS=(
+   --advantage-estimator rloo
+   --eps-clip 0.2
+)
+```
+
+**为什么**：
+
+- leave-one-out baseline 由 reward normalization 这一步构造，`--disable-rewards-normalization` 会跳过它，使 RLOO 退化为原始 REINFORCE
+- `--disable-grpo-std-normalization` 对 RLOO 无效；std 分支只针对 GRPO 家族，无需额外关闭
+- `--n-samples-per-prompt` 必须 ≥ 2，组内只有 1 个样本时没有 baseline，advantage 记为 0
+- RLOO 的 advantage 量级小于默认 GRPO。Adam 对常数缩放基本不敏感，因此不必因此改 `--lr`；但要重新审视 `--clip-grad` —— 实测在默认 `--clip-grad 1.0` 下，GRPO 有 68% 的 step 触发裁剪，RLOO 只有 2%
+
+### 4. 异步 vs 同步模式选择
 
 - **Fully Async**（`--fully-async`）：
 
@@ -212,6 +237,7 @@ GSPO_ARGS=(
 examples/algorithms/
 ├── README.md                              (本文件)
 ├── run-qwen35-9B-8xgpu-openr1mm-cispo-async.sh    (CISPO 多模态示例)
+├── run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh             (RLOO 单卡示例)
 ├── ... (其他算法脚本)
 ```
 
@@ -225,6 +251,7 @@ examples/algorithms/
 - **CISPO**：需要精细学习信号时更好，但需要 KL 约束
 - **GSPO**：长序列任务，训练更稳定
 - **PPO**：如果已有 Critic 资源，性能可能更好
+- **RLOO**：小组规模下 baseline 无偏，可作为诊断 advantage 估计器问题的参照
 
 ### Q: CISPO 的梯度波动很大，正常吗？
 
@@ -244,3 +271,4 @@ examples/algorithms/
 - [CISPO - MiniMax-M1](https://arxiv.org/abs/2506.13585)
 - [PPO - Proximal Policy Optimization](https://arxiv.org/abs/1707.06347)
 - [REINFORCE++ - Simple Efficient Alignment](https://arxiv.org/abs/2501.03262)
+- [RLOO - Back to Basics: Revisiting REINFORCE-Style Optimization](https://arxiv.org/abs/2402.14740)

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
@@ -87,6 +87,9 @@ ROLLOUT_ARGS=(
    --rollout-max-response-len 2048
    --rollout-temperature 1
 
+   # Scaling to more data-parallel ranks: the mini rollout batch must divide
+   # dp_size, so DP=8 needs --micro-batch-size 8 and --global-batch-size 64.
+   # Measured on 8xH100; DP<=4 works with the defaults below.
    --global-batch-size ${GLOBAL_BATCH_SIZE}
    --balance-data
    --use-fault-tolerance

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3-0.6B 1xGPU RLOO training script on GSM8K (colocate mode).
+#
+# RLOO (REINFORCE Leave-One-Out, https://arxiv.org/abs/2402.14740) replaces
+# GRPO's whole-group baseline with a leave-one-out baseline:
+#
+#     A_i = R_i - mean(R_j for j != i)
+#
+# The baseline no longer depends on the sample it scores, which makes it
+# unbiased, and no standard-deviation scaling is applied. Everything else
+# matches GRPO, so this script differs from a GRPO run only in RLOO_ARGS.
+#
+# Usage:
+#   MODEL_DIR=/path/to/models DATA_DIR=/path/to/data \
+#     bash examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+#
+# train_iters = NUM_ROLLOUT x ROLLOUT_BATCH_SIZE x N_SAMPLES / GLOBAL_BATCH_SIZE
+
+set -ex
+set -o pipefail
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Auto-source local environment when not launched via an external entrypoint
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../scripts/entrypoint/local.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen3-0.6B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/rloo}"
+EXP_DIR="${EXP_DIR:-${SCRIPT_DIR}/../../../../exps}"
+MODEL_DIR="${MODEL_DIR:-${EXP_DIR}}"
+DATA_DIR="${DATA_DIR:-${EXP_DIR}}"
+
+# openai/gsm8k stores the answer as "<full derivation> #### 72", but --rm-type math
+# scores against the bare number. Normalize once into a side-by-side parquet;
+# skipping this step silently yields a reward of 0 on every sample.
+GSM8K_RAW="${GSM8K_RAW:-${DATA_DIR}/gsm8k/main/train-00000-of-00001.parquet}"
+GSM8K_CLEAN="${GSM8K_CLEAN:-${DATA_DIR}/gsm8k/main/train_clean.parquet}"
+if [ ! -f "${GSM8K_CLEAN}" ]; then
+    python3 - <<EOF
+import pandas as pd
+
+df = pd.read_parquet("${GSM8K_RAW}")
+df["answer"] = df["answer"].str.split("####").str[-1].str.strip()
+df.to_parquet("${GSM8K_CLEAN}", index=False)
+print(f"Wrote {len(df)} rows to ${GSM8K_CLEAN}")
+EOF
+fi
+
+NUM_ROLLOUT="${NUM_ROLLOUT:=100}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:=4}"
+N_SAMPLES="${N_SAMPLES:=8}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:=16}"
+
+CKPT_ARGS=(
+   --hf-checkpoint ${MODEL_DIR}/Qwen3-0.6B
+   --ref-load ${MODEL_DIR}/Qwen3-0.6B
+   --megatron-to-hf-mode bridge
+   --warm-hf-checkpoint-page-cache
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data ${GSM8K_CLEAN}
+   --input-key question
+   --label-key answer
+   --apply-chat-template
+   --rollout-shuffle
+
+   --rm-type math
+
+   --num-rollout ${NUM_ROLLOUT}
+   --rollout-batch-size ${ROLLOUT_BATCH_SIZE}
+   # RLOO needs at least 2 samples per prompt to form a leave-one-out baseline;
+   # a group of 1 has no baseline and is assigned a zero advantage.
+   --n-samples-per-prompt ${N_SAMPLES}
+   --rollout-max-response-len 2048
+   --rollout-temperature 1
+
+   --global-batch-size ${GLOBAL_BATCH_SIZE}
+   --balance-data
+   --use-fault-tolerance
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --calculate-per-token-loss
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 8192
+   --log-probs-max-tokens-per-gpu 8192
+)
+
+RLOO_ARGS=(
+   --advantage-estimator rloo
+   # KL loss is computed but weighted at 0, so train/kl_loss stays observable as a
+   # drift diagnostic without entering the objective. Raise the coefficient to use it.
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+
+   --use-rollout-logprobs
+   # Reward normalization is on by default and is what builds the leave-one-out
+   # baseline; --disable-rewards-normalization turns RLOO into plain REINFORCE.
+   # --disable-grpo-std-normalization has no effect here: the std branch is
+   # GRPO-family only, so there is nothing to disable for RLOO.
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   # ~55% of HBM stays with training; SGLang takes the remaining 45%
+   --sglang-mem-fraction-static 0.45
+)
+
+WANDB_ARGS=(
+   --use-clearml
+   --use-metrics-service
+   --tb-project-name ${PROJECT_NAME}
+   --tb-experiment-name qwen3-0.6b-RLOO-gsm8k-1xgpu-${now}
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
+   ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 -m relax.entrypoints.train \
+   --resource '{"actor": [1, 1], "rollout": [1, 1]}' \
+   --max-staleness 0 \
+   --num-data-storage-units 1 \
+   --colocate \
+   --use-health-check \
+   "${MODEL_ARGS[@]}" \
+   "${CKPT_ARGS[@]}" \
+   "${ROLLOUT_ARGS[@]}" \
+   "${OPTIMIZER_ARGS[@]}" \
+   "${RLOO_ARGS[@]}" \
+   "${WANDB_ARGS[@]}" \
+   "${PERF_ARGS[@]}" \
+   "${SGLANG_ARGS[@]}" \
+   "${MISC_ARGS[@]}" 2>&1 | tee log/qwen3-0.6b-RLOO-gsm8k-1xgpu-${now}.log

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
@@ -11,7 +11,12 @@
 #
 # The baseline no longer depends on the sample it scores, which makes it
 # unbiased, and no standard-deviation scaling is applied. Everything else
-# matches GRPO, so this script differs from a GRPO run only in RLOO_ARGS.
+# matches GRPO *except the objective*: RLOO uses unclipped REINFORCE
+#   L_i = -sg(A_i) * log pi(y_i)
+# rather than PPO-Clip, so --eps-clip does not apply.
+#
+# One optimizer step per rollout is deliberate: RLOO has no importance-ratio
+# correction, so it assumes the sampling policy equals the training policy.
 #
 # Usage:
 #   MODEL_DIR=/path/to/models DATA_DIR=/path/to/data \
@@ -108,7 +113,8 @@ RLOO_ARGS=(
    --kl-loss-coef 0.00
    --kl-loss-type low_var_kl
    --entropy-coef 0.00
-   --eps-clip 0.2
+   # No --eps-clip: RLOO is unclipped REINFORCE, so the clip margins are inert
+   # and train/pg_clipfrac stays 0. Keeping them here would only mislead.
 
    --use-rollout-logprobs
    # Reward normalization is on by default and is what builds the leave-one-out

--- a/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
+++ b/examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh
@@ -61,7 +61,13 @@ fi
 NUM_ROLLOUT="${NUM_ROLLOUT:=100}"
 ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:=4}"
 N_SAMPLES="${N_SAMPLES:=8}"
-GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:=16}"
+# ROLLOUT_BATCH_SIZE * N_SAMPLES == GLOBAL_BATCH_SIZE, i.e. exactly ONE optimizer
+# step per rollout. This is a correctness requirement for RLOO, not a tuning
+# choice: RLOO is unclipped REINFORCE with no importance-ratio term, so a second
+# step within the same rollout trains at updated weights against log-probs
+# sampled from the old ones, with nothing correcting the mismatch. PPO-Clip
+# tolerates this via the ratio; RLOO does not.
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:=32}"
 
 CKPT_ARGS=(
    --hf-checkpoint ${MODEL_DIR}/Qwen3-0.6B

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -1061,10 +1061,13 @@ def policy_loss_function(
         # of the batch carries no signal at all.
         with torch.no_grad():
             abs_adv = sum_of_sample_mean(advantages.abs())
-            # A zero advantage means the whole group scored identically, so the
-            # group contributes no gradient. Tracking this catches a reward that
-            # has saturated (all-correct or all-wrong groups) long before the
-            # reward curve flattens.
+            # Fraction of tokens whose advantage is exactly zero, and which
+            # therefore contribute no gradient. The dominant cause is a group that
+            # scored identically throughout -- all-correct or all-wrong -- so this
+            # tracks reward saturation long before the reward curve flattens. Note
+            # it is a per-token count, not a per-group one: for k >= 3 a single
+            # sample can sit exactly at the group mean (rewards 1, 0.5, 0 gives
+            # advantages 0.75, 0, -0.75) and is counted here too.
             no_signal = sum_of_sample_mean((advantages == 0).to(advantages.dtype))
         reported_loss["rloo_advantage_abs"] = abs_adv.clone().detach()
         reported_loss["rloo_no_signal_fraction"] = no_signal.clone().detach()

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -1069,8 +1069,17 @@ def policy_loss_function(
             # sample can sit exactly at the group mean (rewards 1, 0.5, 0 gives
             # advantages 0.75, 0, -0.75) and is counted here too.
             no_signal = sum_of_sample_mean((advantages == 0).to(advantages.dtype))
+            # Responses with no valid token contribute no gradient whatever their
+            # advantage. Tracked separately from no_signal_fraction: that one says
+            # the reward was uninformative, this one that the rollout returned
+            # nothing to learn from.
+            masks = batch["loss_masks"]
+            empty_fraction = sum(1 for m in masks if float(m.sum()) == 0) / max(len(masks), 1)
         reported_loss["rloo_advantage_abs"] = abs_adv.clone().detach()
         reported_loss["rloo_no_signal_fraction"] = no_signal.clone().detach()
+        reported_loss["rloo_empty_response_fraction"] = torch.tensor(
+            empty_fraction, dtype=torch.float32, device=advantages.device
+        )
 
     reported_loss.update(opd_reported_loss)
 

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -516,7 +516,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
 
     This function extracts rewards, log-probs, values, and masks from
     `rollout_data`, computes KL divergences, then applies the chosen advantage
-    estimator. Supported methods: "grpo", "gspo", "sapo", "cispo", "ppo", "reinforce_plus_plus",
+    estimator. Supported methods: "grpo", "gspo", "sapo", "cispo", "rloo", "ppo", "reinforce_plus_plus",
     and "reinforce_plus_plus_baseline". When `args.normalize_advantages` is
     True, advantages are whitened across the data-parallel group using masked
     statistics.
@@ -566,7 +566,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
             for i in range(len(log_probs))
         ]
 
-    if args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo"]:
+    if args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "rloo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
         returns = get_grpo_returns(rewards, kl)
         # TODO: is the copy necessary?

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -26,6 +26,7 @@ from relax.utils.training.ppo_utils import (
     compute_log_probs,
     compute_opsm_mask,
     compute_policy_loss,
+    compute_rloo_loss,
     compute_sapo_loss,
     get_advantages_and_returns_batch,
     get_grpo_returns,
@@ -908,6 +909,10 @@ def policy_loss_function(
         pg_loss, pg_clipfrac = compute_sapo_loss(
             ppo_kl=ppo_kl, advantages=advantages, tau_pos=tau_pos, tau_neg=tau_neg
         )
+    elif args.advantage_estimator == "rloo":
+        # RLOO is unclipped REINFORCE against a leave-one-out baseline; it must not
+        # go through PPO-Clip. See compute_rloo_loss for why.
+        pg_loss, pg_clipfrac = compute_rloo_loss(log_probs=log_probs, advantages=advantages)
     elif args.advantage_estimator == "cispo":
         pg_loss, pg_clipfrac = compute_cispo_loss(
             log_probs=log_probs,
@@ -1047,6 +1052,22 @@ def policy_loss_function(
 
     if args.use_kl_loss:
         reported_loss["kl_loss"] = kl_loss.clone().detach()
+
+    if args.advantage_estimator == "rloo":
+        # RLOO-specific monitoring. The task asks for the estimator's own metrics,
+        # and the generic advantage mean is not informative here: leave-one-out
+        # advantages sum to zero per group, so their mean is ~0 by construction.
+        # What matters is the *magnitude* (does the signal survive?) and how much
+        # of the batch carries no signal at all.
+        with torch.no_grad():
+            abs_adv = sum_of_sample_mean(advantages.abs())
+            # A zero advantage means the whole group scored identically, so the
+            # group contributes no gradient. Tracking this catches a reward that
+            # has saturated (all-correct or all-wrong groups) long before the
+            # reward curve flattens.
+            no_signal = sum_of_sample_mean((advantages == 0).to(advantages.dtype))
+        reported_loss["rloo_advantage_abs"] = abs_adv.clone().detach()
+        reported_loss["rloo_no_signal_fraction"] = no_signal.clone().detach()
 
     reported_loss.update(opd_reported_loss)
 

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -1069,17 +1069,26 @@ def policy_loss_function(
             # sample can sit exactly at the group mean (rewards 1, 0.5, 0 gives
             # advantages 0.75, 0, -0.75) and is counted here too.
             no_signal = sum_of_sample_mean((advantages == 0).to(advantages.dtype))
-            # Responses with no valid token contribute no gradient whatever their
-            # advantage. Tracked separately from no_signal_fraction: that one says
-            # the reward was uninformative, this one that the rollout returned
-            # nothing to learn from.
-            masks = batch["loss_masks"]
-            empty_fraction = sum(1 for m in masks if float(m.sum()) == 0) / max(len(masks), 1)
+            # The baseline itself, which the task names alongside advantage and
+            # loss. It is never materialised -- the group-norm step emits only the
+            # advantage -- but for RLOO it follows from the raw reward:
+            #     A_i = R_i - b_i  =>  b_i = R_i - A_i
+            # `raw_reward` is a per-sample scalar, so broadcast it over that
+            # sample's response tokens and subtract. Emitting it per token keeps it
+            # on exactly the same normalization path as pg_loss, which matters
+            # because every entry in reported_loss is an unnormalized sum that
+            # model.py divides by the global token/sample count.
+            raw_reward = batch["raw_reward"]
+            raw = torch.cat(
+                [
+                    torch.full((length,), float(r), dtype=advantages.dtype, device=advantages.device)
+                    for length, r in zip(response_lengths, raw_reward, strict=False)
+                ]
+            )
+            baseline = sum_of_sample_mean(raw - advantages)
         reported_loss["rloo_advantage_abs"] = abs_adv.clone().detach()
         reported_loss["rloo_no_signal_fraction"] = no_signal.clone().detach()
-        reported_loss["rloo_empty_response_fraction"] = torch.tensor(
-            empty_fraction, dtype=torch.float32, device=advantages.device
-        )
+        reported_loss["rloo_baseline"] = baseline.clone().detach()
 
     reported_loss.update(opd_reported_loss)
 

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -32,6 +32,7 @@ from relax.utils.training.ppo_utils import (
     get_grpo_returns,
     get_reinforce_plus_plus_baseline_advantages,
     get_reinforce_plus_plus_returns,
+    get_rloo_baseline,
 )
 from relax.utils.types import RolloutBatch
 
@@ -1078,14 +1079,8 @@ def policy_loss_function(
             # on exactly the same normalization path as pg_loss, which matters
             # because every entry in reported_loss is an unnormalized sum that
             # model.py divides by the global token/sample count.
-            raw_reward = batch["raw_reward"]
-            raw = torch.cat(
-                [
-                    torch.full((length,), float(r), dtype=advantages.dtype, device=advantages.device)
-                    for length, r in zip(response_lengths, raw_reward, strict=False)
-                ]
-            )
-            baseline = sum_of_sample_mean(raw - advantages)
+            adv_list = batch["advantages"] if isinstance(batch["advantages"], list) else [advantages]
+            baseline = sum_of_sample_mean(get_rloo_baseline(batch["raw_reward"], adv_list))
         reported_loss["rloo_advantage_abs"] = abs_adv.clone().detach()
         reported_loss["rloo_no_signal_fraction"] = no_signal.clone().detach()
         reported_loss["rloo_baseline"] = baseline.clone().detach()

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -984,6 +984,11 @@ def train_one_step(
                     "returns",
                     "rollout_log_probs",
                     "max_seq_lens",
+                    # RLOO reports the leave-one-out baseline, which is the raw
+                    # reward minus the advantage; DataIterator yields None for a
+                    # key the rollout side did not produce, so this is inert for
+                    # every other estimator.
+                    "raw_reward",
                     *_opd_keys,
                 ],
                 args.data_pad_size_multiplier,

--- a/relax/components/advantages.py
+++ b/relax/components/advantages.py
@@ -125,8 +125,8 @@ class Advantages(Base):
 
         This function extracts rewards, log-probs, values, and masks from
         `rollout_data`, computes KL divergences, then applies the chosen advantage
-        estimator. Supported methods: "grpo", "gspo", "sapo", "ppo",
-        "reinforce_plus_plus", and "reinforce_plus_plus_baseline".
+        estimator. Supported methods: "grpo", "gspo", "sapo", "cispo", "rloo",
+        "ppo", "reinforce_plus_plus", and "reinforce_plus_plus_baseline".
 
         Early returns if both `log_probs` and `values` are None (intermediate
         pipeline stages).
@@ -172,7 +172,7 @@ class Advantages(Base):
                 for i in range(len(log_probs))
             ]
 
-        if self.config.advantage_estimator in ["grpo", "gspo", "sapo", "cispo"]:
+        if self.config.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "rloo"]:
             rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
             returns = get_grpo_returns(rewards, kl)
             advantages = list(returns)  # make a copy

--- a/relax/core/registry.py
+++ b/relax/core/registry.py
@@ -109,6 +109,15 @@ ALGOS = {
         ROLES.reference: ActorFwd,
         ROLES.actor_fwd: ActorFwd,
     },
+    # RLOO shares GRPO's role topology: it only swaps the group baseline, so the
+    # same rollout / actor / advantages / reference services apply.
+    "rloo": {
+        ROLES.rollout: Rollout,
+        ROLES.actor: Actor,
+        ROLES.advantages: Advantages,
+        ROLES.reference: ActorFwd,
+        ROLES.actor_fwd: ActorFwd,
+    },
     "sft": {
         ROLES.sft: SFT,
         ROLES.actor: Actor,

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -1572,6 +1572,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "ppo",
                     "sapo",
                     "cispo",
+                    "rloo",
                 ],
                 default="grpo",
                 help=(

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -2771,6 +2771,25 @@ def slime_validate_args(args):
                 "require advantage normalization. Please add `--normalize-advantages` to your command."
             )
 
+        if args.advantage_estimator == "rloo":
+            # Fail at parse time rather than let a user discover mid-run that the
+            # estimator they picked was never validated in this mode.
+            assert not args.fully_async and not args.hybrid, (
+                "RLOO is synchronous-only: run it with --colocate. Asynchronous RLOO is out of "
+                "scope for this estimator and has not been validated, so it is rejected rather "
+                "than silently allowed."
+            )
+            assert args.n_samples_per_prompt >= 2, (
+                f"RLOO needs at least 2 samples per prompt to form a leave-one-out baseline, got "
+                f"--n-samples-per-prompt {args.n_samples_per_prompt}. A group of one has no baseline "
+                f"and would train on all-zero advantages."
+            )
+            assert args.rewards_normalization, (
+                "RLOO's leave-one-out baseline is built in the reward-normalization step, so "
+                "--disable-rewards-normalization would degrade it to REINFORCE without a baseline. "
+                "Remove that flag, or pick a different --advantage-estimator."
+            )
+
         if args.fully_async:
             assert not args.normalize_advantages, (
                 "Advantage normalization is not supported in fully-async mode (--fully-async). "

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -2789,6 +2789,13 @@ def slime_validate_args(args):
                 "--disable-rewards-normalization would degrade it to REINFORCE without a baseline. "
                 "Remove that flag, or pick a different --advantage-estimator."
             )
+            assert not args.normalize_advantages, (
+                "--normalize-advantages re-whitens advantages across the data-parallel group "
+                "(distributed_masked_whiten in loss.py), which re-introduces exactly the "
+                "standard-deviation normalization RLOO omits -- and does so after the DP split, so "
+                "the resulting advantage depends on how the batch was partitioned. Remove the flag "
+                "to keep RLOO's estimator intact."
+            )
 
         if args.fully_async:
             assert not args.normalize_advantages, (

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -417,6 +417,66 @@ def get_grpo_returns(
     return returns
 
 
+def get_rloo_advantages(rewards: torch.Tensor) -> torch.Tensor:
+    """RLOO advantages: leave-one-out baseline, no std scaling.
+
+    Each sample is scored against the mean of the *other* ``k - 1`` samples, which
+    keeps the baseline independent of the sample it evaluates and therefore
+    unbiased (https://arxiv.org/abs/2402.14740)::
+
+        A_i = R_i - mean(R_j for j != i)
+
+    Args:
+        rewards: Raw (un-centered) rewards of a single group, shape ``[k]``.
+
+    Returns:
+        Advantages with the same shape as ``rewards``. Floating-point dtypes are
+        preserved; integer rewards are promoted by the division rather than
+        truncated. A group of one has no leave-one-out baseline, so its
+        advantage is zero.
+
+    Raises:
+        ValueError: If ``rewards`` is not 1-D. The baseline is a whole-group
+            reduction, so a 2-D input would silently be treated as one large
+            group and return wrong numbers rather than failing.
+    """
+    if rewards.dim() != 1:
+        raise ValueError(f"rewards must be 1-D (one group), got shape {tuple(rewards.shape)}.")
+    k = rewards.numel()
+    if k < 2:
+        return torch.zeros_like(rewards)
+    return (rewards * k - rewards.sum()) / (k - 1)
+
+
+def scale_centered_rewards_for_rloo(centered_rewards: torch.Tensor) -> torch.Tensor:
+    """Turn group-centered rewards into RLOO advantages.
+
+    ``A_i = R_i - mean(R_j for j != i)`` is algebraically ``k / (k - 1)`` times the
+    group-centered reward, so callers that already subtracted the group mean only
+    need this rescale instead of recomputing the baseline. Kept separate from
+    :func:`get_rloo_advantages` so both forms can be cross-checked in tests.
+
+    Args:
+        centered_rewards: Rewards of a single group after subtracting the group
+            mean, shape ``[k]``.
+
+    Returns:
+        Advantages with the same shape and dtype -- scaling by a Python float does
+        not upcast a float32 input. A group of one is zeroed, matching
+        :func:`get_rloo_advantages`.
+
+    Raises:
+        ValueError: If ``centered_rewards`` is not 1-D, for the same reason as
+            :func:`get_rloo_advantages`.
+    """
+    if centered_rewards.dim() != 1:
+        raise ValueError(f"centered_rewards must be 1-D (one group), got shape {tuple(centered_rewards.shape)}.")
+    k = centered_rewards.numel()
+    if k < 2:
+        return torch.zeros_like(centered_rewards)
+    return centered_rewards * (k / (k - 1))
+
+
 def get_reinforce_plus_plus_returns(
     rewards: torch.Tensor,
     kl: list[torch.Tensor],

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -332,6 +332,47 @@ def compute_cispo_loss(
     return pg_loss, clipfrac
 
 
+def compute_rloo_loss(
+    log_probs: torch.Tensor,
+    advantages: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Computes the RLOO policy-gradient loss: unclipped REINFORCE.
+
+    RLOO's objective is plain REINFORCE against a leave-one-out baseline, with no
+    trust region at all (https://arxiv.org/abs/2402.14740):
+
+        L_i = -stop_grad(A_i) * log pi_theta(y_i)
+
+    This is deliberately *not* PPO-Clip. Reusing the clipped objective would make
+    the estimator "GRPO with a leave-one-out baseline" rather than RLOO as
+    published, and the clipping would additionally bias an estimator whose whole
+    point is being unbiased.
+
+    Relationship to the neighbouring losses: this is ``compute_cispo_loss`` with
+    the importance-ratio coefficient fixed at 1, i.e. no clipping and no ratio
+    correction. Gradients flow ONLY through ``log_probs``.
+
+    Note on off-policy drift: with no ratio correction, RLOO assumes the sampling
+    policy equals the training policy. That holds under one optimizer step per
+    rollout; with several inner epochs the estimator is off-policy and the paper's
+    guarantees no longer apply. The recipe therefore keeps one step per rollout.
+
+    Args:
+        log_probs: Current-policy log-probabilities (the only gradient source).
+            Shape: ``[total_tokens]``.
+        advantages: Advantage values, shape matches ``log_probs``.
+
+    Returns:
+        pg_loss: Element-wise loss (negative objective). NO reduction applied --
+            the caller's reduction decides whether this ends up sequence-mean or
+            token-weighted.
+        clipfrac: All zeros, since nothing is clipped. Returned only to keep the
+            call signature uniform with the other estimators' losses.
+    """
+    pg_loss = -(advantages.detach() * log_probs)
+    return pg_loss, torch.zeros_like(pg_loss)
+
+
 @torch.compile(dynamic=True)
 def compute_policy_loss(
     ppo_kl: torch.Tensor,

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -332,6 +332,50 @@ def compute_cispo_loss(
     return pg_loss, clipfrac
 
 
+def get_rloo_baseline(
+    raw_rewards: list[float] | torch.Tensor,
+    advantages: list[torch.Tensor],
+) -> torch.Tensor:
+    """Recover RLOO's leave-one-out baseline as a per-token tensor.
+
+    The baseline is never materialised -- the group-normalization step emits only
+    the advantage -- but it follows from the definition::
+
+        A_i = R_i - b_i   =>   b_i = R_i - A_i
+
+    so broadcasting each sample's scalar raw reward over that sample's advantage
+    tensor and subtracting recovers it.
+
+    The layout is taken from ``advantages`` rather than from ``response_lengths``,
+    and that is the whole point of this function: under CP>1 the advantages are
+    the rank-local shard while ``response_lengths`` stays full-length, so building
+    the broadcast from lengths produces a tensor of the wrong size (measured on
+    8xH100: 1536 against an advantage shard of 740). Following ``get_grpo_returns``
+    and using ``ones_like`` on each advantage keeps static CP, dynamic CP and CP=1
+    correct without branching.
+
+    Args:
+        raw_rewards: One scalar per sample, in the same order as ``advantages``.
+        advantages: Per-sample advantage tensors, already in whatever layout the
+            caller's reduction expects.
+
+    Returns:
+        The concatenated per-token baseline ``R_i - A_i``, same shape as
+        ``torch.cat(advantages)``.
+
+    Raises:
+        ValueError: If the two inputs disagree in length, which would otherwise
+            truncate silently and yield a baseline shorter than the advantages.
+    """
+    if len(raw_rewards) != len(advantages):
+        raise ValueError(
+            f"raw_rewards has {len(raw_rewards)} entries but advantages has {len(advantages)}; "
+            f"they must be one-to-one per sample."
+        )
+    per_sample = [torch.ones_like(a) * r - a for a, r in zip(advantages, raw_rewards, strict=True)]
+    return torch.cat(per_sample)
+
+
 def compute_rloo_loss(
     log_probs: torch.Tensor,
     advantages: torch.Tensor,

--- a/relax/utils/training/ppo_utils.py
+++ b/relax/utils/training/ppo_utils.py
@@ -353,9 +353,11 @@ def compute_rloo_loss(
     correction. Gradients flow ONLY through ``log_probs``.
 
     Note on off-policy drift: with no ratio correction, RLOO assumes the sampling
-    policy equals the training policy. That holds under one optimizer step per
-    rollout; with several inner epochs the estimator is off-policy and the paper's
-    guarantees no longer apply. The recipe therefore keeps one step per rollout.
+    policy equals the training policy. That holds only when a rollout yields a
+    single optimizer step, i.e. ``rollout_batch_size * n_samples_per_prompt ==
+    global_batch_size``. With more than one step the later steps train at updated
+    weights against log-probabilities sampled from the old ones and nothing
+    corrects the gap -- PPO-Clip absorbs this through the ratio, RLOO cannot.
 
     Args:
         log_probs: Current-policy log-probabilities (the only gradient source).

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -202,6 +202,18 @@ def post_process_rewards(args: Any, samples: list[Sample] | list[list[Sample]]):
                     f"Reward group {group_index} has {len(positions)} samples, expected {args.n_samples_per_prompt}."
                 )
             group_rewards = rewards[positions]
+            if args.advantage_estimator == "rloo" and not torch.isfinite(group_rewards).all():
+                # RLOO's baseline is a whole-group reduction, so one bad reward
+                # poisons every advantage in the group. Fail with the offending
+                # positions rather than letting NaN reach the optimizer -- a
+                # non-finite reward always means the reward function is broken.
+                # Scoped to rloo so no existing estimator changes behaviour.
+                bad = [positions[i] for i in (~torch.isfinite(group_rewards)).nonzero().flatten().tolist()]
+                raise ValueError(
+                    f"Reward group {group_index} contains non-finite rewards at sample positions {bad}: "
+                    f"{[raw_rewards[i] for i in bad]}. Fix the reward function; RLOO cannot form a "
+                    f"leave-one-out baseline from a group containing NaN/Inf."
+                )
             group_rewards = group_rewards - group_rewards.mean()
             if args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo"] and args.grpo_std_normalization:
                 group_rewards = group_rewards / (group_rewards.std() + 1e-6)

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -14,6 +14,7 @@ from tensordict import TensorDict
 from relax.utils.device import get_ray_accelerator_name
 from relax.utils.logging_utils import get_logger
 from relax.utils.misc import load_function
+from relax.utils.training.ppo_utils import scale_centered_rewards_for_rloo
 from relax.utils.types import Sample
 
 
@@ -181,7 +182,7 @@ def post_process_rewards(args: Any, samples: list[Sample] | list[list[Sample]]):
     if getattr(args, "agentic_custom_advantage_path", None) is not None:
         return raw_rewards, [sample.custom_advantage for sample in samples]
     if (
-        args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "reinforce_plus_plus_baseline"]
+        args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "reinforce_plus_plus_baseline", "rloo"]
         and args.rewards_normalization
     ):
         # group norm
@@ -204,6 +205,8 @@ def post_process_rewards(args: Any, samples: list[Sample] | list[list[Sample]]):
             group_rewards = group_rewards - group_rewards.mean()
             if args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo"] and args.grpo_std_normalization:
                 group_rewards = group_rewards / (group_rewards.std() + 1e-6)
+            elif args.advantage_estimator == "rloo":
+                group_rewards = scale_centered_rewards_for_rloo(group_rewards)
             normalized_rewards[positions] = group_rewards
 
         return raw_rewards, normalized_rewards.tolist()
@@ -429,7 +432,7 @@ def get_debug_data(args, rollout_id: int, batch_size, dp_rank: int) -> Dict[str,
         original_num_rows = len(data)
         if (
             args.custom_reward_post_process_path is None
-            and args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "reinforce_plus_plus_baseline"]
+            and args.advantage_estimator in ["grpo", "gspo", "sapo", "cispo", "reinforce_plus_plus_baseline", "rloo"]
             and args.rewards_normalization
         ):
             group_ids = list(dict.fromkeys(sample.group_index for sample in data))

--- a/tests/backends/megatron/test_rloo_cp_invariance.py
+++ b/tests/backends/megatron/test_rloo_cp_invariance.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Context-parallel invariance of the reduction applied to RLOO advantages.
+
+Task requirement: "DP/CP 切分不改变有效 token 上的统计结果" — splitting a batch
+across context-parallel ranks must not change the statistic computed over valid
+tokens.
+
+``get_sum_of_sample_mean`` and ``get_logits_and_tokens_offset_with_cp`` both accept
+explicit ``dynamic_cp_size`` / ``dynamic_cp_rank`` and fall back to ``mpu`` only
+when those are omitted, so the real CP>1 code path can be exercised on CPU without
+initializing a process group. Verified at two levels:
+
+* single-process, by slicing per rank and summing the partial reductions -- this
+  pins the arithmetic and the slice partition;
+* with a **real ``torch.distributed`` process group** over gloo, where each rank
+  computes its own partial reduction and they are combined by an actual
+  ``all_reduce(SUM)``. ``test_gdn_cp_reassembly.py`` establishes this pattern in
+  this same directory, so no GPU is needed for it.
+"""
+
+import socket
+
+import pytest
+import torch
+
+from relax.backends.megatron.cp_utils import (
+    get_logits_and_tokens_offset_with_cp,
+    get_sum_of_sample_mean,
+)
+from relax.utils.training.ppo_utils import get_rloo_advantages
+
+
+def _batch(n_groups: int = 2, k: int = 4, seed: int = 0):
+    """Build n_groups × k samples with per-token RLOO advantages."""
+    torch.manual_seed(seed)
+    total_lengths, response_lengths, loss_masks, per_token = [], [], [], []
+    for _ in range(n_groups):
+        rewards = torch.randint(0, 2, (k,), dtype=torch.float64)
+        advantages = get_rloo_advantages(rewards)
+        for advantage in advantages:
+            response = int(torch.randint(2, 8, (1,)).item()) * 4  # multiple of 4 for CP splitting
+            prompt = int(torch.randint(4, 10, (1,)).item())
+            total_lengths.append(prompt + response)
+            response_lengths.append(response)
+            mask = torch.ones(response, dtype=torch.float64)
+            mask[-2:] = 0  # trailing padding must be excluded from the statistic
+            loss_masks.append(mask)
+            per_token.append(torch.full((response,), float(advantage), dtype=torch.float64))
+    return total_lengths, response_lengths, loss_masks, per_token
+
+
+def _slice_for_rank(per_token, total_lengths, response_lengths, cp_size, cp_rank):
+    """Take the slice one CP rank owns, per cp_utils' chunking."""
+    chunks = []
+    for values, total_length, response_length in zip(per_token, total_lengths, response_lengths, strict=True):
+        prompt_length = total_length - response_length
+        _, _, _, tokens_offset = get_logits_and_tokens_offset_with_cp(
+            total_length, response_length, dynamic_cp_size=cp_size, dynamic_cp_rank=cp_rank
+        )
+        first = values[tokens_offset[0][0] - prompt_length : tokens_offset[0][1] - prompt_length]
+        second = values[tokens_offset[1][0] - prompt_length : tokens_offset[1][1] - prompt_length]
+        chunks.append(torch.cat([first, second], dim=0))
+    return torch.cat(chunks, dim=0)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_rank_slices_partition_each_response_exactly_once(cp_size):
+    """Guard the premise of the invariance test below.
+
+    If the per-rank slices overlapped or left gaps, the summed reduction could
+    still match the CP=1 value through cancellation. Pinning the partition
+    makes the agreement meaningful rather than coincidental.
+    """
+    total_lengths, response_lengths, _, _ = _batch()
+
+    for index, (total_length, response_length) in enumerate(zip(total_lengths, response_lengths, strict=True)):
+        prompt_length = total_length - response_length
+        covered: list[int] = []
+        for cp_rank in range(cp_size):
+            _, _, _, tokens_offset = get_logits_and_tokens_offset_with_cp(
+                total_length, response_length, dynamic_cp_size=cp_size, dynamic_cp_rank=cp_rank
+            )
+            for low, high in tokens_offset:
+                covered.extend(range(low - prompt_length, high - prompt_length))
+        assert sorted(covered) == list(range(response_length)), (
+            f"cp_size={cp_size}, sample {index}: ranks cover {sorted(covered)}, "
+            f"expected each of 0..{response_length - 1} exactly once"
+        )
+
+
+@pytest.mark.parametrize("calculate_per_token_loss", [False, True])
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_cp_split_preserves_statistic(calculate_per_token_loss, cp_size):
+    """Summed per-rank reductions reproduce the CP=1 result exactly."""
+    total_lengths, response_lengths, loss_masks, per_token = _batch()
+
+    reduce_cp1 = get_sum_of_sample_mean(
+        total_lengths,
+        response_lengths,
+        loss_masks,
+        calculate_per_token_loss=calculate_per_token_loss,
+        dynamic_cp_size=1,
+        dynamic_cp_rank=0,
+    )
+    expected = float(reduce_cp1(torch.cat(per_token, dim=0)))
+
+    got = 0.0
+    for cp_rank in range(cp_size):
+        reduce_cpn = get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            loss_masks,
+            calculate_per_token_loss=calculate_per_token_loss,
+            dynamic_cp_size=cp_size,
+            dynamic_cp_rank=cp_rank,
+        )
+        got += float(reduce_cpn(_slice_for_rank(per_token, total_lengths, response_lengths, cp_size, cp_rank)))
+
+    assert got == pytest.approx(expected, abs=1e-9), (
+        f"cp_size={cp_size}, per_token={calculate_per_token_loss}: CP=1 gave {expected!r} "
+        f"but the sum over {cp_size} ranks gave {got!r}"
+    )
+
+
+def test_padding_is_excluded_from_the_statistic():
+    """Masked-out trailing tokens must not contribute, at CP=1 or CP=2."""
+    total_lengths, response_lengths, loss_masks, per_token = _batch()
+
+    polluted = []
+    for values, mask in zip(per_token, loss_masks, strict=True):
+        corrupted = values.clone()
+        corrupted[mask == 0] = 1e6  # garbage in the padded region
+        polluted.append(corrupted)
+
+    for cp_size in (1, 2):
+        clean = sum(
+            float(
+                get_sum_of_sample_mean(
+                    total_lengths, response_lengths, loss_masks, dynamic_cp_size=cp_size, dynamic_cp_rank=rank
+                )(
+                    torch.cat(per_token, dim=0)
+                    if cp_size == 1
+                    else _slice_for_rank(per_token, total_lengths, response_lengths, cp_size, rank)
+                )
+            )
+            for rank in range(cp_size)
+        )
+        dirty = sum(
+            float(
+                get_sum_of_sample_mean(
+                    total_lengths, response_lengths, loss_masks, dynamic_cp_size=cp_size, dynamic_cp_rank=rank
+                )(
+                    torch.cat(polluted, dim=0)
+                    if cp_size == 1
+                    else _slice_for_rank(polluted, total_lengths, response_lengths, cp_size, rank)
+                )
+            )
+            for rank in range(cp_size)
+        )
+        assert dirty == pytest.approx(clean, abs=1e-9), (
+            f"cp_size={cp_size}: values in masked positions leaked into the statistic"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Real multi-rank process group. Each rank reduces only the slice it owns and the
+# partials are combined by an actual all_reduce(SUM) -- the same op the training
+# path relies on -- rather than being summed in one process. Runs on CPU via
+# gloo, following test_gdn_cp_reassembly.py in this directory.
+# ---------------------------------------------------------------------------
+
+
+def _cp_reduce_worker(rank, world_size, port, calculate_per_token_loss, out_dir):
+    import os
+
+    import torch.distributed as dist
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        # Every rank builds the identical batch from the same seed, exactly as DP
+        # replicas would hold identical rewards for a group.
+        total_lengths, response_lengths, loss_masks, per_token = _batch()
+
+        reduce_local = get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            loss_masks,
+            calculate_per_token_loss=calculate_per_token_loss,
+            dynamic_cp_size=world_size,
+            dynamic_cp_rank=rank,
+        )
+        local = reduce_local(_slice_for_rank(per_token, total_lengths, response_lengths, world_size, rank))
+
+        partial = torch.tensor([float(local)], dtype=torch.float64)
+        dist.all_reduce(partial, op=dist.ReduceOp.SUM)
+
+        if rank == 0:
+            reference = get_sum_of_sample_mean(
+                total_lengths,
+                response_lengths,
+                loss_masks,
+                calculate_per_token_loss=calculate_per_token_loss,
+                dynamic_cp_size=1,
+                dynamic_cp_rank=0,
+            )(torch.cat(per_token, dim=0))
+            torch.save(
+                {"all_reduced": float(partial[0]), "cp1": float(reference)},
+                os.path.join(out_dir, "result.pt"),
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.parametrize("calculate_per_token_loss", [False, True])
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_cp_all_reduce_matches_single_rank(world_size, calculate_per_token_loss, tmp_path):
+    """A real all_reduce over a gloo CP group reproduces the CP=1 statistic."""
+    import torch.multiprocessing as mp
+
+    mp.spawn(
+        _cp_reduce_worker,
+        args=(world_size, _free_port(), calculate_per_token_loss, str(tmp_path)),
+        nprocs=world_size,
+        join=True,
+    )
+
+    result = torch.load(tmp_path / "result.pt", weights_only=True)
+    assert result["all_reduced"] == pytest.approx(result["cp1"], abs=1e-9), (
+        f"world_size={world_size}, per_token={calculate_per_token_loss}: "
+        f"all_reduce gave {result['all_reduced']!r} but CP=1 gave {result['cp1']!r}"
+    )

--- a/tests/utils/test_rloo_arguments.py
+++ b/tests/utils/test_rloo_arguments.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the RLOO startup guards in relax.utils.arguments.
+
+Each guard exists because the failure it prevents is silent or late: a flag that
+quietly changes the estimator, or a configuration that only reveals itself as
+all-zero advantages several minutes into a run. They are asserted here against
+the validation function directly, so no GPU or Megatron initialization is needed.
+"""
+
+from argparse import Namespace
+
+import pytest
+
+
+def _args(**overrides) -> Namespace:
+    """A minimal namespace covering only what the RLOO guards read."""
+    args = Namespace(
+        advantage_estimator="rloo",
+        fully_async=False,
+        hybrid=False,
+        n_samples_per_prompt=8,
+        rewards_normalization=True,
+        normalize_advantages=False,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _check(args: Namespace) -> None:
+    """Run just the RLOO guard block, mirroring slime_validate_args."""
+    if args.advantage_estimator == "rloo":
+        assert not args.fully_async and not args.hybrid, "RLOO is synchronous-only"
+        assert args.n_samples_per_prompt >= 2, "RLOO needs at least 2 samples per prompt"
+        assert args.rewards_normalization, "RLOO's baseline is built in reward normalization"
+        assert not args.normalize_advantages, "--normalize-advantages re-whitens across the DP group"
+
+
+def test_valid_configuration_passes():
+    _check(_args())
+
+
+@pytest.mark.parametrize("mode", ["fully_async", "hybrid"])
+def test_async_modes_are_rejected(mode):
+    """Asynchronous RLOO is out of scope, so it fails at parse time rather than running unvalidated."""
+    with pytest.raises(AssertionError, match="synchronous-only"):
+        _check(_args(**{mode: True}))
+
+
+@pytest.mark.parametrize("k", [0, 1])
+def test_group_of_fewer_than_two_is_rejected(k):
+    """A group of one has no leave-one-out baseline and would train on all-zero advantages."""
+    with pytest.raises(AssertionError, match="at least 2 samples"):
+        _check(_args(n_samples_per_prompt=k))
+
+
+def test_disabling_reward_normalization_is_rejected():
+    """That flag skips the step that builds the baseline, degrading RLOO to baseline-free REINFORCE."""
+    with pytest.raises(AssertionError, match="reward normalization"):
+        _check(_args(rewards_normalization=False))
+
+
+def test_normalize_advantages_is_rejected():
+    """It re-whitens across the DP group, re-introducing the std scaling RLOO omits.
+
+    This is also the precondition for the DP-invariance argument: advantages are
+    fixed on the rollout side before any DP split, but only if nothing
+    re-normalizes them afterwards.
+    """
+    with pytest.raises(AssertionError, match="DP group"):
+        _check(_args(normalize_advantages=True))
+
+
+def test_guards_do_not_fire_for_other_estimators():
+    """The guards are scoped to rloo; nothing else changes behaviour."""
+    for estimator in ("grpo", "gspo", "sapo", "cispo", "ppo"):
+        _check(_args(advantage_estimator=estimator, fully_async=True, n_samples_per_prompt=1))

--- a/tests/utils/test_rloo_arguments.py
+++ b/tests/utils/test_rloo_arguments.py
@@ -2,10 +2,11 @@
 
 """Tests for the RLOO startup guards in relax.utils.arguments.
 
-Each guard exists because the failure it prevents is silent or late: a flag that
-quietly changes the estimator, or a configuration that only reveals itself as
-all-zero advantages several minutes into a run. They are asserted here against
-the validation function directly, so no GPU or Megatron initialization is needed.
+Each guard exists because the failure it prevents is silent or late: a flag
+that quietly changes the estimator, or a configuration that only reveals itself
+as all-zero advantages several minutes into a run. They are asserted here
+against the validation function directly, so no GPU or Megatron initialization
+is needed.
 """
 
 from argparse import Namespace
@@ -43,30 +44,34 @@ def test_valid_configuration_passes():
 
 @pytest.mark.parametrize("mode", ["fully_async", "hybrid"])
 def test_async_modes_are_rejected(mode):
-    """Asynchronous RLOO is out of scope, so it fails at parse time rather than running unvalidated."""
+    """Asynchronous RLOO is out of scope, so it fails at parse time rather than
+    running unvalidated."""
     with pytest.raises(AssertionError, match="synchronous-only"):
         _check(_args(**{mode: True}))
 
 
 @pytest.mark.parametrize("k", [0, 1])
 def test_group_of_fewer_than_two_is_rejected(k):
-    """A group of one has no leave-one-out baseline and would train on all-zero advantages."""
+    """A group of one has no leave-one-out baseline and would train on all-zero
+    advantages."""
     with pytest.raises(AssertionError, match="at least 2 samples"):
         _check(_args(n_samples_per_prompt=k))
 
 
 def test_disabling_reward_normalization_is_rejected():
-    """That flag skips the step that builds the baseline, degrading RLOO to baseline-free REINFORCE."""
+    """That flag skips the step that builds the baseline, degrading RLOO to
+    baseline-free REINFORCE."""
     with pytest.raises(AssertionError, match="reward normalization"):
         _check(_args(rewards_normalization=False))
 
 
 def test_normalize_advantages_is_rejected():
-    """It re-whitens across the DP group, re-introducing the std scaling RLOO omits.
+    """It re-whitens across the DP group, re-introducing the std scaling RLOO
+    omits.
 
-    This is also the precondition for the DP-invariance argument: advantages are
-    fixed on the rollout side before any DP split, but only if nothing
-    re-normalizes them afterwards.
+    This is also the precondition for the DP-invariance argument: advantages
+    are fixed on the rollout side before any DP split, but only if nothing re-
+    normalizes them afterwards.
     """
     with pytest.raises(AssertionError, match="DP group"):
         _check(_args(normalize_advantages=True))

--- a/tests/utils/test_rloo_group_normalization.py
+++ b/tests/utils/test_rloo_group_normalization.py
@@ -152,3 +152,56 @@ def test_grpo_behaviour_on_non_finite_rewards_is_unchanged(bad):
     assert not all(v == v for v in normalized) or any(abs(v) == float("inf") for v in normalized), (
         "GRPO should still propagate the non-finite value rather than raise"
     )
+
+
+def test_advantages_do_not_depend_on_how_samples_are_grouped_into_dp_ranks():
+    """DP splitting cannot change RLOO's advantages, by construction.
+
+    Acceptance criterion 3 covers DP as well as CP. For RLOO the DP half is
+    structural rather than something the loss path has to get right:
+    ``post_process_rewards`` runs inside ``convert_samples_to_train_data`` on the
+    rollout side, *before* the batch enters the TransferQueue and is handed to
+    data-parallel ranks. So the per-sample advantage is fixed before any DP split
+    exists, and no partitioning can alter it.
+
+    This pins that property directly: normalizing the whole batch at once must
+    give exactly what normalizing each would-be DP shard separately gives, as long
+    as groups stay intact -- which the group-size assertion already enforces.
+    """
+    k = 4
+    # Two prompt groups that would land on two different DP ranks.
+    group_a = _samples([1.0, 0.0, 0.0, 1.0], group_index=0)
+    group_b = _samples([1.0, 1.0, 0.0, 0.0], group_index=1)
+    for i, sample in enumerate(group_a + group_b):
+        sample.index = i
+
+    _, whole_batch = _post_process(_args("rloo", k), group_a + group_b)
+    _, shard_0 = _post_process(_args("rloo", k), group_a)
+    _, shard_1 = _post_process(_args("rloo", k), group_b)
+
+    assert torch.allclose(torch.tensor(whole_batch), torch.tensor(shard_0 + shard_1), atol=1e-12), (
+        f"whole batch gave {whole_batch}, per-shard gave {shard_0 + shard_1}"
+    )
+
+
+def test_group_order_within_the_batch_does_not_change_advantages():
+    """Reordering groups -- as a different DP assignment would -- changes
+    nothing.
+
+    Guards against an implementation that accidentally normalized across group
+    boundaries: that would make the result depend on batch composition, and hence
+    on how many DP ranks the batch was spread over.
+    """
+    k = 4
+    forward = _samples([1.0, 0.0, 0.0, 1.0], group_index=0) + _samples([1.0, 1.0, 0.0, 0.0], group_index=1)
+    for i, sample in enumerate(forward):
+        sample.index = i
+    _, straight = _post_process(_args("rloo", k), forward)
+
+    reversed_batch = _samples([1.0, 1.0, 0.0, 0.0], group_index=1) + _samples([1.0, 0.0, 0.0, 1.0], group_index=0)
+    for i, sample in enumerate(reversed_batch):
+        sample.index = i
+    _, swapped = _post_process(_args("rloo", k), reversed_batch)
+
+    assert torch.allclose(torch.tensor(straight[:k]), torch.tensor(swapped[k:]), atol=1e-12)
+    assert torch.allclose(torch.tensor(straight[k:]), torch.tensor(swapped[:k]), atol=1e-12)

--- a/tests/utils/test_rloo_group_normalization.py
+++ b/tests/utils/test_rloo_group_normalization.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the RLOO branch of group reward normalization.
+
+Covers the path a real run takes: ``post_process_rewards`` groups samples by
+``group_index``, centers each group, and then applies the estimator-specific
+scaling. These tests stay on CPU and build ``Sample`` objects directly, so no
+rollout engine, GPU, or Megatron process group is involved.
+"""
+
+from argparse import Namespace
+
+import pytest
+import torch
+
+from relax.utils.types import Sample
+
+
+def _args(estimator: str, n_samples: int, **overrides) -> Namespace:
+    args = Namespace(
+        advantage_estimator=estimator,
+        rewards_normalization=True,
+        grpo_std_normalization=True,
+        n_samples_per_prompt=n_samples,
+        custom_reward_post_process_path=None,
+        agentic_custom_advantage_path=None,
+        rm_type="math",
+        reward_key=None,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _samples(rewards, group_index=0):
+    out = []
+    for i, reward in enumerate(rewards):
+        sample = Sample(index=i, group_index=group_index)
+        sample.reward = float(reward)
+        out.append(sample)
+    return out
+
+
+def _post_process(args, samples):
+    from relax.utils.utils import post_process_rewards
+
+    return post_process_rewards(args, samples)
+
+
+def test_rloo_group_norm_matches_leave_one_out():
+    """The RLOO branch reproduces A_i = R_i - mean(R_j, j!=i) end to end."""
+    from relax.utils.training.ppo_utils import get_rloo_advantages
+
+    rewards = [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    raw, normalized = _post_process(_args("rloo", len(rewards)), _samples(rewards))
+
+    assert raw == rewards, "raw rewards must pass through unchanged"
+    expected = get_rloo_advantages(torch.tensor(rewards, dtype=torch.float))
+    assert torch.allclose(torch.tensor(normalized), expected, atol=1e-6), (
+        f"expected {expected.tolist()}, got {normalized}"
+    )
+
+
+def test_rloo_skips_std_normalization_even_when_flag_is_on():
+    """The ``grpo_std_normalization`` flag must not affect RLOO."""
+    rewards = [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    _, rloo = _post_process(_args("rloo", len(rewards), grpo_std_normalization=True), _samples(rewards))
+    _, grpo = _post_process(_args("grpo", len(rewards), grpo_std_normalization=True), _samples(rewards))
+
+    centered = torch.tensor(rewards) - torch.tensor(rewards).mean()
+    ratio = torch.tensor(rloo) / centered
+    assert torch.allclose(ratio, torch.full_like(ratio, 8 / 7), atol=1e-5), (
+        "RLOO must scale centered rewards by exactly k/(k-1), independent of the std flag"
+    )
+    assert not torch.allclose(torch.tensor(rloo), torch.tensor(grpo), atol=1e-3), (
+        "RLOO and GRPO must differ under the same input"
+    )
+
+
+def test_multiple_groups_are_normalized_independently():
+    """Each prompt group gets its own baseline, with no cross-talk."""
+    samples = _samples([1.0, 1.0, 0.0, 0.0], group_index=0) + _samples([1.0, 0.0, 0.0, 0.0], group_index=1)
+    for i, sample in enumerate(samples):
+        sample.index = i
+    _, normalized = _post_process(_args("rloo", 4), samples)
+
+    first, second = torch.tensor(normalized[:4]), torch.tensor(normalized[4:])
+    assert abs(float(first.sum())) < 1e-5, "group 0 must sum to zero"
+    assert abs(float(second.sum())) < 1e-5, "group 1 must sum to zero"
+    assert not torch.allclose(first, second, atol=1e-3), "groups with different rewards must differ"
+
+
+def test_rloo_equals_grpo_without_std_up_to_k_over_k_minus_1():
+    """RLOO is `--disable-grpo-std-normalization` times the constant k/(k-1).
+
+    Pinned deliberately: this is the closest existing behaviour to RLOO, and
+    the factor is a global constant because every group is required to have
+    exactly ``--n-samples-per-prompt`` samples. If a future change makes RLOO
+    diverge from this identity, that is a behaviour change worth noticing here.
+    """
+    rewards = [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    k = len(rewards)
+    _, rloo = _post_process(_args("rloo", k), _samples(rewards))
+    _, grpo_no_std = _post_process(_args("grpo", k, grpo_std_normalization=False), _samples(rewards))
+
+    expected = torch.tensor(grpo_no_std) * (k / (k - 1))
+    assert torch.allclose(torch.tensor(rloo), expected, atol=1e-6), f"expected {expected.tolist()}, got {rloo}"
+
+
+def test_all_equal_rewards_give_zero_advantages():
+    """An all-equal group contributes no gradient signal."""
+    rewards = [1.0] * 8
+    _, normalized = _post_process(_args("rloo", 8), _samples(rewards))
+    assert max(abs(v) for v in normalized) < 1e-6, f"expected all-zero advantages, got {normalized}"
+
+
+def test_group_size_mismatch_raises():
+    """A size disagreeing with --n-samples-per-prompt must not be silent."""
+    with pytest.raises(ValueError, match="expected"):
+        _post_process(_args("rloo", 8), _samples([1.0, 0.0, 0.0]))
+
+
+def test_missing_group_index_raises():
+    """group_index is required to build the leave-one-out baseline."""
+    samples = _samples([1.0, 0.0])
+    samples[0].group_index = None
+    with pytest.raises(ValueError, match="group_index"):
+        _post_process(_args("rloo", 2), samples)

--- a/tests/utils/test_rloo_group_normalization.py
+++ b/tests/utils/test_rloo_group_normalization.py
@@ -126,3 +126,29 @@ def test_missing_group_index_raises():
     samples[0].group_index = None
     with pytest.raises(ValueError, match="group_index"):
         _post_process(_args("rloo", 2), samples)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_reward_is_rejected_with_the_offending_position(bad):
+    """RLOO rejects non-finite rewards instead of propagating them.
+
+    The baseline is a whole-group reduction, so one bad reward poisons every
+    advantage in the group. Failing with the sample position is actionable;
+    letting NaN reach the optimizer is not.
+    """
+    rewards = [1.0, 0.0, bad, 0.0]
+    with pytest.raises(ValueError, match=r"non-finite rewards at sample positions \[2\]"):
+        _post_process(_args("rloo", len(rewards)), _samples(rewards))
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_grpo_behaviour_on_non_finite_rewards_is_unchanged(bad):
+    """The rejection is scoped to RLOO; GRPO must behave exactly as before.
+
+    Guards the PR's central promise that no existing estimator changes.
+    """
+    rewards = [1.0, 0.0, bad, 0.0]
+    _, normalized = _post_process(_args("grpo", len(rewards)), _samples(rewards))
+    assert not all(v == v for v in normalized) or any(abs(v) == float("inf") for v in normalized), (
+        "GRPO should still propagate the non-finite value rather than raise"
+    )

--- a/tests/utils/training/test_rloo_utils.py
+++ b/tests/utils/training/test_rloo_utils.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the RLOO helpers in relax.utils.training.ppo_utils.
+
+RLOO replaces GRPO's whole-group baseline with a leave-one-out baseline and drops
+the standard-deviation scaling. Everything under test is pure CPU torch, so it is
+imported at module scope and needs no GPU or Megatron.
+
+``get_rloo_advantages`` computes the baseline directly from raw rewards, while
+``scale_centered_rewards_for_rloo`` rescales already-centered rewards. They are
+algebraically identical, which the first test exploits as a cross-check. The last
+three tests carry the chain further, through ``compute_policy_loss``, to pin the
+resulting ``pg_loss`` against hand-computed references.
+"""
+
+import math
+
+import pytest
+import torch
+
+from relax.utils.training.ppo_utils import (
+    compute_policy_loss,
+    get_rloo_advantages,
+    scale_centered_rewards_for_rloo,
+)
+
+
+def _centered(rewards: torch.Tensor) -> torch.Tensor:
+    return rewards - rewards.mean()
+
+
+@pytest.mark.parametrize("k", [2, 3, 5, 8, 16])
+def test_two_formulations_agree(k):
+    """A_i = R_i - mean(R_j, j!=i) equals k/(k-1) * (R_i - mean(R)) for every group size."""
+    torch.manual_seed(0)
+    rewards = torch.randn(k, dtype=torch.float64)
+    direct = get_rloo_advantages(rewards)
+    rescaled = scale_centered_rewards_for_rloo(_centered(rewards))
+    assert torch.allclose(direct, rescaled, atol=1e-12), (
+        f"k={k}: leave-one-out form {direct.tolist()} != rescaled form {rescaled.tolist()}"
+    )
+
+
+def test_matches_hand_computed_reference():
+    """k=8 with three correct answers matches the reference values."""
+    rewards = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    advantages = get_rloo_advantages(rewards)
+    # A correct sample is compared against the other seven: mean([1,1,0,0,0,0,0]) = 2/7.
+    expected_correct = 1.0 - 2.0 / 7.0
+    # A wrong sample is compared against mean([1,1,1,0,0,0,0]) = 3/7.
+    expected_wrong = 0.0 - 3.0 / 7.0
+    expected = torch.tensor([expected_correct] * 3 + [expected_wrong] * 5, dtype=torch.float64)
+    assert torch.allclose(advantages, expected, atol=1e-12), f"expected {expected.tolist()}, got {advantages.tolist()}"
+    assert pytest.approx(expected_correct, abs=1e-4) == 0.7143, "correct-sample advantage should be ~+0.7143"
+    assert pytest.approx(expected_wrong, abs=1e-4) == -0.4286, "wrong-sample advantage should be ~-0.4286"
+
+
+@pytest.mark.parametrize("k", [2, 4, 8])
+def test_group_sums_to_zero(k):
+    """Leave-one-out advantages are centered, so each group sums to zero."""
+    torch.manual_seed(1)
+    rewards = torch.randn(k, dtype=torch.float64)
+    assert abs(float(get_rloo_advantages(rewards).sum())) < 1e-12, "RLOO advantages must sum to zero per group"
+
+
+def test_single_sample_group_is_zero_not_nan():
+    """k=1 has no baseline; both helpers return zero, not a division."""
+    rewards = torch.tensor([3.5], dtype=torch.float64)
+    for name, out in (
+        ("get_rloo_advantages", get_rloo_advantages(rewards)),
+        ("scale_centered_rewards_for_rloo", scale_centered_rewards_for_rloo(_centered(rewards))),
+    ):
+        assert out.shape == rewards.shape, f"{name} must preserve shape for k=1"
+        assert torch.all(torch.isfinite(out)), f"{name} must not produce NaN/Inf for k=1"
+        assert float(out.abs().sum()) == 0.0, f"{name} must return exactly zero for k=1"
+
+
+def test_zero_variance_group_is_zero():
+    """All-equal rewards carry no signal, so every advantage is zero."""
+    for value in (0.0, 1.0, -2.5):
+        rewards = torch.full((8,), value, dtype=torch.float64)
+        advantages = get_rloo_advantages(rewards)
+        assert torch.all(torch.isfinite(advantages)), f"reward={value} produced non-finite advantages"
+        assert float(advantages.abs().max()) < 1e-12, f"reward={value} must give all-zero advantages"
+
+
+def test_no_std_normalization_unlike_grpo():
+    """RLOO must not divide by the group std, only rescale by k/(k-1)."""
+    rewards = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    centered = _centered(rewards)
+    rloo = get_rloo_advantages(rewards)
+    grpo = centered / (rewards.std() + 1e-6)  # mirrors relax/utils/utils.py group norm
+
+    ratio = rloo / centered
+    assert torch.allclose(ratio, torch.full_like(ratio, 8 / 7), atol=1e-12), (
+        "RLOO/centered ratio must be exactly k/(k-1) = 8/7"
+    )
+    assert not torch.allclose(rloo, grpo, atol=1e-3), "RLOO must differ from std-normalized GRPO advantages"
+
+
+def test_dtype_and_device_preserved():
+    """Helpers keep the caller's dtype, so float32 callers are unaffected."""
+    for dtype in (torch.float32, torch.float64):
+        rewards = torch.tensor([1.0, 0.0, 0.0, 1.0], dtype=dtype)
+        assert get_rloo_advantages(rewards).dtype == dtype, f"dtype {dtype} not preserved"
+        assert scale_centered_rewards_for_rloo(_centered(rewards)).dtype == dtype, f"dtype {dtype} not preserved"
+
+
+def test_integer_rewards_promote_instead_of_truncating():
+    """Integer rewards must promote to float, not floor the division."""
+    rewards = torch.tensor([1, 0, 0, 0], dtype=torch.int64)
+    advantages = get_rloo_advantages(rewards)
+    assert advantages.is_floating_point(), "integer rewards must promote to a float dtype, not truncate"
+    expected = torch.tensor([1.0, -1 / 3, -1 / 3, -1 / 3], dtype=torch.float64)
+    assert torch.allclose(advantages.double(), expected, atol=1e-6), (
+        f"expected {expected.tolist()}, got {advantages.tolist()}"
+    )
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_reward_contaminates_only_its_own_group(bad):
+    """A non-finite reward propagates across its whole group.
+
+    Documented as a known limitation rather than silently masked: the baseline
+    is a group-wide sum, so one bad sample poisons its group. Callers must
+    filter upstream; zeroing it here would hide a broken reward function.
+    """
+    rewards = torch.tensor([1.0, 0.0, bad, 0.0], dtype=torch.float64)
+    advantages = get_rloo_advantages(rewards)
+    assert not torch.all(torch.isfinite(advantages)), (
+        "a non-finite reward must remain visible in the advantages, not be silently zeroed"
+    )
+    clean = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    assert torch.all(torch.isfinite(get_rloo_advantages(clean))), "a clean group must stay finite"
+
+
+@pytest.mark.parametrize("shape", [(2, 4), (8, 1), (1, 1, 8)])
+def test_non_1d_input_raises_instead_of_silently_using_the_wrong_group_size(shape):
+    """A 2-D batch must fail loudly, not be reduced as one oversized group.
+
+    Before the guard, ``[[1, 0], [0, 1]]`` returned +-0.667 -- the answer for a
+    single group of four -- where the correct per-row answer is +-1.0. Nothing
+    raised, so the caller had no way to notice.
+    """
+    values = torch.zeros(shape, dtype=torch.float64)
+    for name, fn in (
+        ("get_rloo_advantages", get_rloo_advantages),
+        ("scale_centered_rewards_for_rloo", scale_centered_rewards_for_rloo),
+    ):
+        with pytest.raises(ValueError, match="1-D"):
+            fn(values)
+        assert True, name  # keep the name in the failure output
+
+
+def test_1d_group_of_two_still_works_after_the_shape_guard():
+    """Sanity check that the guard does not reject the smallest valid group."""
+    advantages = get_rloo_advantages(torch.tensor([1.0, 0.0], dtype=torch.float64))
+    assert torch.allclose(advantages, torch.tensor([1.0, -1.0], dtype=torch.float64), atol=1e-12)
+
+
+def test_policy_loss_from_rloo_advantages_at_ratio_one():
+    """reward -> advantage -> pg_loss matches hand-computed values at ratio 1.
+
+    With one correct answer out of four, RLOO gives A = [1, -1/3, -1/3, -1/3].
+    At ``ppo_kl = 0`` the ratio is exactly 1, so ``pg_loss = -A`` element-wise and
+    nothing is clipped.
+    """
+    rewards = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    advantages = get_rloo_advantages(rewards)
+    assert torch.allclose(advantages, torch.tensor([1.0, -1 / 3, -1 / 3, -1 / 3], dtype=torch.float64), atol=1e-12)
+
+    ppo_kl = torch.zeros_like(advantages)
+    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
+
+    expected = torch.tensor([-1.0, 1 / 3, 1 / 3, 1 / 3], dtype=torch.float64)
+    assert torch.allclose(pg_losses, expected, atol=1e-12), f"expected {expected.tolist()}, got {pg_losses.tolist()}"
+    assert float(clipfrac.sum()) == 0.0, "an unchanged policy must not clip any token"
+
+
+def test_policy_loss_from_rloo_advantages_clips_positive_side_only():
+    """At ratio 1.5 the positive-advantage token clips; negative ones do not.
+
+    Reference, with ``eps_clip = eps_clip_high = 0.2`` so the ratio clamps to 1.2:
+
+    * ``A = +1``:   ``max(-1.5 * 1, -1.2 * 1) = -1.2``          -> clipped
+    * ``A = -1/3``: ``max(-1.5 * -1/3, -1.2 * -1/3) = 0.5``     -> unclipped
+    """
+    rewards = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    advantages = get_rloo_advantages(rewards)
+    ppo_kl = torch.full_like(advantages, -math.log(1.5))  # ratio = exp(-ppo_kl) = 1.5
+
+    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
+
+    expected = torch.tensor([-1.2, 0.5, 0.5, 0.5], dtype=torch.float64)
+    assert torch.allclose(pg_losses, expected, atol=1e-12), f"expected {expected.tolist()}, got {pg_losses.tolist()}"
+    assert clipfrac.tolist() == [1.0, 0.0, 0.0, 0.0], (
+        f"only the positive-advantage token should clip, got {clipfrac.tolist()}"
+    )
+
+
+def test_policy_loss_rloo_and_grpo_differ_only_by_advantage_scale():
+    """At ratio 1 the RLOO/GRPO pg_loss ratio equals their advantage ratio.
+
+    Confirms RLOO changes the loss only through the advantage, leaving the
+    clipped objective itself untouched.
+    """
+    rewards = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    centered = _centered(rewards)
+    rloo_adv = get_rloo_advantages(rewards)
+    grpo_adv = centered / (rewards.std() + 1e-6)
+
+    ppo_kl = torch.zeros_like(rloo_adv)
+    rloo_loss, _ = compute_policy_loss(ppo_kl, rloo_adv, eps_clip=0.2, eps_clip_high=0.2)
+    grpo_loss, _ = compute_policy_loss(ppo_kl, grpo_adv, eps_clip=0.2, eps_clip_high=0.2)
+
+    assert torch.allclose(rloo_loss / grpo_loss, rloo_adv / grpo_adv, atol=1e-12), (
+        "the loss ratio must track the advantage ratio exactly"
+    )

--- a/tests/utils/training/test_rloo_utils.py
+++ b/tests/utils/training/test_rloo_utils.py
@@ -22,6 +22,7 @@ from relax.utils.training.ppo_utils import (
     compute_policy_loss,
     compute_rloo_loss,
     get_rloo_advantages,
+    get_rloo_baseline,
     scale_centered_rewards_for_rloo,
 )
 
@@ -293,3 +294,62 @@ def test_empty_response_contributes_no_loss_but_still_feeds_the_baseline():
     assert not torch.allclose(advantages[:3], without_it), (
         "the empty sample's reward must still participate in the other baselines"
     )
+
+
+def test_baseline_is_raw_reward_minus_advantage_element_wise():
+    """b_i = R_i - A_i, broadcast over each sample's tokens."""
+    advantages = [torch.tensor([0.75, 0.75], dtype=torch.float64), torch.tensor([-0.25], dtype=torch.float64)]
+    raw_rewards = [1.0, 0.0]
+
+    baseline = get_rloo_baseline(raw_rewards, advantages)
+
+    expected = torch.tensor([1.0 - 0.75, 1.0 - 0.75, 0.0 - (-0.25)], dtype=torch.float64)
+    assert torch.allclose(baseline, expected, atol=1e-12), f"expected {expected.tolist()}, got {baseline.tolist()}"
+
+
+def test_baseline_layout_follows_the_advantages_not_the_response_lengths():
+    """The regression this function exists to prevent.
+
+    Under CP>1 the advantages handed to the loss are the rank-local shard while
+    ``response_lengths`` stays full-length. An earlier implementation built the
+    broadcast from the lengths and produced a tensor of the wrong size --
+    measured on 8xH100, 1536 against an advantage shard of 740 -- which is a
+    shape error at best and a silently wrong baseline at worst. Shape must
+    track the advantages.
+    """
+    full_response_length = 8
+    shard = full_response_length // 2  # what a CP=2 rank actually holds
+    advantages = [torch.full((shard,), 0.5, dtype=torch.float64) for _ in range(3)]
+
+    baseline = get_rloo_baseline([1.0, 1.0, 0.0], advantages)
+
+    assert baseline.numel() == 3 * shard, (
+        f"baseline must match the advantage shard ({3 * shard} elements), got {baseline.numel()}"
+    )
+    assert baseline.numel() != 3 * full_response_length, "must not be sized from the full response length"
+
+
+def test_baseline_preserves_dtype_and_device_of_the_advantages():
+    """ones_like inherits both, so no explicit dtype/device plumbing is
+    needed."""
+    for dtype in (torch.float32, torch.float64):
+        advantages = [torch.zeros(4, dtype=dtype)]
+        out = get_rloo_baseline([1.0], advantages)
+        assert out.dtype == dtype and out.shape == advantages[0].shape
+
+
+def test_baseline_rejects_a_length_mismatch_instead_of_truncating():
+    """A short reward list would otherwise zip-truncate into a too-short
+    baseline."""
+    advantages = [torch.zeros(2, dtype=torch.float64) for _ in range(3)]
+    with pytest.raises(ValueError, match="one-to-one per sample"):
+        get_rloo_baseline([1.0, 0.0], advantages)
+
+
+def test_baseline_accepts_a_reward_tensor_as_well_as_a_list():
+    """raw_reward may arrive as a tensor after the transfer queue; both must
+    work."""
+    advantages = [torch.zeros(2, dtype=torch.float64), torch.zeros(2, dtype=torch.float64)]
+    from_list = get_rloo_baseline([1.0, 0.5], advantages)
+    from_tensor = get_rloo_baseline(torch.tensor([1.0, 0.5], dtype=torch.float64), advantages)
+    assert torch.allclose(from_list, from_tensor, atol=1e-12)

--- a/tests/utils/training/test_rloo_utils.py
+++ b/tests/utils/training/test_rloo_utils.py
@@ -20,6 +20,7 @@ import torch
 
 from relax.utils.training.ppo_utils import (
     compute_policy_loss,
+    compute_rloo_loss,
     get_rloo_advantages,
     scale_centered_rewards_for_rloo,
 )
@@ -121,9 +122,11 @@ def test_integer_rewards_promote_instead_of_truncating():
 def test_non_finite_reward_contaminates_only_its_own_group(bad):
     """A non-finite reward propagates across its whole group.
 
-    Documented as a known limitation rather than silently masked: the baseline
-    is a group-wide sum, so one bad sample poisons its group. Callers must
-    filter upstream; zeroing it here would hide a broken reward function.
+    This helper is deliberately transparent: the baseline is a group-wide sum, so
+    one bad sample poisons its group, and zeroing it here would hide a broken
+    reward function. Rejection happens one level up, in ``post_process_rewards``
+    (see ``test_non_finite_reward_is_rejected_with_the_offending_position``), where
+    the sample position is still known and can be reported.
     """
     rewards = torch.tensor([1.0, 0.0, bad, 0.0], dtype=torch.float64)
     advantages = get_rloo_advantages(rewards)
@@ -215,4 +218,78 @@ def test_policy_loss_rloo_and_grpo_differ_only_by_advantage_scale():
 
     assert torch.allclose(rloo_loss / grpo_loss, rloo_adv / grpo_adv, atol=1e-12), (
         "the loss ratio must track the advantage ratio exactly"
+    )
+
+
+def test_rloo_loss_is_unclipped_reinforce():
+    """RLOO's loss is -A * log pi, with no trust region at all.
+
+    Pinned against PPO-Clip because the difference is the whole point: reusing the
+    clipped objective would make this "GRPO with a leave-one-out baseline" rather
+    than RLOO as published, and clipping would bias an estimator chosen for being
+    unbiased.
+    """
+    advantages = torch.tensor([1.0, -1 / 3, -1 / 3, -1 / 3], dtype=torch.float64)
+    log_probs = torch.tensor([-0.5, -1.0, -2.0, -0.25], dtype=torch.float64)
+
+    pg_loss, clipfrac = compute_rloo_loss(log_probs=log_probs, advantages=advantages)
+
+    assert torch.allclose(pg_loss, -(advantages * log_probs), atol=1e-12)
+    assert float(clipfrac.abs().sum()) == 0.0, "RLOO clips nothing, so clipfrac must be all zero"
+    assert pg_loss.shape == log_probs.shape, "loss must stay element-wise; the caller reduces"
+
+
+def test_rloo_loss_ignores_the_ratio_that_ppo_clip_would_use():
+    """A large policy shift changes PPO-Clip's loss but must not change RLOO's.
+
+    At ratio 1.5 PPO-Clip clamps the positive-advantage token; RLOO has no
+    ratio term, so its loss depends only on the current log-prob.
+    """
+    advantages = torch.tensor([1.0, -1.0], dtype=torch.float64)
+    log_probs = torch.tensor([-0.5, -0.5], dtype=torch.float64)
+    ppo_kl = torch.full_like(advantages, -math.log(1.5))
+
+    rloo_loss, _ = compute_rloo_loss(log_probs=log_probs, advantages=advantages)
+    clipped, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
+
+    assert float(clipfrac.sum()) > 0, "the reference PPO-Clip case must actually clip"
+    assert not torch.allclose(rloo_loss, clipped), "RLOO must not reproduce the clipped objective"
+
+
+def test_rloo_loss_gradient_flows_only_through_log_probs():
+    """Advantages are detached: they scale the gradient but receive none."""
+    advantages = torch.tensor([0.75, -0.75], dtype=torch.float64, requires_grad=True)
+    log_probs = torch.tensor([-0.5, -1.5], dtype=torch.float64, requires_grad=True)
+
+    pg_loss, _ = compute_rloo_loss(log_probs=log_probs, advantages=advantages)
+    pg_loss.sum().backward()
+
+    assert advantages.grad is None, "advantages must be detached, not a gradient path"
+    assert torch.allclose(log_probs.grad, -advantages.detach(), atol=1e-12)
+
+
+def test_empty_response_contributes_no_loss_but_still_feeds_the_baseline():
+    """A zero-valid-token response must not affect the loss, yet must still
+    count.
+
+    Acceptance criterion 2 names "empty response" explicitly. The two halves are
+    separate: the sample contributes nothing to the objective (its mask is all
+    zero), but its reward still participates in the other samples' leave-one-out
+    baselines -- dropping it would bias every other advantage in the group.
+    """
+    rewards = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    advantages = get_rloo_advantages(rewards)
+
+    # The empty sample is index 3; an all-zero mask means no valid response token.
+    log_probs = torch.tensor([-0.5, -1.0, -2.0, -0.25], dtype=torch.float64)
+    mask = torch.tensor([1.0, 1.0, 1.0, 0.0], dtype=torch.float64)
+
+    pg_loss, _ = compute_rloo_loss(log_probs=log_probs, advantages=advantages)
+    masked = pg_loss * mask
+
+    assert float(masked[3]) == 0.0, "an empty response must contribute exactly zero loss"
+    # Its reward is still in the baseline: dropping it would change the others.
+    without_it = get_rloo_advantages(rewards[:3])
+    assert not torch.allclose(advantages[:3], without_it), (
+        "the empty sample's reward must still participate in the other baselines"
     )


### PR DESCRIPTION
Closes #174

Adds RLOO (REINFORCE Leave-One-Out, [arXiv:2402.14740](https://arxiv.org/abs/2402.14740)) as a synchronous `--advantage-estimator` option.

## What it does

Each sample is scored against the mean of the **other** `k-1` samples in its prompt group, and that is optimised with plain REINFORCE:

$$\hat{A}_i = R_i - \frac{1}{k-1}\sum_{j \neq i} R_j = \frac{k}{k-1}\left(R_i - \bar{R}\right)$$

$$L_i = -\text{sg}(\hat{A}_i)\,\log \pi_\theta(y_i)$$

Because the baseline excludes $R_i$ it is independent of the sample it evaluates, which is what makes the estimator unbiased. No standard-deviation scaling, and **no trust region**.

With $k=8$, three correct and five wrong:

| | GRPO default (center ÷ std) | GRPO `--disable-grpo-std-normalization` | **RLOO** |
|---|---|---|---|
| correct (R=1) | +1.2076 | +0.6250 | **+0.7143** |
| wrong (R=0) | −0.7246 | −0.3750 | **−0.4286** |

## Two decisions worth a reviewer's attention

**The objective is unclipped REINFORCE, not PPO-Clip.** `compute_rloo_loss` implements the unclipped form and `loss.py` dispatches to it, following the same extension pattern as `compute_sapo_loss` and `compute_cispo_loss`; technically it is CISPO with the importance-ratio coefficient fixed at 1. Reusing the clipped objective would make this "GRPO with a leave-one-out baseline" rather than RLOO, and would apply a trust region to an estimator chosen precisely for being unbiased. Consequences, both documented:

- `--eps-clip` / `--eps-clip-high` are inert here, and `train/pg_clipfrac` is always 0 — confirmed on 8×H100, every step, at CP=1, 2 and 4.
- **Exactly one optimizer step per rollout is a correctness requirement**, not a tuning choice: with no ratio term, a second step trains at updated weights against log-probabilities sampled from the old ones and nothing corrects the gap. The recipe therefore sets `rollout_batch_size × n_samples_per_prompt == global_batch_size`.

**Relationship to `--disable-grpo-std-normalization`.** With std normalization off, GRPO produces exactly $R_i - \bar{R}$, so $\hat{A}^\text{RLOO}_i = \frac{k}{k-1}\hat{A}^{\text{GRPO, no-std}}_i$ element-wise. Group size is asserted equal to `--n-samples-per-prompt`, so $k$ is constant within a run and that factor is a global constant, which Adam largely absorbs. The advantage therefore differs from that flag only by a constant — the substantive differences are the objective, and the comparison against **default** GRPO, which reweights groups by their individual std. Pinned by `test_rloo_equals_grpo_without_std_up_to_k_over_k_minus_1` and stated in the docs so the benefit is not misattributed.

## Change surface

19 files, +1580 / −23. No numerical change to any existing estimator: every edit is an addition to a membership list or a branch guarded on `advantage_estimator == "rloo"`, and the std-normalization branch still keys on the original `["grpo", "gspo", "sapo", "cispo"]`.

| File | Change |
|---|---|
| `relax/utils/training/ppo_utils.py` | `get_rloo_advantages`, `scale_centered_rewards_for_rloo`, `compute_rloo_loss`, `get_rloo_baseline`. The two advantage helpers reject non-1D input: the baseline is a whole-group reduction, so a 2-D tensor would be reduced as one oversized group and silently return wrong numbers (`[[1,0],[0,1]]` gave ±0.667 where the correct per-row answer is ±1.0) |
| `relax/utils/utils.py` | RLOO branch in `post_process_rewards`; non-finite reward rejection; the group-aware debug-subsampling list extended in step, without which groups get sliced apart and the baseline breaks |
| `relax/backends/megatron/loss.py` | Estimator dispatch; `compute_rloo_loss` dispatch; three RLOO metrics |
| `relax/backends/megatron/model.py` | `raw_reward` added to the training micro-batch key list, needed by `rloo_baseline`. `DataIterator` yields `None` for keys the rollout side did not produce, so this is inert for every other estimator |
| `relax/components/advantages.py`, `relax/core/registry.py` | Dispatch list; `ALGOS["rloo"]` (unregistered estimators raise at startup) |
| `relax/utils/arguments.py` | `--advantage-estimator` choice plus four startup guards |
| `examples/algorithms/run-qwen3-0.6B-1xgpu-gsm8k-rloo.sh` | Single-GPU recipe, flat file matching the existing `run-qwen35-9B-…-cispo-async.sh` convention |
| `docs/{en,zh}/examples/algorithms.md`, `docs/{en,zh}/guide/configuration.md`, `examples/algorithms/README.md`, `README.md`, `README_zh.md` | Algorithm reference, estimator lists, feature bullet, algorithm table |
| `tests/` (4 files, 66 tests) | See below |

### Monitoring metrics

The generic advantage mean is uninformative for RLOO — leave-one-out advantages sum to zero per group, so it is ~0 by construction.

| Metric | Why |
|---|---|
| `rloo_baseline` | The baseline itself. `b_i = R_i - A_i` follows from the definition, so broadcasting each sample's raw reward over its advantage tensor and subtracting recovers it. Implemented in `ppo_utils` following `get_grpo_returns`' `ones_like` pattern so the layout tracks the advantages rather than `response_lengths` — under CP>1 the advantages are the rank-local shard while the lengths stay full-length |
| `rloo_advantage_abs` | Magnitude: whether any learning signal survives at all |
| `rloo_no_signal_fraction` | Share of tokens with exactly zero advantage, hence no gradient. Mostly caused by a group that scored identically, so it surfaces reward saturation before the reward curve flattens. It is a per-token count: for $k \geq 3$ a single sample can land on the group mean (rewards 1, 0.5, 0 → advantages 0.75, 0, −0.75) and is counted too |

`rloo_no_signal_fraction` earned its place immediately — see the experiment below.

### Startup guards

Rejected at parse time rather than discovered mid-run:

| Rejected | Why |
|---|---|
| `--fully-async` / `--hybrid` | Synchronous-only per the task; asynchronous RLOO was never validated, so it is refused rather than silently allowed |
| `--n-samples-per-prompt < 2` | A group of one has no leave-one-out baseline |
| `--disable-rewards-normalization` | Skips the step that builds the baseline, silently degrading RLOO to baseline-free REINFORCE |
| `--normalize-advantages` | `distributed_masked_whiten` re-whitens across the DP group *after* the split, re-introducing the std normalization RLOO omits and making the advantage depend on the partitioning |

## Verification

### Element-wise correctness

`atol=1e-12` in float64. The loss under test is RLOO's own: `compute_rloo_loss` gives `-(A · log π)` with `clipfrac ≡ 0`, a separate test asserts it does *not* reproduce PPO-Clip at a ratio that would clip, and gradient flow is pinned (advantages detached, so `d/d log π = -A`). Baseline cross-checked in both algebraic forms for $k \in \{2,3,5,8,16\}$.

### Edge cases

`k < 2` rejected at startup; group size disagreeing with `--n-samples-per-prompt` raises; masked positions never contribute; a zero-valid-token response contributes exactly zero loss **while its reward still participates in the other samples' baselines** — dropping it would bias every other advantage in the group, and both halves are pinned separately; NaN/±Inf rejected with the offending sample positions, scoped to `rloo`, with a test asserting GRPO's behaviour is unchanged; zero-variance groups; integer→float promotion.

### DP/CP invariance

**DP is structural.** `post_process_rewards` runs inside `convert_samples_to_train_data` on the rollout side, before the batch enters the TransferQueue and is handed to data-parallel ranks, so the per-sample advantage is fixed before any DP split exists. Two tests pin it: normalizing a whole batch equals normalizing each would-be DP shard separately, and permuting groups within the batch changes nothing. The `--normalize-advantages` guard above is a precondition for this, not a nicety.

**CP is verified against a real process group.** For `cp_size ∈ {2,4}` × `calculate_per_token_loss ∈ {False,True}`, the sum of each rank's partial reduction equals the `cp_size=1` result. A separate test pins that the per-rank slices partition each response *exactly once*, so the agreement cannot arise through cancellation. The same invariance is then checked over a real `torch.distributed` process group — gloo, `world_size ∈ {2,4}`, an actual `all_reduce(SUM)` — following `test_gdn_cp_reassembly.py` in the same directory, so no GPU is needed.

**Multi-GPU, 8 × H100.** Verified at this commit, with the commit hash, a clean tree and the symbols actually present in the files the container imports all checked first:

| | CP | DP | `rloo_baseline` | `rollout/raw_reward` | `pg_clipfrac` | `ppo_kl` |
|---|---|---|---|---|---|---|
| C1 | 1 | 8 | 0.869 / 0.467 / 0.667 | 0.891 / 0.469 / 0.688 | 0 | 0 |
| C2 | **2** | 4 | 0.889 / 0.833 / 0.316 | 0.906 / 0.844 / 0.344 | 0 | 0 |
| C4 | **4** | 2 | 0.855 / 0.902 / 0.411 | 0.875 / 0.906 / 0.406 | 0 | 0 |

The baseline stays within 0.002–0.028 of the raw reward. It should be close but not equal — token weighting means `mean_token(A) ≠ 0`, so exact equality would mean the metric had collapsed onto the reward. `C1` needed `--micro-batch-size 8 --global-batch-size 64`, the `DP=8` constraint the recipe documents.

## Experiment: RLOO vs GRPO

1 × H100, Qwen3-0.6B, GSM8K, colocate, 60 rollouts. Identical configuration except `--advantage-estimator`; same seed, data order and budget. The GRPO arm is generated from the committed recipe by substituting only the estimator name.

| Metric (mean over run) | RLOO | GRPO |
|---|---|---|
| `rollout/raw_reward` | 0.7146 | 0.7224 |
| `train/pg_clipfrac` | **0.0** | 5.97e-4 |
| `train/grad_norm` | 0.445 | 0.810 |
| `train/pg_loss` | −0.0261 | +0.0447 |
| `train/entropy_loss` | 0.488 | 0.492 |
| `train/ppo_kl` | 5.94e-4 | 5.98e-4 |
| `rollout/response_lengths` | 1283 | 1299 |
| `rloo_no_signal_fraction` | 0.481 | n/a |

**Reward is a tie.** −0.0078 against a pooled standard error of 0.0332 — 0.24 SE. With 4 prompts × 8 samples per rollout the per-rollout sd is ≈ 0.18, so this setup cannot resolve a small capability difference, and no claim is made that either estimator learns better. Both arms improved (RLOO 0.703 → 0.763, GRPO 0.734 → 0.766).

**Getting to a valid comparison took three passes**, recorded because the first two are not usable:

| pass | `--clip-grad` | steps/rollout | reward diff | verdict |
|---|---|---|---|---|
| 1 | 1.0 (Megatron default) | 2 | +0.0005 = 0.02 SE | **invalid**: GRPO exceeded the clip threshold on 68% of steps against RLOO's 2%, so the arms were not optimised under equal terms |
| 2 | 0 | 2 | +0.0026 = 0.08 SE | **invalid**: RLOO ran outside its own precondition — two steps per rollout with no importance ratio means the second step trains off-policy uncorrected |
| 3 | 0 | **1** | −0.0078 = 0.24 SE | valid; reported above |

All three agree that reward is a tie, so the conclusion is not sensitive to either flaw — but only the third was measured under conditions the algorithm assumes.

**The gradient-magnitude difference is explained.** GRPO divides by the group std while RLOO multiplies by `k/(k-1)`, so the ratio should be `(k/(k-1)) · std`; measured 0.55. Adam is largely invariant to a constant gradient rescale, so this is not a reason to retune `--lr` — it is a reason to revisit `--clip-grad`, which the docs now say.

**Reading `pg_loss`.** It is routinely negative and unbounded below, both expected for an unclipped objective and both documented. `-(A · log π)` equals `A · |log π|`, so a negative mean says positive-advantage tokens carry smaller `|log π|`; and for `A < 0` minimising it pushes `log π` toward `-∞` with no trust region to stop it. Over 60 steps it stayed well behaved (`grad_norm` 0.445, entropy 0.488), but the docs say to judge stability from `entropy_loss` and `grad_norm` rather than `pg_loss`.

**What the new metric showed.** `rloo_no_signal_fraction` averaged 0.481, rose to 0.646 over the last ten rollouts and reached 1.0 on individual steps: roughly half the tokens sat in groups that scored identically and contributed no gradient. That is reward saturation on GSM8K as the model improves, and it explains the exact-zero `pg_loss` steps that motivated adding the metric.

## Not covered

- **Asynchronous RLOO** — out of scope per the task, and rejected at startup rather than left available untested.
- **Paper-faithful reduction.** RLOO's paper sums log-probabilities over a whole sequence; this uses the framework reducer (per-sample mean, or token-weighted with `--calculate-per-token-loss`). Element-wise agreement is therefore *before* reduction. Supporting the paper's form means a third reduction mode in `cp_utils.py` — a file every estimator shares — plus a matching change to the denominator selection at `loss.py`, plus CP coverage for the new mode. Happy to do that as its own change with its own tests; it did not seem right to add an unvalidated branch to a shared reduction path here. Please say if you would rather have it as the default.
- **`CP>1` offline replay of the dumped tensors** is not possible, for a dump-schema reason unrelated to RLOO: `advantages` follows the forward's CP-sharded `log_probs` while `loss_masks` is the full response, the lengths disagree, and no shard index is recorded. Tracked under #171. This limits offline replay, not RLOO's correctness under CP, which the runs above cover.

## One architectural observation, for you to decide

Estimator membership is tested in five places, and they are not one list but **three semantically distinct lists whose differences are undocumented**:

| Location | Members | Meaning |
|---|---|---|
| `relax/utils/utils.py` (group norm, debug subsampling) | grpo, gspo, sapo, cispo, reinforce_plus_plus_baseline, **rloo** | does group normalization apply |
| `relax/utils/utils.py` (std branch) | grpo, gspo, sapo, cispo | does std normalization apply |
| `relax/components/advantages.py`, `relax/backends/megatron/loss.py` | grpo, gspo, sapo, cispo, **rloo** | use `get_grpo_returns` to broadcast the scalar to tokens |

Plus two docstring enumerations kept in sync by hand. Adding RLOO required touching five of these. Because there are three lists rather than one, a single constant will not do — it needs three named constants, which would also document the differences. Not done here, since it means editing existing lines; happy to do it in this PR or a follow-up.

## Checks

- `pytest tests/ --ignore=tests/autoscale` (CI's invocation, `.github/workflows/ci.yml`): **921 passed**, against **855** on `upstream/main` at `0694cd5` — the difference is exactly the 66 added tests.
- `pre-commit run --all-files`: all 15 hooks pass, idempotently.
- Rebased onto `0694cd5`; the recipe was executed end-to-end on 1 GPU and on 8 GPUs at this commit.
