### PR TITLE
[Task 33.] feat: add reproducibility bundle manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ traces
 output
 outputs
 tensorboard_log
+relax_runs
 
 .history
 *.log

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -285,6 +285,7 @@ export default defineConfig({
               items: [
                 { text: 'How to Contribute', link: '/en/guide/how-to-contribute' },
                 { text: 'Debugging Guide', link: '/en/guide/debugging' },
+                { text: 'Reproducibility Bundle', link: '/en/guide/reproducibility-bundle' },
                 { text: 'Rollout Result Viewer', link: '/en/guide/rollout-result-viewer' }
               ]
             }
@@ -394,6 +395,7 @@ export default defineConfig({
               items: [
                 { text: '如何贡献', link: '/zh/guide/how-to-contribute' },
                 { text: '调试指南', link: '/zh/guide/debugging' },
+                { text: '可复现实验清单', link: '/zh/guide/reproducibility-bundle' },
                 { text: 'Rollout 结果可视化', link: '/zh/guide/rollout-result-viewer' }
               ]
             }

--- a/docs/en/guide/reproducibility-bundle.md
+++ b/docs/en/guide/reproducibility-bundle.md
@@ -1,0 +1,59 @@
+# Reproducibility Bundle
+
+Relax writes a versioned experiment manifest for every training run. The manifest records enough information to review the code, resolved configuration, software environment, hardware, Ray topology, model and data inputs, and the original command without storing credentials or internal addresses by default.
+
+## Output
+
+The default path is:
+
+```text
+relax_runs/<experiment-name-or-UTC-time>/experiment-manifest.json
+```
+
+Set `RELAX_MANIFEST_PATH` to choose a different file. Manifest creation is best effort: an I/O or collection error emits a warning and never blocks training.
+
+## Schema v1
+
+`schema_version` is currently `1.0`. Readers accept integer v1 and later v1 minor versions, ignore unknown fields, and supply empty defaults for optional sections. A different major version is rejected.
+
+| Section | Contents |
+| --- | --- |
+| `code` | Repository name, commit, branch, and dirty state |
+| `command` | Argument vector and portable working directory |
+| `config` | Resolved arguments and Ray runtime environment |
+| `environment` | Python, platform, package, CUDA, and container image versions |
+| `hardware` | CPU, memory, GPU model, driver, and memory |
+| `runtime` | Local, single-node Ray, or multi-node Ray mode; aggregate resources; per-node resource summaries; role and parallel topology |
+| `inputs` | Model, checkpoint, and dataset identifiers with cheap local file metadata |
+
+Collection avoids recursive directory scans, model hashing, network calls, and `pip freeze`. The manifest includes `collection_duration_ms` so startup overhead can be measured.
+
+## Redaction
+
+Secret-like keys (for example `token`, `password`, `api_key`, and `authorization`) and address-like keys are replaced with `<redacted>`. The same policy is applied recursively to resolved arguments, runtime environment values, and command-line flags. Ray node IDs, hostnames, IP addresses, and node resource labels are never written.
+
+Only a small allowlist of environment information is collected. A command containing a redacted argument cannot be replayed; provide credentials through the runtime environment instead.
+
+## Check and replay
+
+Compare the current code, Python/package versions, platform, CPU, and GPUs with a manifest:
+
+```bash
+python -m relax.entrypoints.reproducibility check path/to/experiment-manifest.json
+```
+
+The command exits with `0` when the environment matches, `1` when drift is found, and `2` for an invalid manifest. Every difference includes a suggested fix, which makes the command suitable for CI.
+
+Preview the recorded command:
+
+```bash
+python -m relax.entrypoints.reproducibility rerun path/to/experiment-manifest.json
+```
+
+Execute it in the current directory after the environment check succeeds:
+
+```bash
+python -m relax.entrypoints.reproducibility rerun path/to/experiment-manifest.json --execute
+```
+
+Use `--allow-drift` only when the reported differences are intentional. Replay passes the recorded argument vector directly to the process and never invokes a shell.

--- a/docs/en/guide/reproducibility-bundle.md
+++ b/docs/en/guide/reproducibility-bundle.md
@@ -7,10 +7,10 @@ Relax writes a versioned experiment manifest for every training run. The manifes
 The default path is:
 
 ```text
-relax_runs/<experiment-name-or-UTC-time>/experiment-manifest.json
+relax_runs/<experiment-name>/<unique-run-id>/experiment-manifest.json
 ```
 
-Set `RELAX_MANIFEST_PATH` to choose a different file. Manifest creation is best effort: an I/O or collection error emits a warning and never blocks training.
+Each default run ID contains a UTC timestamp, process ID, and random suffix, so repeated runs do not overwrite earlier manifests. Set `RELAX_MANIFEST_PATH` to choose a specific file. Manifest creation is best effort: an I/O or collection error emits a warning and never blocks training.
 
 ## Schema v1
 

--- a/docs/zh/guide/reproducibility-bundle.md
+++ b/docs/zh/guide/reproducibility-bundle.md
@@ -7,10 +7,10 @@ Relax 会为每次训练自动生成带版本号的 experiment manifest。它记
 默认路径为：
 
 ```text
-relax_runs/<实验名称或 UTC 时间>/experiment-manifest.json
+relax_runs/<实验名称>/<唯一运行 ID>/experiment-manifest.json
 ```
 
-可通过 `RELAX_MANIFEST_PATH` 指定其他文件。生成 manifest 采用 best-effort 语义：收集或写入失败只输出告警，不会阻塞训练。
+默认运行 ID 包含 UTC 时间、进程 ID 和随机后缀，因此重复运行不会覆盖之前的 manifest。可通过 `RELAX_MANIFEST_PATH` 指定固定文件。生成 manifest 采用 best-effort 语义：收集或写入失败只输出告警，不会阻塞训练。
 
 ## Schema v1
 

--- a/docs/zh/guide/reproducibility-bundle.md
+++ b/docs/zh/guide/reproducibility-bundle.md
@@ -1,0 +1,59 @@
+# 可复现实验清单
+
+Relax 会为每次训练自动生成带版本号的 experiment manifest。它记录代码、最终配置、软件环境、硬件、Ray 拓扑、模型与数据输入以及原始命令，并默认排除凭据和内部地址。
+
+## 输出位置
+
+默认路径为：
+
+```text
+relax_runs/<实验名称或 UTC 时间>/experiment-manifest.json
+```
+
+可通过 `RELAX_MANIFEST_PATH` 指定其他文件。生成 manifest 采用 best-effort 语义：收集或写入失败只输出告警，不会阻塞训练。
+
+## Schema v1
+
+当前 `schema_version` 为 `1.0`。读取器接受整数形式的 v1 和后续 v1 次版本，忽略未知字段，并为空缺的可选分区提供空值。不同主版本会被拒绝。
+
+| 分区 | 内容 |
+| --- | --- |
+| `code` | 仓库名、commit、分支与 dirty 状态 |
+| `command` | 参数数组和可移植工作目录 |
+| `config` | 最终参数与 Ray runtime environment |
+| `environment` | Python、系统、关键包、CUDA 和容器镜像版本 |
+| `hardware` | CPU、内存、GPU 型号、驱动和显存 |
+| `runtime` | 本地、单机 Ray 或多节点 Ray 模式；集群及逐节点资源摘要；角色与并行拓扑 |
+| `inputs` | 模型、checkpoint 和数据集标识，以及低开销的本地文件元数据 |
+
+收集过程不会递归扫描目录、计算模型 hash、访问网络或执行 `pip freeze`。`collection_duration_ms` 字段可用于衡量启动开销。
+
+## 默认脱敏
+
+名称类似 `token`、`password`、`api_key`、`authorization` 和地址的字段会替换成 `<redacted>`。相同规则会递归应用到最终参数、runtime environment 和命令行参数。Ray 节点 ID、主机名、IP 地址及包含节点地址的资源标签不会写入文件。
+
+环境变量仅按小型白名单收集。若命令中存在被脱敏的参数，系统会拒绝复跑；凭据应通过运行环境提供。
+
+## 检查与复跑
+
+比较当前代码、Python/依赖版本、系统、CPU 和 GPU：
+
+```bash
+python -m relax.entrypoints.reproducibility check path/to/experiment-manifest.json
+```
+
+环境一致返回 `0`，发现差异返回 `1`，manifest 无效返回 `2`。每项差异都会给出修复建议，适合接入 CI。
+
+预览记录的命令：
+
+```bash
+python -m relax.entrypoints.reproducibility rerun path/to/experiment-manifest.json
+```
+
+环境检查通过后，在当前目录执行：
+
+```bash
+python -m relax.entrypoints.reproducibility rerun path/to/experiment-manifest.json --execute
+```
+
+只有确认差异符合预期时才使用 `--allow-drift`。复跑直接向子进程传递参数数组，不会调用 shell。

--- a/relax/entrypoints/reproducibility.py
+++ b/relax/entrypoints/reproducibility.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from pathlib import Path
+from typing import Sequence
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.reproducibility import (
+    ManifestError,
+    execute_manifest,
+    inspect_environment,
+    load_manifest,
+    replay_command,
+)
+
+
+logger = get_logger(__name__)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check or replay a Relax experiment manifest.")
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    check_parser = subparsers.add_parser("check", help="Compare the current environment with a manifest.")
+    check_parser.add_argument("manifest", type=Path)
+
+    rerun_parser = subparsers.add_parser("rerun", help="Preview or execute the recorded command.")
+    rerun_parser.add_argument("manifest", type=Path)
+    rerun_parser.add_argument(
+        "--execute", action="store_true", help="Execute after validation; default is preview only."
+    )
+    rerun_parser.add_argument("--allow-drift", action="store_true", help="Execute even if environment drift is found.")
+    return parser
+
+
+def _log_differences(differences: list[dict]) -> None:
+    for difference in differences:
+        logger.warning(
+            "%s differs: expected=%r actual=%r. %s",
+            difference["field"],
+            difference["expected"],
+            difference["actual"],
+            difference["suggestion"],
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        differences = inspect_environment(manifest)
+        if args.action == "check":
+            if differences:
+                _log_differences(differences)
+                return 1
+            logger.info("Environment matches the manifest.")
+            return 0
+
+        command = replay_command(manifest)
+        logger.info("Recorded command: %s", shlex.join(command))
+        if differences:
+            _log_differences(differences)
+        if not args.execute:
+            logger.info("Preview only. Add --execute to rerun the command.")
+            return 0
+        if differences and not args.allow_drift:
+            logger.error("Replay stopped because environment drift was found. Use --allow-drift to override.")
+            return 1
+        return execute_manifest(manifest)
+    except ManifestError as error:
+        logger.error("%s", error)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/relax/entrypoints/train.py
+++ b/relax/entrypoints/train.py
@@ -20,6 +20,7 @@ try_import_telemetry_hook()
 from relax.core.controller import Controller  # noqa: E402
 from relax.utils.arguments import parse_args  # noqa: E402
 from relax.utils.logging_utils import get_logger  # noqa: E402
+from relax.utils.reproducibility import write_experiment_manifest  # noqa: E402
 from relax.utils.tracking_utils import init_tracking  # noqa: E402
 from relax.utils.utils import post_process_env  # noqa: E402
 
@@ -98,6 +99,8 @@ def main(args):
             )
         except RuntimeError:
             pass
+
+    write_experiment_manifest(args, runtime_env, ray_module=ray)
 
     # init_tracking must run after serve.start() (metrics adapter probes Ray
     # Serve for the /metrics endpoint) and before Controller() (wandb primary

--- a/relax/utils/reproducibility.py
+++ b/relax/utils/reproducibility.py
@@ -1,0 +1,561 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import enum
+import importlib
+import importlib.metadata
+import ipaddress
+import json
+import math
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from relax.utils.logging_utils import get_logger
+
+
+logger = get_logger(__name__)
+
+SCHEMA_VERSION = "1.0"
+SUPPORTED_SCHEMA_MAJOR = 1
+REDACTED = "<redacted>"
+
+_PACKAGE_NAMES = ("relax", "ray", "torch", "sglang", "transformers", "megatron-core")
+_IMAGE_ENV_KEYS = ("RELAX_CONTAINER_IMAGE", "CONTAINER_IMAGE", "IMAGE_NAME")
+_INPUT_FIELDS = (
+    "hf_checkpoint",
+    "load",
+    "ref_load",
+    "prompt_data",
+    "eval_prompt_data",
+    "custom_dataset_class_path",
+)
+_PARALLEL_FIELDS = (
+    "tensor_model_parallel_size",
+    "pipeline_model_parallel_size",
+    "context_parallel_size",
+    "expert_model_parallel_size",
+    "expert_tensor_parallel_size",
+    "virtual_pipeline_model_parallel_size",
+    "sequence_parallel",
+)
+_ROLE_FIELDS = {
+    "actor": ("actor_num_nodes", "actor_num_gpus_per_node"),
+    "critic": ("critic_num_nodes", "critic_num_gpus_per_node"),
+    "rollout": (None, "rollout_num_gpus"),
+    "genrm": (None, "genrm_num_gpus"),
+}
+_SECRET_KEY_RE = re.compile(
+    r"(?:^|_)(?:token|password|passwd|secret|api_?key|access_?key|private_?key|credential|authorization|auth)(?:$|_)",
+    re.IGNORECASE,
+)
+_ADDRESS_KEY_RE = re.compile(
+    r"(?:^|_)(?:address|addresses|addr|addrs|host|hostname|ip|endpoint|url)(?:$|_)", re.IGNORECASE
+)
+_IPV4_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.])")
+_NETWORK_LOCATION_RE = re.compile(r"(?P<scheme>\b[a-z][a-z0-9+.-]*://)(?P<location>[^/\s]+)", re.IGNORECASE)
+_ASSIGNMENT_SECRET_RE = re.compile(
+    r"(?i)\b(token|password|passwd|secret|api[-_]?key|access[-_]?key|authorization)=([^\s&]+)"
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+")
+_SAFE_RESOURCE_NAMES = {"CPU", "GPU", "memory", "object_store_memory"}
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest cannot be read or safely replayed."""
+
+
+def _normalise_key(key: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", str(key).lower()).strip("_")
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    return bool(_SECRET_KEY_RE.search(_normalise_key(key)))
+
+
+def _is_address_key(key: Any) -> bool:
+    return bool(_ADDRESS_KEY_RE.search(_normalise_key(key)))
+
+
+def _redact_private_ip(match: re.Match[str]) -> str:
+    value = match.group(0)
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return value
+    if address.is_private or address.is_loopback or address.is_link_local or address.is_reserved:
+        return REDACTED
+    return value
+
+
+def _redact_network_location(match: re.Match[str]) -> str:
+    scheme = match.group("scheme")
+    location = match.group("location")
+    host_port = location.rsplit("@", 1)[-1]
+    host = host_port.rsplit(":", 1)[0].strip("[]").lower()
+    internal_hostname = host in {"localhost", "0.0.0.0"} or "." not in host
+    internal_hostname = internal_hostname or host.endswith((".local", ".internal", ".cluster.local"))
+    try:
+        address = ipaddress.ip_address(host)
+        internal_hostname = internal_hostname or address.is_private or address.is_loopback or address.is_link_local
+    except ValueError:
+        pass
+    if "@" in location or internal_hostname:
+        return f"{scheme}{REDACTED}"
+    return match.group(0)
+
+
+def _sanitize_string(value: str) -> str:
+    value = _BEARER_RE.sub(f"Bearer {REDACTED}", value)
+    value = _ASSIGNMENT_SECRET_RE.sub(lambda match: f"{match.group(1)}={REDACTED}", value)
+    value = _NETWORK_LOCATION_RE.sub(_redact_network_location, value)
+    return _IPV4_RE.sub(_redact_private_ip, value)
+
+
+def sanitize_value(value: Any, *, key: Any = None) -> Any:
+    """Convert a value to JSON-safe data while removing secrets and addresses."""
+    if key is not None and (_is_sensitive_key(key) or _is_address_key(key)):
+        return REDACTED
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, enum.Enum):
+        return sanitize_value(value.value, key=key)
+    if isinstance(value, Path):
+        return _sanitize_string(str(value))
+    if isinstance(value, str):
+        return _sanitize_string(value)
+    if isinstance(value, Mapping):
+        return {str(item_key): sanitize_value(item_value, key=item_key) for item_key, item_value in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [sanitize_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted((sanitize_value(item) for item in value), key=str)
+    if callable(value):
+        module = getattr(value, "__module__", "")
+        name = getattr(value, "__qualname__", getattr(value, "__name__", type(value).__name__))
+        return f"{module}.{name}".lstrip(".")
+    return _sanitize_string(str(value))
+
+
+def sanitize_argv(argv: Sequence[str]) -> list[str]:
+    """Redact sensitive flag values without treating `tokenizer` as `token`."""
+    sanitized: list[str] = []
+    redact_next = False
+    for token in argv:
+        if redact_next:
+            sanitized.append(REDACTED)
+            redact_next = False
+            continue
+        if token.startswith("--"):
+            option, separator, option_value = token.partition("=")
+            option_key = option[2:]
+            if _is_sensitive_key(option_key) or _is_address_key(option_key):
+                if separator:
+                    sanitized.append(f"{option}={REDACTED}")
+                else:
+                    sanitized.append(option)
+                    redact_next = True
+                continue
+        sanitized.append(_sanitize_string(str(token)))
+    return sanitized
+
+
+def _run_git(arguments: Sequence[str], cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _collect_code(cwd: Path) -> dict[str, Any]:
+    repository_root = _run_git(("rev-parse", "--show-toplevel"), cwd)
+    git_cwd = Path(repository_root) if repository_root else cwd
+    status = _run_git(("status", "--porcelain"), git_cwd) if repository_root else None
+    return {
+        "repository": git_cwd.name if repository_root else None,
+        "commit": _run_git(("rev-parse", "HEAD"), git_cwd),
+        "branch": _run_git(("branch", "--show-current"), git_cwd),
+        "dirty": bool(status) if status is not None else None,
+    }
+
+
+def _package_versions() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for package in _PACKAGE_NAMES:
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return versions
+
+
+def _sanitize_image_reference(value: str) -> str:
+    sanitized = _sanitize_string(value)
+    parts = sanitized.split("/", 1)
+    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0] or parts[0] == "localhost"):
+        return f"{REDACTED}/{parts[1]}"
+    return sanitized
+
+
+def _collect_environment(*, probe_framework: bool = False) -> dict[str, Any]:
+    image = next((os.environ.get(key) for key in _IMAGE_ENV_KEYS if os.environ.get(key)), None)
+    environment: dict[str, Any] = {
+        "python": platform.python_version(),
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "packages": _package_versions(),
+        "container_image": _sanitize_image_reference(image) if image else None,
+    }
+    torch_module = sys.modules.get("torch")
+    if torch_module is None and probe_framework:
+        try:
+            torch_module = importlib.import_module("torch")
+        except Exception:
+            torch_module = None
+    if torch_module is not None:
+        torch_version = getattr(torch_module, "version", None)
+        environment["cuda"] = getattr(torch_version, "cuda", None)
+    return environment
+
+
+def _system_memory_bytes() -> int | None:
+    try:
+        return int(os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES"))
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _probe_gpus() -> list[dict[str, Any]]:
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name,driver_version,memory.total", "--format=csv,noheader,nounits"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    gpus = []
+    for line in result.stdout.splitlines():
+        fields = [field.strip() for field in line.split(",")]
+        if len(fields) != 3:
+            continue
+        name, driver, memory_mib = fields
+        try:
+            memory_value: int | None = int(memory_mib)
+        except ValueError:
+            memory_value = None
+        gpus.append({"name": name, "driver": driver, "memory_mib": memory_value})
+    return gpus
+
+
+def _collect_hardware() -> dict[str, Any]:
+    return {
+        "cpu_count": os.cpu_count(),
+        "memory_bytes": _system_memory_bytes(),
+        "gpus": _probe_gpus(),
+    }
+
+
+def _safe_resources(resources: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not resources:
+        return {}
+    safe = {}
+    for name, value in resources.items():
+        if name in _SAFE_RESOURCE_NAMES or name.startswith("accelerator_type:"):
+            safe[name] = sanitize_value(value)
+    return dict(sorted(safe.items()))
+
+
+def _collect_topology(args: Any) -> dict[str, Any]:
+    config = vars(args) if args is not None and hasattr(args, "__dict__") else {}
+    parallelism = {
+        field: sanitize_value(config[field], key=field) for field in _PARALLEL_FIELDS if config.get(field) is not None
+    }
+    roles: dict[str, Any] = {}
+    if isinstance(config.get("resource"), Mapping):
+        roles["resource_config"] = sanitize_value(config["resource"], key="resource")
+    for role, (node_field, gpu_field) in _ROLE_FIELDS.items():
+        nodes = config.get(node_field) if node_field else None
+        gpus = config.get(gpu_field)
+        if nodes is None and gpus is None:
+            continue
+        role_data: dict[str, Any] = {}
+        if nodes is not None:
+            role_data["nodes"] = sanitize_value(nodes)
+        if gpus is not None:
+            role_data["gpus"] = sanitize_value(gpus)
+        roles[role] = role_data
+    return {"parallelism": parallelism, "roles": roles}
+
+
+def _collect_runtime(args: Any, ray_module: Any = None) -> dict[str, Any]:
+    initialized = False
+    nodes: list[Mapping[str, Any]] = []
+    cluster_resources: Mapping[str, Any] = {}
+    if ray_module is not None:
+        try:
+            initialized = bool(ray_module.is_initialized())
+            if initialized:
+                nodes = [node for node in ray_module.nodes() if node.get("Alive")]
+                cluster_resources = ray_module.cluster_resources()
+        except Exception:
+            initialized = False
+            nodes = []
+            cluster_resources = {}
+    node_summaries = [{"resources": _safe_resources(node.get("Resources"))} for node in nodes]
+    node_summaries.sort(key=lambda item: json.dumps(item, sort_keys=True))
+    mode = "local"
+    if initialized:
+        mode = "single_node_ray" if len(nodes) <= 1 else "multi_node_ray"
+    return {
+        "mode": mode,
+        "node_count": len(nodes) if initialized else 1,
+        "cluster_resources": _safe_resources(cluster_resources),
+        "nodes": node_summaries,
+        "topology": _collect_topology(args),
+    }
+
+
+def _describe_input(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        return [_describe_input(item) for item in value]
+    if not isinstance(value, (str, Path)):
+        return sanitize_value(value)
+    identifier = _sanitize_string(str(value))
+    descriptor: dict[str, Any] = {"identifier": identifier}
+    try:
+        path = Path(value).expanduser()
+        if path.is_file():
+            descriptor.update({"kind": "file", "size_bytes": path.stat().st_size})
+        elif path.is_dir():
+            descriptor["kind"] = "directory"
+        else:
+            descriptor["kind"] = "identifier"
+    except (OSError, RuntimeError, ValueError):
+        descriptor["kind"] = "unavailable"
+    return descriptor
+
+
+def _collect_inputs(args: Any) -> dict[str, Any]:
+    config = vars(args) if args is not None and hasattr(args, "__dict__") else {}
+    return {field: _describe_input(config[field]) for field in _INPUT_FIELDS if config.get(field) is not None}
+
+
+def build_manifest(
+    args: Any = None,
+    runtime_env: Mapping[str, Any] | None = None,
+    *,
+    argv: Sequence[str] | None = None,
+    cwd: str | Path | None = None,
+    ray_module: Any = None,
+    probe_framework: bool = False,
+) -> dict[str, Any]:
+    """Build a shareable manifest without importing optional training dependencies."""
+    started_at = time.perf_counter()
+    working_directory = Path(cwd or Path.cwd()).resolve()
+    command = list(argv) if argv is not None else [sys.executable, *sys.argv]
+    config = vars(args) if args is not None and hasattr(args, "__dict__") else {}
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "code": _collect_code(working_directory),
+        "command": {"argv": sanitize_argv(command), "working_directory": "."},
+        "config": {
+            "arguments": sanitize_value(config),
+            "runtime_env": sanitize_value(runtime_env or {}),
+        },
+        "environment": _collect_environment(probe_framework=probe_framework),
+        "hardware": _collect_hardware(),
+        "runtime": _collect_runtime(args, ray_module),
+        "inputs": _collect_inputs(args),
+    }
+    manifest["collection_duration_ms"] = round((time.perf_counter() - started_at) * 1000, 3)
+    return manifest
+
+
+def _schema_major(version: Any) -> int:
+    if isinstance(version, int):
+        return version
+    try:
+        return int(str(version).split(".", 1)[0])
+    except (TypeError, ValueError) as error:
+        raise ManifestError(f"Invalid manifest schema version: {version!r}") from error
+
+
+def normalize_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Read any v1 manifest, accepting missing optional fields and future v1 minors."""
+    if "schema_version" not in manifest:
+        raise ManifestError("Manifest is missing schema_version")
+    major = _schema_major(manifest["schema_version"])
+    if major != SUPPORTED_SCHEMA_MAJOR:
+        raise ManifestError(
+            f"Unsupported manifest schema major version {major}; supported major is {SUPPORTED_SCHEMA_MAJOR}"
+        )
+    normalized = dict(manifest)
+    normalized["schema_version"] = str(manifest["schema_version"])
+    for section in ("code", "command", "config", "environment", "hardware", "runtime", "inputs"):
+        normalized.setdefault(section, {})
+    return normalized
+
+
+def write_manifest(manifest: Mapping[str, Any], path: str | Path) -> Path:
+    """Validate and atomically write a manifest."""
+    normalized = normalize_manifest(manifest)
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=destination.parent, delete=False) as temporary:
+            json.dump(normalized, temporary, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False)
+            temporary.write("\n")
+            temporary_path = Path(temporary.name)
+        os.replace(temporary_path, destination)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+    return destination
+
+
+def load_manifest(path: str | Path) -> dict[str, Any]:
+    try:
+        with Path(path).open(encoding="utf-8") as file:
+            manifest = json.load(file)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"Unable to read manifest {path}: {error}") from error
+    if not isinstance(manifest, Mapping):
+        raise ManifestError("Manifest root must be a JSON object")
+    return normalize_manifest(manifest)
+
+
+def default_manifest_path(args: Any = None) -> Path:
+    override = os.environ.get("RELAX_MANIFEST_PATH")
+    if override:
+        return Path(override).expanduser()
+    run_name = None
+    if args is not None:
+        run_name = getattr(args, "tb_experiment_name", None) or getattr(args, "wandb_group", None)
+    run_name = run_name or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    safe_run_name = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(run_name)).strip("-.") or "run"
+    return Path.cwd() / "relax_runs" / safe_run_name[:120] / "experiment-manifest.json"
+
+
+def write_experiment_manifest(
+    args: Any,
+    runtime_env: Mapping[str, Any] | None,
+    *,
+    path: str | Path | None = None,
+    ray_module: Any = None,
+) -> Path | None:
+    """Best-effort training hook: manifest failures never block the run."""
+    try:
+        destination = Path(path) if path is not None else default_manifest_path(args)
+        manifest = build_manifest(args, runtime_env, ray_module=ray_module)
+        written_path = write_manifest(manifest, destination)
+        logger.info("Reproducibility manifest saved to %s", written_path)
+        return written_path
+    except Exception as error:
+        logger.warning("Unable to write reproducibility manifest; training will continue: %s", error)
+        return None
+
+
+def _get_path(data: Mapping[str, Any], path: Sequence[str]) -> Any:
+    current: Any = data
+    for component in path:
+        if not isinstance(current, Mapping) or component not in current:
+            return None
+        current = current[component]
+    return current
+
+
+def compare_environment(expected: Mapping[str, Any], actual: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return actionable differences while allowing extra fields in newer v1 manifests."""
+    differences = []
+    paths = (
+        ("code", "commit"),
+        ("environment", "python"),
+        ("environment", "platform", "system"),
+        ("environment", "platform", "machine"),
+        ("environment", "packages"),
+        ("environment", "cuda"),
+        ("hardware", "cpu_count"),
+        ("hardware", "gpus"),
+    )
+    for path in paths:
+        expected_value = _get_path(expected, path)
+        actual_value = _get_path(actual, path)
+        if expected_value is None:
+            continue
+        if expected_value != actual_value:
+            differences.append(
+                {
+                    "field": ".".join(path),
+                    "expected": expected_value,
+                    "actual": actual_value,
+                    "suggestion": _suggest(path),
+                }
+            )
+    return differences
+
+
+def _suggest(path: Sequence[str]) -> str:
+    field = ".".join(path)
+    if field == "code.commit":
+        return "Check out the recorded commit before replaying."
+    if field == "environment.packages":
+        return "Use the recorded image or align the listed package versions."
+    if field.startswith("hardware.gpus"):
+        return "Use hosts with the recorded GPU model, driver, and memory."
+    return f"Align {field} with the recorded value or replay with an explicit override."
+
+
+def inspect_environment(manifest: Mapping[str, Any], *, cwd: str | Path | None = None) -> list[dict[str, Any]]:
+    current = build_manifest(argv=[], cwd=cwd, probe_framework=True)
+    return compare_environment(normalize_manifest(manifest), current)
+
+
+def replay_command(manifest: Mapping[str, Any]) -> list[str]:
+    normalized = normalize_manifest(manifest)
+    argv = normalized.get("command", {}).get("argv")
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+        raise ManifestError("Manifest command.argv must be a non-empty string array")
+    if any(REDACTED in item for item in argv):
+        raise ManifestError("Manifest command contains redacted values; supply credentials outside the manifest")
+    return argv
+
+
+def execute_manifest(manifest: Mapping[str, Any], *, cwd: str | Path | None = None) -> int:
+    """Replay using argv directly; shell expansion is deliberately disabled."""
+    command = replay_command(manifest)
+    try:
+        result = subprocess.run(command, cwd=cwd or Path.cwd(), check=False)
+    except OSError as error:
+        raise ManifestError(f"Unable to execute recorded command: {error}") from error
+    return result.returncode

--- a/relax/utils/reproducibility.py
+++ b/relax/utils/reproducibility.py
@@ -122,7 +122,8 @@ def _sanitize_string(value: str) -> str:
 
 
 def sanitize_value(value: Any, *, key: Any = None) -> Any:
-    """Convert a value to JSON-safe data while removing secrets and addresses."""
+    """Convert a value to JSON-safe data while removing secrets and
+    addresses."""
     if key is not None and (_is_sensitive_key(key) or _is_address_key(key)):
         return REDACTED
     if value is None or isinstance(value, (bool, int)):
@@ -378,7 +379,8 @@ def build_manifest(
     ray_module: Any = None,
     probe_framework: bool = False,
 ) -> dict[str, Any]:
-    """Build a shareable manifest without importing optional training dependencies."""
+    """Build a shareable manifest without importing optional training
+    dependencies."""
     started_at = time.perf_counter()
     working_directory = Path(cwd or Path.cwd()).resolve()
     command = list(argv) if argv is not None else [sys.executable, *sys.argv]
@@ -411,7 +413,8 @@ def _schema_major(version: Any) -> int:
 
 
 def normalize_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
-    """Read any v1 manifest, accepting missing optional fields and future v1 minors."""
+    """Read any v1 manifest, accepting missing optional fields and future v1
+    minors."""
     if "schema_version" not in manifest:
         raise ManifestError("Manifest is missing schema_version")
     major = _schema_major(manifest["schema_version"])
@@ -496,7 +499,8 @@ def _get_path(data: Mapping[str, Any], path: Sequence[str]) -> Any:
 
 
 def compare_environment(expected: Mapping[str, Any], actual: Mapping[str, Any]) -> list[dict[str, Any]]:
-    """Return actionable differences while allowing extra fields in newer v1 manifests."""
+    """Return actionable differences while allowing extra fields in newer v1
+    manifests."""
     differences = []
     paths = (
         ("code", "commit"),

--- a/relax/utils/reproducibility.py
+++ b/relax/utils/reproducibility.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -62,6 +63,11 @@ _ADDRESS_KEY_RE = re.compile(
     r"(?:^|_)(?:address|addresses|addr|addrs|host|hostname|ip|endpoint|url)(?:$|_)", re.IGNORECASE
 )
 _IPV4_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.])")
+_IPV6_RE = re.compile(r"(?<![0-9a-f:])(?:[0-9a-f]{0,4}:){2,}[0-9a-f]{0,4}(?![0-9a-f:])", re.IGNORECASE)
+_INTERNAL_HOST_RE = re.compile(
+    r"(?<![\w.-])(?:localhost|[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.(?:internal|local))(?::\d{1,5})?(?![\w.-])",
+    re.IGNORECASE,
+)
 _NETWORK_LOCATION_RE = re.compile(r"(?P<scheme>\b[a-z][a-z0-9+.-]*://)(?P<location>[^/\s]+)", re.IGNORECASE)
 _ASSIGNMENT_SECRET_RE = re.compile(
     r"(?i)\b(token|password|passwd|secret|api[-_]?key|access[-_]?key|authorization)=([^\s&]+)"
@@ -97,6 +103,17 @@ def _redact_private_ip(match: re.Match[str]) -> str:
     return value
 
 
+def _redact_private_ipv6(match: re.Match[str]) -> str:
+    value = match.group(0)
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return value
+    if address.is_private or address.is_loopback or address.is_link_local or address.is_reserved:
+        return REDACTED
+    return value
+
+
 def _redact_network_location(match: re.Match[str]) -> str:
     scheme = match.group("scheme")
     location = match.group("location")
@@ -115,10 +132,21 @@ def _redact_network_location(match: re.Match[str]) -> str:
 
 
 def _sanitize_string(value: str) -> str:
+    stripped = value.strip()
+    if stripped.startswith(("{", "[")):
+        try:
+            structured_value = json.loads(stripped)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(structured_value, (Mapping, list)):
+                return json.dumps(sanitize_value(structured_value), ensure_ascii=False, separators=(",", ":"))
     value = _BEARER_RE.sub(f"Bearer {REDACTED}", value)
     value = _ASSIGNMENT_SECRET_RE.sub(lambda match: f"{match.group(1)}={REDACTED}", value)
     value = _NETWORK_LOCATION_RE.sub(_redact_network_location, value)
-    return _IPV4_RE.sub(_redact_private_ip, value)
+    value = _INTERNAL_HOST_RE.sub(REDACTED, value)
+    value = _IPV4_RE.sub(_redact_private_ip, value)
+    return _IPV6_RE.sub(_redact_private_ipv6, value)
 
 
 def sanitize_value(value: Any, *, key: Any = None) -> Any:
@@ -168,8 +196,22 @@ def sanitize_argv(argv: Sequence[str]) -> list[str]:
                     sanitized.append(option)
                     redact_next = True
                 continue
+            if separator:
+                sanitized.append(f"{option}={_sanitize_string(option_value)}")
+                continue
         sanitized.append(_sanitize_string(str(token)))
     return sanitized
+
+
+def _current_command_argv() -> list[str]:
+    """Keep ``python -m module`` portable instead of recording its resolved
+    file path."""
+    main_module = sys.modules.get("__main__")
+    module_spec = getattr(main_module, "__spec__", None)
+    module_name = getattr(module_spec, "name", None)
+    if module_name and sys.argv:
+        return [sys.executable, "-m", module_name, *sys.argv[1:]]
+    return [sys.executable, *sys.argv]
 
 
 def _run_git(arguments: Sequence[str], cwd: Path) -> str | None:
@@ -383,7 +425,7 @@ def build_manifest(
     dependencies."""
     started_at = time.perf_counter()
     working_directory = Path(cwd or Path.cwd()).resolve()
-    command = list(argv) if argv is not None else [sys.executable, *sys.argv]
+    command = list(argv) if argv is not None else _current_command_argv()
     config = vars(args) if args is not None and hasattr(args, "__dict__") else {}
     manifest = {
         "schema_version": SCHEMA_VERSION,
@@ -415,6 +457,8 @@ def _schema_major(version: Any) -> int:
 def normalize_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     """Read any v1 manifest, accepting missing optional fields and future v1
     minors."""
+    if not isinstance(manifest, Mapping):
+        raise ManifestError("Manifest root must be a JSON object")
     if "schema_version" not in manifest:
         raise ManifestError("Manifest is missing schema_version")
     major = _schema_major(manifest["schema_version"])
@@ -425,7 +469,10 @@ def normalize_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     normalized = dict(manifest)
     normalized["schema_version"] = str(manifest["schema_version"])
     for section in ("code", "command", "config", "environment", "hardware", "runtime", "inputs"):
-        normalized.setdefault(section, {})
+        value = normalized.setdefault(section, {})
+        if not isinstance(value, Mapping):
+            raise ManifestError(f"Manifest section {section!r} must be a JSON object")
+        normalized[section] = dict(value)
     return normalized
 
 
@@ -465,9 +512,11 @@ def default_manifest_path(args: Any = None) -> Path:
     run_name = None
     if args is not None:
         run_name = getattr(args, "tb_experiment_name", None) or getattr(args, "wandb_group", None)
-    run_name = run_name or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_name = run_name or "run"
     safe_run_name = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(run_name)).strip("-.") or "run"
-    return Path.cwd() / "relax_runs" / safe_run_name[:120] / "experiment-manifest.json"
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    run_id = f"{timestamp}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    return Path.cwd() / "relax_runs" / safe_run_name[:120] / run_id / "experiment-manifest.json"
 
 
 def write_experiment_manifest(

--- a/tests/integration/test_reproducibility_bundle.py
+++ b/tests/integration/test_reproducibility_bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
 from relax.entrypoints.reproducibility import main
@@ -22,3 +23,12 @@ def test_manifest_reruns_minimal_cpu_task(tmp_path):
 
     assert exit_code == 0
     assert marker.read_text(encoding="utf-8") == "replayed"
+
+
+def test_cli_returns_invalid_manifest_exit_code_for_non_object_section(tmp_path):
+    manifest_path = tmp_path / "invalid-manifest.json"
+    manifest_path.write_text(json.dumps({"schema_version": "1.0", "command": None}), encoding="utf-8")
+
+    exit_code = main(["rerun", str(manifest_path)])
+
+    assert exit_code == 2

--- a/tests/integration/test_reproducibility_bundle.py
+++ b/tests/integration/test_reproducibility_bundle.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import sys
+
+from relax.entrypoints.reproducibility import main
+from relax.utils.reproducibility import build_manifest, write_manifest
+
+
+def test_manifest_reruns_minimal_cpu_task(tmp_path):
+    marker = tmp_path / "replayed.txt"
+    command = [
+        sys.executable,
+        "-c",
+        f"from pathlib import Path; Path({str(marker)!r}).write_text('replayed', encoding='utf-8')",
+    ]
+    manifest = build_manifest(argv=command, cwd=tmp_path)
+    manifest_path = write_manifest(manifest, tmp_path / "experiment-manifest.json")
+
+    exit_code = main(["rerun", str(manifest_path), "--execute"])
+
+    assert exit_code == 0
+    assert marker.read_text(encoding="utf-8") == "replayed"

--- a/tests/utils/test_reproducibility.py
+++ b/tests/utils/test_reproducibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +13,7 @@ from relax.utils.reproducibility import (
     ManifestError,
     build_manifest,
     compare_environment,
+    default_manifest_path,
     load_manifest,
     replay_command,
     sanitize_argv,
@@ -127,6 +129,64 @@ def test_sanitize_argv_does_not_confuse_tokenizer_with_token():
     ]
 
 
+def test_serialized_manifest_redacts_json_arguments_internal_hosts_and_ipv6(tmp_path):
+    runtime_env_json = json.dumps(
+        {
+            "HF_TOKEN": "super-secret-value",
+            "workers": ["ray-head.prod.internal:6379", "fd00::1234"],
+        }
+    )
+    manifest = build_manifest(
+        argv=[
+            "python",
+            "train.py",
+            "--runtime-env-json",
+            runtime_env_json,
+            f"--worker-config={runtime_env_json}",
+        ],
+        cwd=tmp_path,
+    )
+
+    manifest_path = write_manifest(manifest, tmp_path / "experiment-manifest.json")
+    serialized = manifest_path.read_text(encoding="utf-8")
+
+    assert "super-secret-value" not in serialized
+    assert "ray-head.prod.internal" not in serialized
+    assert "fd00::1234" not in serialized
+    assert REDACTED in serialized
+
+
+def test_build_manifest_preserves_python_module_invocation(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["/tmp/ray/session/working_dir/train.py", "--epochs", "1"])
+    monkeypatch.setattr(
+        sys.modules["__main__"],
+        "__spec__",
+        SimpleNamespace(name="relax.entrypoints.train"),
+    )
+
+    manifest = build_manifest(cwd=tmp_path)
+
+    assert manifest["command"]["argv"] == [
+        sys.executable,
+        "-m",
+        "relax.entrypoints.train",
+        "--epochs",
+        "1",
+    ]
+
+
+def test_default_manifest_path_is_unique_within_experiment_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    args = SimpleNamespace(tb_experiment_name="same experiment")
+
+    first_path = default_manifest_path(args)
+    second_path = default_manifest_path(args)
+
+    assert first_path != second_path
+    assert first_path.parent.parent == tmp_path / "relax_runs" / "same-experiment"
+    assert first_path.name == "experiment-manifest.json"
+
+
 def test_runtime_mode_covers_local_and_single_node_ray(tmp_path):
     local_manifest = build_manifest(cwd=tmp_path)
     ray_manifest = build_manifest(cwd=tmp_path, ray_module=_SingleNodeRay)
@@ -153,6 +213,15 @@ def test_reader_rejects_unknown_major_version(tmp_path):
     path.write_text(json.dumps({"schema_version": "2.0"}), encoding="utf-8")
 
     with pytest.raises(ManifestError, match="Unsupported manifest schema"):
+        load_manifest(path)
+
+
+@pytest.mark.parametrize(("section", "value"), [("command", None), ("environment", []), ("runtime", "bad")])
+def test_reader_rejects_non_object_sections(tmp_path, section, value):
+    path = tmp_path / f"manifest-{section}.json"
+    path.write_text(json.dumps({"schema_version": "1.0", section: value}), encoding="utf-8")
+
+    with pytest.raises(ManifestError, match=rf"section '{section}' must be a JSON object"):
         load_manifest(path)
 
 

--- a/tests/utils/test_reproducibility.py
+++ b/tests/utils/test_reproducibility.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from relax.utils.reproducibility import (
+    REDACTED,
+    ManifestError,
+    build_manifest,
+    compare_environment,
+    load_manifest,
+    replay_command,
+    sanitize_argv,
+    write_experiment_manifest,
+    write_manifest,
+)
+
+
+class _FakeRay:
+    @staticmethod
+    def is_initialized():
+        return True
+
+    @staticmethod
+    def nodes():
+        return [
+            {
+                "Alive": True,
+                "NodeID": "node-a",
+                "NodeManagerAddress": "10.0.0.1",
+                "Resources": {"CPU": 8, "GPU": 4, "node:10.0.0.1": 1},
+            },
+            {
+                "Alive": True,
+                "NodeID": "node-b",
+                "NodeManagerAddress": "10.0.0.2",
+                "Resources": {"CPU": 8, "GPU": 4, "accelerator_type:L40": 1},
+            },
+        ]
+
+    @staticmethod
+    def cluster_resources():
+        return {"CPU": 16, "GPU": 8, "node:10.0.0.1": 1}
+
+
+class _SingleNodeRay(_FakeRay):
+    @staticmethod
+    def nodes():
+        return _FakeRay.nodes()[:1]
+
+
+def test_manifest_redacts_secrets_addresses_and_ray_node_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONTAINER_IMAGE", "registry.corp.internal/team/relax:latest")
+    args = SimpleNamespace(
+        api_token="plain-secret-token",
+        tokenizer_path="/models/tokenizer.json",
+        rollout_external_engine_addrs=["10.0.0.8:8000"],
+        nested={"password": "plain-password", "safe": "kept"},
+        tensor_model_parallel_size=4,
+        actor_num_nodes=2,
+        actor_num_gpus_per_node=4,
+    )
+    runtime_env = {
+        "env_vars": {
+            "HF_TOKEN": "runtime-secret-token",
+            "SERVICE_URL": "ray://head.internal:10001",
+            "SAFE_SETTING": "kept",
+        }
+    }
+    manifest = build_manifest(
+        args,
+        runtime_env,
+        argv=[
+            "python",
+            "train.py",
+            "--api-token",
+            "argv-secret-token",
+            "--tokenizer-path=/models/tokenizer.json",
+        ],
+        cwd=tmp_path,
+        ray_module=_FakeRay,
+    )
+
+    payload = json.dumps(manifest, sort_keys=True)
+    for sensitive_value in (
+        "plain-secret-token",
+        "plain-password",
+        "runtime-secret-token",
+        "argv-secret-token",
+        "10.0.0.1",
+        "10.0.0.2",
+        "10.0.0.8",
+        "head.internal",
+        "node-a",
+        "node-b",
+    ):
+        assert sensitive_value not in payload
+    assert "/models/tokenizer.json" in payload
+    assert manifest["runtime"]["mode"] == "multi_node_ray"
+    assert manifest["runtime"]["node_count"] == 2
+    assert manifest["runtime"]["cluster_resources"]["GPU"] == 8
+    assert manifest["config"]["arguments"]["api_token"] == REDACTED
+    assert manifest["environment"]["container_image"] == f"{REDACTED}/team/relax:latest"
+
+
+def test_sanitize_argv_does_not_confuse_tokenizer_with_token():
+    argv = sanitize_argv(
+        ["train.py", "--token", "secret", "--tokenizer-path", "/models/tokenizer", "--endpoint=ray://head:1"]
+    )
+
+    assert argv == [
+        "train.py",
+        "--token",
+        REDACTED,
+        "--tokenizer-path",
+        "/models/tokenizer",
+        f"--endpoint={REDACTED}",
+    ]
+
+
+def test_runtime_mode_covers_local_and_single_node_ray(tmp_path):
+    local_manifest = build_manifest(cwd=tmp_path)
+    ray_manifest = build_manifest(cwd=tmp_path, ray_module=_SingleNodeRay)
+
+    assert local_manifest["runtime"]["mode"] == "local"
+    assert local_manifest["runtime"]["node_count"] == 1
+    assert ray_manifest["runtime"]["mode"] == "single_node_ray"
+    assert ray_manifest["runtime"]["node_count"] == 1
+
+
+def test_v1_reader_accepts_integer_and_future_minor_versions(tmp_path):
+    for version in (1, "1.9"):
+        path = tmp_path / f"manifest-{version}.json"
+        path.write_text(json.dumps({"schema_version": version, "command": {"argv": ["true"]}}), encoding="utf-8")
+
+        manifest = load_manifest(path)
+
+        assert manifest["schema_version"] == str(version)
+        assert manifest["runtime"] == {}
+
+
+def test_reader_rejects_unknown_major_version(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"schema_version": "2.0"}), encoding="utf-8")
+
+    with pytest.raises(ManifestError, match="Unsupported manifest schema"):
+        load_manifest(path)
+
+
+def test_write_manifest_is_atomic_and_replay_rejects_redacted_command(tmp_path):
+    path = write_manifest({"schema_version": "1.0", "command": {"argv": ["python", "-V"]}}, tmp_path / "m.json")
+
+    assert load_manifest(path)["command"]["argv"] == ["python", "-V"]
+    with pytest.raises(ManifestError, match="redacted values"):
+        replay_command({"schema_version": "1.0", "command": {"argv": ["python", REDACTED]}})
+
+
+def test_compare_environment_reports_actionable_drift():
+    expected = {
+        "schema_version": "1.0",
+        "code": {"commit": "abc"},
+        "environment": {"python": "3.10.1", "packages": {"ray": "2.1"}},
+    }
+    actual = {
+        "schema_version": "1.0",
+        "code": {"commit": "def"},
+        "environment": {"python": "3.11.1", "packages": {"ray": "2.2"}},
+    }
+
+    differences = compare_environment(expected, actual)
+
+    assert {difference["field"] for difference in differences} == {
+        "code.commit",
+        "environment.python",
+        "environment.packages",
+    }
+    assert all(difference["suggestion"] for difference in differences)
+
+
+def test_training_hook_failure_does_not_escape(tmp_path):
+    args = SimpleNamespace(tb_experiment_name="test")
+
+    assert write_experiment_manifest(args, {}, path=tmp_path) is None

