### PR TITLE
[No.04]perf(training): optimize Qwen3 MoE topology

### DIFF
--- a/scripts/training/text/run-qwen3-30B-A3B-8xgpu.sh
+++ b/scripts/training/text/run-qwen3-30B-A3B-8xgpu.sh
@@ -75,7 +75,7 @@ PERF_ARGS=(
    --tensor-model-parallel-size 4
    --sequence-parallel
    --pipeline-model-parallel-size 1
-   --context-parallel-size 2
+   --context-parallel-size 1
    --expert-model-parallel-size 8
    --expert-tensor-parallel-size 1
 
@@ -131,7 +131,7 @@ OPTIMIZER_ARGS=(
 
 
 SGLANG_ARGS=(
-   --rollout-num-gpus-per-engine 8
+   --rollout-num-gpus-per-engine 4
    --sglang-mem-fraction-static 0.7
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
 )


### PR DESCRIPTION
## Summary

- set `--context-parallel-size` from `2` to `1`
- set `--rollout-num-gpus-per-engine` from `8` to `4`, changing rollout from one TP8 engine to two TP4 engines while keeping 8 rollout GPUs
- select the combined V2+V3 recipe (`optimized1`) validated in #149

This is a combined topology change. Its measured gain should not be attributed to either parameter independently. CP2 to CP1 also changes Actor data parallelism from DP1 to DP2; TP8 to 2xTP4 increases rollout concurrency and changes KV-cache and service-management trade-offs.

## 200-step result

| Metric | Baseline | Optimized1 | Change |
|---|---:|---:|---:|
| Samples/s | 0.778 | 0.937 | +20.54% |
| E2E response tokens/GPU/s | 488.4 | 638.4 | +30.72% |
| Actor train tokens/GPU/s | 2,889.7 | 3,246.6 | +12.35% |
| Mean step time | 329.22 s | 273.11 s | -17.04% |
| P95 step time | 386.09 s | 308.73 s | -20.04% |

The comparison kept the 8xH800 colocated setup, TP4/PP1/EP8/ETP1, GBS 256, 32 prompts x 8 samples, model, dataset, seeds, lengths, dynamic batching, recompute, DeepEP flex, optimizer, and algorithm settings aligned.

## Validation

- `bash -n scripts/training/text/run-qwen3-30B-A3B-8xgpu.sh`
- `git diff --check`
- matched no-profiler 200-step evidence and independent short profiler/MoE routing evidence are summarized in #149

Closes #149
