### PR TITLE
fix(logging_utils): preserve logger hierarchy and eliminate global class mutation

### DIFF
--- a/relax/utils/logging_utils.py
+++ b/relax/utils/logging_utils.py
@@ -234,8 +234,16 @@ def get_logger(name: str, prefix: str = "") -> LazyConfiguredLogger:
     logger = logging.getLogger(name)
     logging.setLoggerClass(logging.Logger)  # Reset to default for other loggers
 
-    if not isinstance(logger, LazyConfiguredLogger):
-        # If logger already exists and is not our class, create a new instance
-        logger = LazyConfiguredLogger(name)
+    if not isinstance(logger, LazyConfiguredLogger) and type(logger) is logging.Logger:
+        # Upgrade the manager-registered instance in place instead of building a
+        # detached `LazyConfiguredLogger(name)`: a Logger constructed directly
+        # (not via getLogger) has parent=None and no handlers, so every record
+        # it emits falls through to logging.lastResort (WARNING+) and INFO
+        # output silently disappears. The name can pre-exist as a plain Logger
+        # because Ray/cloudpickle reconstructs @ray.remote class namespaces by
+        # value and unpickles their module-global loggers via getLogger(name)
+        # with the default logger class (see _LOCAL_ROLLOUT_MANAGER note in
+        # relax/distributed/ray/rollout.py).
+        logger.__class__ = LazyConfiguredLogger
 
     return logger

--- a/relax/utils/logging_utils.py
+++ b/relax/utils/logging_utils.py
@@ -206,7 +206,7 @@ for _method_name in _LOG_METHODS:
     setattr(LazyConfiguredLogger, _method_name, _create_log_method(_method_name))
 
 
-def get_logger(name: str, prefix: str = "") -> LazyConfiguredLogger:
+def get_logger(name: str, prefix: str = "") -> logging.Logger:
     """Get a logger instance with automatic lazy configuration.
 
     Returns a logger that automatically configures logging on first use.
@@ -227,23 +227,26 @@ def get_logger(name: str, prefix: str = "") -> LazyConfiguredLogger:
         prefix: (Deprecated) Additional prefix for log timestamps
 
     Returns:
-        LazyConfiguredLogger: A logger instance ready for use
+        logging.Logger: A logger instance ready for use. This is normally a
+            ``LazyConfiguredLogger``; if ``name`` is already registered as a
+            different ``Logger`` subclass, that instance is returned as-is.
     """
-    # Set the logger class for this logger
-    logging.setLoggerClass(LazyConfiguredLogger)
     logger = logging.getLogger(name)
-    logging.setLoggerClass(logging.Logger)  # Reset to default for other loggers
 
-    if not isinstance(logger, LazyConfiguredLogger) and type(logger) is logging.Logger:
+    if type(logger) is logging.Logger:
         # Upgrade the manager-registered instance in place instead of building a
         # detached `LazyConfiguredLogger(name)`: a Logger constructed directly
         # (not via getLogger) has parent=None and no handlers, so every record
         # it emits falls through to logging.lastResort (WARNING+) and INFO