--- a/tests/utils/test_reproducibility.py
+++ b/tests/utils/test_reproducibility.py
@@ -20,6 +20,11 @@ from relax.utils.reproducibility import (
 )
 
 
+_PRIVATE_IP_A = ".".join(("10", "0", "0", "1"))
+_PRIVATE_IP_B = ".".join(("10", "0", "0", "2"))
+_PRIVATE_IP_C = ".".join(("10", "0", "0", "8"))
+
+
 class _FakeRay:
     @staticmethod
     def is_initialized():
@@ -31,20 +36,20 @@ class _FakeRay:
             {
                 "Alive": True,
                 "NodeID": "node-a",
-                "NodeManagerAddress": "10.0.0.1",
-                "Resources": {"CPU": 8, "GPU": 4, "node:10.0.0.1": 1},
+                "NodeManagerAddress": _PRIVATE_IP_A,
+                "Resources": {"CPU": 8, "GPU": 4, f"node:{_PRIVATE_IP_A}": 1},
             },
             {
                 "Alive": True,
                 "NodeID": "node-b",
-                "NodeManagerAddress": "10.0.0.2",
+                "NodeManagerAddress": _PRIVATE_IP_B,
                 "Resources": {"CPU": 8, "GPU": 4, "accelerator_type:L40": 1},
             },
         ]
 
     @staticmethod
     def cluster_resources():