-        # output silently disappears. The name can pre-exist as a plain Logger
-        # because Ray/cloudpickle reconstructs @ray.remote class namespaces by
-        # value and unpickles their module-global loggers via getLogger(name)
-        # with the default logger class (see _LOCAL_ROLLOUT_MANAGER note in
-        # relax/distributed/ray/rollout.py).
+        # output silently disappears. The plain instance exists either because
+        # getLogger just created it (fresh name, default logger class) or
+        # because the name was pre-registered before get_logger ran — e.g.
+        # Ray/cloudpickle reconstructs @ray.remote class namespaces by value
+        # and unpickles their module-global loggers via getLogger(name) (see
+        # the _LOCAL_ROLLOUT_MANAGER note in relax/distributed/ray/rollout.py).
+        # In-place upgrade also avoids logging.setLoggerClass entirely: that
+        # would mutate process-global state, race with concurrent getLogger
+        # calls on other threads, and stomp third-party default logger classes.
         logger.__class__ = LazyConfiguredLogger
 
     return logger

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,0 +1,138 @@
+"""Regression tests for :func:`relax.utils.logging_utils.get_logger`.
+
+A logger name can already be registered as a plain :class:`logging.Logger`
+before ``get_logger`` runs -- Ray/cloudpickle reconstructs ``@ray.remote``
+class namespaces by value and unpickles their module-global loggers through
+``logging.getLogger(name)`` with the default logger class.
+
+The previous fallback built a fresh ``LazyConfiguredLogger(name)``. Because
+that bypasses ``logging.getLogger``, the resulting object is detached from the
+logging hierarchy: ``parent`` is ``None`` and ``handlers`` is empty, so every
+record falls through to ``logging.lastResort`` (WARNING and above) and all
+INFO output silently disappears.
+"""
+
+import logging
+
+from relax.utils.logging_utils import LazyConfiguredLogger, get_logger
+
+
+def _unregister(name: str) -> None:
+    logging.Logger.manager.loggerDict.pop(name, None)
+
+
+def test_get_logger_returns_lazy_configured_logger():
+    name = "relax_test.logging_utils.fresh"
+    _unregister(name)
+    try:
+        logger = get_logger(name)
+        assert isinstance(logger, LazyConfiguredLogger)
+        assert logging.getLogger(name) is logger
+    finally:
+        _unregister(name)
+
+
+def test_get_logger_upgrades_preregistered_plain_logger_in_place():
+    """The pre-registered instance must be upgraded, not replaced."""
+    name = "relax_test.logging_utils.preregistered"
+    _unregister(name)
+    try:
+        plain = logging.getLogger(name)
+        assert type(plain) is logging.Logger
+
+        logger = get_logger(name)
+
+        assert isinstance(logger, LazyConfiguredLogger)
+        # Same object: upgraded in place rather than detached.
+        assert logger is plain
+        assert logging.getLogger(name) is logger
+    finally:
+        _unregister(name)
+
+
+def test_upgraded_logger_stays_attached_to_hierarchy():
+    """Guards the actual failure mode: silently dropped INFO records.
+
+    A detached logger has ``parent is None`` and no handlers, so records never
+    reach an ancestor handler.
+    """
+    name = "relax_test.logging_utils.attached"
+    _unregister(name)
+    try:
+        logging.getLogger(name)  # pre-register as a plain Logger
+        logger = get_logger(name)
+
+        assert logger.parent is not None
+        assert logger.manager is logging.Logger.manager
+
+        # Walk to the root the way logging.Logger.callHandlers does.
+        ancestors = []
+        current = logger
+        while current:
+            ancestors.append(current)
+            current = current.parent
+        assert ancestors[-1] is logging.getLogger()
+    finally:
+        _unregister(name)
+
+
+def test_upgraded_logger_emits_info_records():
+    """End-to-end guard on the actual failure mode: dropped INFO records.
+
+    ``LazyConfiguredLogger`` installs its own handler on first use, so the
+    record is asserted at the logger's own handlers rather than at the root.
+    A detached logger has no handlers at all and would drop the record to
+    ``logging.lastResort``, which only passes WARNING and above.
+    """
+    name = "relax_test.logging_utils.emit"
+    _unregister(name)
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    try:
+        logging.getLogger(name)  # pre-register as a plain Logger
+        logger = get_logger(name)
+        logger.setLevel(logging.INFO)
+
+        # Trigger lazy configuration so the real handler set is in place.
+        logger.info("warmup")
+
+        handler = _Capture(level=logging.INFO)
+        target = logger if logger.handlers else logger.parent
+        assert target is not None, "logger must be attached to the hierarchy"
+        target.addHandler(handler)
+        try:
+            logger.info("rloo-metrics-visible")
+        finally:
+            target.removeHandler(handler)
+
+        assert "rloo-metrics-visible" in records
+    finally:
+        _unregister(name)
+
+
+def test_get_logger_preserves_logger_subclasses():
+    """Only plain ``logging.Logger`` instances are upgraded."""
+
+    class _CustomLogger(logging.Logger):
+        pass
+
+    name = "relax_test.logging_utils.subclass"
+    _unregister(name)
+    previous_class = logging.getLoggerClass()
+    try:
+        logging.setLoggerClass(_CustomLogger)
+        custom = logging.getLogger(name)
+        logging.setLoggerClass(previous_class)
+        assert type(custom) is _CustomLogger
+
+        logger = get_logger(name)
+
+        # Left untouched: not our class, but not a plain Logger either.
+        assert type(logger) is _CustomLogger
+    finally:
+        logging.setLoggerClass(previous_class)
+        _unregister(name)

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -80,8 +80,8 @@ def test_upgraded_logger_emits_info_records():
     """End-to-end guard on the actual failure mode: dropped INFO records.
 
     ``LazyConfiguredLogger`` installs its own handler on first use, so the
-    record is asserted at the logger's own handlers rather than at the root.
-    A detached logger has no handlers at all and would drop the record to
+    record is asserted at the logger's own handlers rather than at the root. A
+    detached logger has no handlers at all and would drop the record to
     ``logging.lastResort``, which only passes WARNING and above.
     """
     name = "relax_test.logging_utils.emit"
@@ -111,6 +111,37 @@ def test_upgraded_logger_emits_info_records():
 
         assert "rloo-metrics-visible" in records
     finally:
+        _unregister(name)
+
+
+def test_get_logger_leaves_global_logger_class_untouched():
+    """get_logger must not mutate process-global logging state.
+
+    The previous implementation flipped ``logging.setLoggerClass`` around its
+    ``getLogger`` call, which raced with concurrent ``getLogger`` calls on
+    other threads and reset third-party default logger classes to
+    ``logging.Logger``.
+    """
+
+    class _ThirdPartyLogger(logging.Logger):
+        pass
+
+    name = "relax_test.logging_utils.global_class"
+    _unregister(name)
+    previous_class = logging.getLoggerClass()
+    try:
+        logging.setLoggerClass(_ThirdPartyLogger)
+
+        logger = get_logger(name)
+
+        # The third-party default class must survive get_logger.
+        assert logging.getLoggerClass() is _ThirdPartyLogger
+        # A name created under a third-party default class is respected
+        # (registered and attached), consistent with the subclass test below.
+        assert logging.getLogger(name) is logger
+        assert type(logger) is _ThirdPartyLogger
+    finally:
+        logging.setLoggerClass(previous_class)
         _unregister(name)
 
 


### PR DESCRIPTION
## What

`get_logger()` had two independent defects, both silent:

1. It could return a logger **detached from the `logging` hierarchy**, causing
   every `INFO` record emitted through it to be discarded.
2. It mutated **process-global** logging state on every call.

The original implementation:

```python
# Set the logger class for this logger
logging.setLoggerClass(LazyConfiguredLogger)
logger = logging.getLogger(name)
logging.setLoggerClass(logging.Logger)  # Reset to default for other loggers

if not isinstance(logger, LazyConfiguredLogger):
    # If logger already exists and is not our class, create a new instance
    logger = LazyConfiguredLogger(name)

return logger
```

This PR upgrades the already-registered instance in place, drops the
`setLoggerClass` dance entirely, and adds regression tests for both defects.

## Why

### Defect 1 — detached logger swallows `INFO`

Constructing a `Logger` directly (rather than via `logging.getLogger`) bypasses
`Logger.manager`, so the resulting object is not part of the logger tree:

- `parent` is `None`
- `handlers` is `[]`
- `logging.getLogger(name) is not logger`

`Logger.callHandlers` walks `self.parent` looking for handlers; with no parent
and no handlers it finds none and falls back to `logging.lastResort`, which is
fixed at `WARNING` level. Every `INFO` record therefore disappears without any
error. `isEnabledFor(logging.INFO)` still returns `True` on such a logger,
which makes the problem hard to spot.

This is reachable in normal operation: Ray/cloudpickle reconstructs
`@ray.remote` class namespaces by value, and unpickles their module-global
loggers through `logging.getLogger(name)` using the default logger class. That
registers the name as a plain `logging.Logger` before the canonical module is
imported and calls `get_logger()` for the same name. The repository already
documents this reconstruction behaviour in the `_LOCAL_ROLLOUT_MANAGER` note in
`relax/distributed/ray/rollout.py`.

Observed impact: under colocate deployments the whole rollout metrics family
logged by `_log_rollout_data` — the `perf N: {...}` line carrying
`rollout/response_len/*`, `rollout/repetition_frac`, `rollout/truncated_ratio`,
`rollout/zero_std/*`, `perf/*` and friends — never reached the console. The
metrics were computed correctly every step; only the output channel was dead.
Because the affected logger belongs to a different module than the one whose
`__init__` logging still worked, this looked like the metrics code was not
running at all.

### Defect 2 — global `setLoggerClass` mutation

`logging.setLoggerClass()` sets a **process-wide** default. The reset was
unconditional (`setLoggerClass(logging.Logger)`) rather than restoring the
previous value, so a single `get_logger()` call:

- destroyed any default logger class installed earlier by a third-party
  library, silently downgrading every logger that library created afterwards;
- opened a window in which a concurrent `logging.getLogger()` on another thread
  received a `LazyConfiguredLogger` it never asked for.

Neither symptom raises an error, and both are invisible at the call site.

## How

Look the name up normally, then upgrade the manager-registered instance in
place so the `parent`/`handler` chain is preserved:

```python
logger = logging.getLogger(name)

if type(logger) is logging.Logger:
    logger.__class__ = LazyConfiguredLogger

return logger
```

Three details worth noting:

- `LazyConfiguredLogger` declares no `__init__` and no instance attributes — it
  only adds a class-level `_configured` flag plus patched log methods — so
  reassigning `__class__` cannot skip initialisation or drop state. The
  instance `__dict__` keeps all of `name`, `level`, `parent`, `propagate`,
  `handlers`, `filters`, `disabled`, `manager`, `_cache`.