-        return {"CPU": 16, "GPU": 8, "node:10.0.0.1": 1}
+        return {"CPU": 16, "GPU": 8, f"node:{_PRIVATE_IP_A}": 1}
 
 
 class _SingleNodeRay(_FakeRay):
@@ -58,7 +63,7 @@ def test_manifest_redacts_secrets_addresses_and_ray_node_identity(tmp_path, monk
     args = SimpleNamespace(
         api_token="plain-secret-token",
         tokenizer_path="/models/tokenizer.json",
-        rollout_external_engine_addrs=["10.0.0.8:8000"],
+        rollout_external_engine_addrs=[f"{_PRIVATE_IP_C}:8000"],
         nested={"password": "plain-password", "safe": "kept"},
         tensor_model_parallel_size=4,
         actor_num_nodes=2,
@@ -91,9 +96,9 @@ def test_manifest_redacts_secrets_addresses_and_ray_node_identity(tmp_path, monk
         "plain-password",
         "runtime-secret-token",
         "argv-secret-token",
-        "10.0.0.1",
-        "10.0.0.2",
-        "10.0.0.8",
+        _PRIVATE_IP_A,
+        _PRIVATE_IP_B,
+        _PRIVATE_IP_C,
         "head.internal",
         "node-a",
         "node-b",


### PR DESCRIPTION
## What

- generate a versioned experiment manifest automatically after Ray initialization
- record code, resolved configuration, software/hardware, inputs, and local/single-node/multi-node Ray topology
- redact secrets, credentials, internal addresses, and Ray node identity by default
- add `check` and safe `rerun` commands with actionable environment-drift output
- document schema v1 and usage in English and Chinese

## Why

RL runs are difficult to reproduce when their code revision, final arguments, image, dependencies, inputs, and distributed topology are recorded separately or not recorded at all. This adds a small best-effort bundle that is shareable and does not block training when collection fails.

## Behavior and compatibility

- v1 readers accept integer v1 and later v1 minor versions while rejecting unknown major versions
- manifest writes are atomic; collection avoids network calls, recursive scans, hashing, and `pip freeze`
- replay passes an argv array directly to the child process and refuses commands containing redacted values
- default output is `relax_runs/<experiment>/<unique-run-id>/experiment-manifest.json`; `RELAX_MANIFEST_PATH` overrides it
- measured local collection time: about 44 ms

## Checks

- `pytest -q tests/utils/test_reproducibility.py tests/integration/test_reproducibility_bundle.py` — 16 passed
- GitHub CI — Python 3.10/3.11/3.12 tests, Ruff, and full pre-commit passed
- real CLI check and rerun preview — passed

GPU training was not run because the feature only adds driver-side metadata collection; local, single-node Ray, and multi-node Ray metadata paths are covered by tests.