- `setLoggerClass` is no longer needed at all. A brand-new name is created by
  `getLogger` as a plain `logging.Logger` and then takes the same in-place
  upgrade path, so the two cases converge and no global state is touched.
- The `type(logger) is logging.Logger` guard keeps the upgrade narrow: genuine
  third-party `Logger` subclasses are returned untouched rather than being
  silently rewritten.

Because that last case can now return something other than a
`LazyConfiguredLogger`, the return annotation is widened from
`-> LazyConfiguredLogger` to `-> logging.Logger` and the docstring says so.
This is a widening, not a break: callers only use the `logging.Logger` API.

## Testing

Minimal reproduction of defect 1 (standard library only, no Relax imports):

```python
import logging

class LazyConfiguredLogger(logging.Logger):
    _configured = False

name = "demo.orphan"
logging.getLogger(name)             # pre-register as a plain Logger
orphan = LazyConfiguredLogger(name) # previous fallback

print(orphan.parent)                              # None
print(orphan.handlers)                            # []
print(logging.getLogger(name) is orphan)          # False
print(orphan.isEnabledFor(logging.INFO))          # True  <-- misleading

logging.getLogger().addHandler(logging.StreamHandler())
logging.getLogger().setLevel(logging.INFO)
orphan.info("this never appears")                 # silently dropped
```

Replacing the last construction with `plain.__class__ = LazyConfiguredLogger`
restores `parent`, keeps the logger in the manager tree, and the record is
emitted.

New tests — `tests/utils/test_logging_utils.py`:

| Test | Guards |
| --- | --- |
| `test_get_logger_returns_lazy_configured_logger` | happy path still returns the registered instance |
| `test_get_logger_upgrades_preregistered_plain_logger_in_place` | same object is upgraded, not replaced |
| `test_upgraded_logger_stays_attached_to_hierarchy` | `parent` chain reaches the root logger |
| `test_upgraded_logger_emits_info_records` | an `INFO` record actually reaches a handler |
| `test_get_logger_leaves_global_logger_class_untouched` | a third-party default logger class survives `get_logger` |
| `test_get_logger_preserves_logger_subclasses` | third-party `Logger` subclasses are left alone |

Results on this branch:

```text
$ pytest tests/utils/test_logging_utils.py
6 passed in 0.03s

$ pytest tests/utils/
182 passed, 4 skipped in 35.50s

$ pytest tests/
909 passed, 14 skipped in 270.47s

$ ruff check relax/utils/logging_utils.py tests/utils/test_logging_utils.py
All checks passed!

$ ruff format --check relax/utils/logging_utils.py tests/utils/test_logging_utils.py
2 files already formatted

$ pre-commit run --all-files
(15 hooks, all Passed or Skipped-by-file-type; no failures)

$ git diff --check
(clean)
```

Negative control — the tests fail without the fix. Restoring the previous
`get_logger` implementation and re-running:

```text
5 failed, 1 passed
```

The single pass is `test_get_logger_returns_lazy_configured_logger`, which the
old code also satisfied; the five failures pin down the detached `parent`, the
replaced-instead-of-upgraded instance, the dropped `INFO` record, the clobbered
global logger class and the rewritten third-party subclass respectively. The
new tests therefore constrain the behaviour rather than passing
unconditionally.

End-to-end check on a single-GPU colocate run (`Qwen3-0.6B`, GSM8K, 1×A100):
before the fix no `perf N:` line ever reached the console across nine runs;
after the fix it appears on every rollout step, carrying the previously
invisible metrics, e.g. `rollout/response_len/mean = 1094.625`,
`rollout/repetition_frac = 0.0`, `rollout/truncated_ratio = 0.125`.

- [x] `pre-commit run --all-files` passes
- [x] Tests pass  (`pytest tests/` — 909 passed, 14 skipped, 0 failed)
- [x] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

Scope notes for reviewers:

- The `get_logger` docstring is updated in place (return type and the
  third-party-subclass case). No prose documentation appeared to need a change,
  since the fix restores the behaviour the existing docs already describe.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Before the fix — the rollout step completes and metrics are computed, but no
`perf N:` line is ever logged:

```text
| INFO | relax.engine.rollout.sglang_rollout:905  Total yielded: 4/4 for step: 0
| INFO | relax.utils.utils:496                    Prepared rollout batch 4 with 16 samples for transfer
(no `perf 0:` line — rollout metrics silently dropped)
```

After the fix — same configuration, metrics now reach the console:

```text
| INFO | relax.distributed.ray.rollout:3913  perf 0: {..., 'rollout/response_len/mean': 1094.625,
  'rollout/repetition_frac': 0.0, 'rollout/truncated_ratio': 0.125, 'perf/step_time': ..., ...}
```
