### PR TITLE
perf(megatron): reuse process groups for colocate weight sync

### DIFF
--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -56,7 +56,12 @@ from relax.utils.opd.opd_utils import (
     consume_opd_train_data,
     has_managed_opd_teacher_manager,
 )
-from relax.utils.reloadable_process_group import destroy_process_groups, monkey_patch_torch_dist, reload_process_groups
+from relax.utils.reloadable_process_group import (
+    all_process_groups_active,
+    destroy_process_groups,
+    monkey_patch_torch_dist,
+    reload_process_groups,
+)
 from relax.utils.rotate_ckpt import rotate_ckpt
 from relax.utils.timer import Timer, inverse_timer, timer, with_defer
 from relax.utils.tracking_utils import init_tracking
@@ -102,6 +107,9 @@ logger = logging.getLogger(__name__)
 
 
 ROLLOUT_MINI_BATCH_METAS_KEY = "rollout_mini_batch_metas"
+PG_ACTIVE = "active"
+PG_PAUSED_LIVE = "paused_live"
+PG_DESTROYED = "destroyed"
 
 
 def _split_by_rollout_mini_counts(values: Any, counts: list[int]) -> list[Any]:
@@ -221,6 +229,10 @@ class MegatronTrainRayActor(TrainRayActor):
         self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id = initialize_model_and_optimizer(
             args, role
         )
+        self._training_pg_state = PG_ACTIVE
+        self._preserve_pg_for_weight_sync_eligible = False
+        self._preserve_pg_for_weight_sync_ready = False
+        self._preserved_pg_canary_passed = False
 
         # Train-state offload for colocate sleep/wake. Picks torch_memory_saver
         # (VMM pause) or manual selective CPU offload based on TMS availability;
@@ -339,6 +351,13 @@ class MegatronTrainRayActor(TrainRayActor):
                     lock=self.lock,
                 )
             )
+        self._preserve_pg_for_weight_sync_eligible = self._all_ranks_agree(self._local_pg_preservation_eligibility())
+        if is_megatron_main_rank():
+            logger.info(
+                "[weight-sync-pg] short-window preservation eligible=%s; "
+                "the legacy lifecycle remains active until a local IPC weight sync succeeds",
+                self._preserve_pg_for_weight_sync_eligible,
+            )
         # empty cache after initialization
         clear_memory()
 
@@ -367,8 +386,63 @@ class MegatronTrainRayActor(TrainRayActor):
 
         return start_rollout_id
 
+    def _all_ranks_agree(self, value: bool) -> bool:
+        decision = torch.tensor([int(value)], dtype=torch.int32)
+        dist.all_reduce(decision, op=dist.ReduceOp.MIN, group=get_gloo_group())
+        return bool(decision.item())
+
+    def _local_pg_preservation_eligibility(self) -> bool:
+        """Conservative capability gate for the colocated IPC weight-sync
+        path."""
+        return bool(
+            self.role == "actor"
+            and self.args.colocate
+            and self.args.offload_train
+            and self._per_step_rollout
+            # The canary below only certifies communicators against the TMS
+            # (VMM pause) offload path; the selective-offload strategy has not
+            # been validated for group preservation.
+            and self._train_state_offloader.uses_tms
+            and not self.args.use_critic
+            and not self.args.fully_async
+            and getattr(self.args, "enable_weights_backuper", False)
+            and isinstance(getattr(self, "weight_updater", None), UpdateWeightFromTensor)
+            and mpu.get_pipeline_model_parallel_world_size() == 1
+            and mpu.get_context_parallel_world_size() == 1
+            and mpu.get_expert_model_parallel_world_size() == 1
+            and not device_utils.is_klx()
+        )
+
+    def _run_preserved_pg_canary(self) -> bool:
+        """Verify the TP/DP communicators still work after the train-state
+        offload."""
+        local_success = True
+        try:
+            groups = (
+                mpu.get_tensor_model_parallel_group(),
+                mpu.get_data_parallel_group(with_context_parallel=False),
+            )
+            # The canary allocates a scratch tensor that must not be tracked by
+            # the offloader, otherwise it would be paused on the next sleep().
+            with self._train_state_offloader.disable_during_update():
+                for group in groups:
+                    world_size = dist.get_world_size(group=group)
+                    if world_size <= 1:
+                        continue
+                    value = torch.ones(1, device=device_utils.make_current_torch_device())
+                    dist.all_reduce(value, group=group)
+                    if value.item() != world_size:
+                        raise RuntimeError(
+                            f"preserved process-group canary mismatch: got={value.item()}, expected={world_size}"
+                        )
+                device_utils.synchronize()
+        except Exception:
+            local_success = False
+            logger.exception("[weight-sync-pg] post-pause communicator canary failed")
+        return self._all_ranks_agree(local_success)
+
     @timer
-    def sleep(self) -> None:
+    def sleep(self, *, preserve_process_groups_for_weight_sync: bool = False) -> None:
         assert self.args.offload_train
 
         clear_memory(clear_host_memory=True)
@@ -385,9 +459,34 @@ class MegatronTrainRayActor(TrainRayActor):
             and hasattr(self.weight_updater, "disconnect_rollout_engines")
         ):
             self.weight_updater.disconnect_rollout_engines()
-        destroy_process_groups()
+        preserve_process_groups = bool(
+            preserve_process_groups_for_weight_sync
+            and self._preserve_pg_for_weight_sync_ready
+            and self._training_pg_state == PG_ACTIVE
+            and all_process_groups_active()
+        )
+        preserve_process_groups = self._all_ranks_agree(preserve_process_groups)
+        if preserve_process_groups:
+            # All ranks must enter TMS pause with the same communicator state.
+            dist.barrier(group=get_gloo_group())
+        else:
+            destroy_process_groups()
 
         self._train_state_offloader.offload()
+
+        if preserve_process_groups:
+            self._training_pg_state = PG_PAUSED_LIVE
+            if not self._preserved_pg_canary_passed:
+                self._preserved_pg_canary_passed = self._run_preserved_pg_canary()
+                if not self._preserved_pg_canary_passed:
+                    logger.warning("[weight-sync-pg] disabling short-window preservation after canary failure")
+                    self._preserve_pg_for_weight_sync_ready = False
+                    destroy_process_groups()
+                    self._training_pg_state = PG_DESTROYED
+                elif dist.get_rank() == 0:
+                    logger.info("[weight-sync-pg] post-pause TP/DP communicator canary passed")
+        else:
+            self._training_pg_state = PG_DESTROYED
 
         print_memory("after offload model")
 
@@ -400,6 +499,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         clear_memory()
         reload_process_groups(timeout_minutes=self.args.distributed_timeout_minutes)
+        self._training_pg_state = PG_ACTIVE
         print_memory("after wake_up model")
 
     def _switch_model(self, target_tag: str) -> None:
@@ -945,7 +1045,7 @@ class MegatronTrainRayActor(TrainRayActor):
         has_rollout = getattr(self, "rollout_manager", None) is not None
         if self._per_step_rollout:
             if self.args.offload_train:
-                self.sleep()
+                self.sleep(preserve_process_groups_for_weight_sync=has_rollout)
             if has_rollout:
                 self.update_weights()
         tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rollout_id))
@@ -1561,6 +1661,7 @@ class MegatronTrainRayActor(TrainRayActor):
         # touch GPU tensors.
         if self.args.offload_train and self._per_step_rollout:
             reload_process_groups()
+            self._training_pg_state = PG_ACTIVE
 
         if self.args.async_save:
             from megatron.training.async_utils import maybe_finalize_async_save
@@ -1584,11 +1685,25 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if self.args.offload_train and self._per_step_rollout:
             destroy_process_groups()
+            self._training_pg_state = PG_DESTROYED
 
     @timer
     def update_weights(self) -> None:
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
+
+        preserved_process_groups = self._training_pg_state == PG_PAUSED_LIVE
+        try:
+            self._update_weights_impl(preserved_process_groups)
+        except BaseException:
+            # Never leak training communicators into rollout after a partial
+            # SGLang resume or failed weight transfer.
+            if preserved_process_groups and self._training_pg_state == PG_PAUSED_LIVE:
+                destroy_process_groups(post_destroy_delay=0)
+                self._training_pg_state = PG_DESTROYED
+            raise
+
+    def _update_weights_impl(self, preserved_process_groups: bool) -> None:
 
         if self.args.offload_train:
             # CRITICAL: Barrier before onload_weights to ensure ALL ranks have
@@ -1623,8 +1738,11 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if reconnect_rollout_engines:
             self.wake_up()
-        elif self.args.offload_train:
+        elif self.args.offload_train and not preserved_process_groups:
             reload_process_groups(timeout_minutes=self.args.distributed_timeout_minutes)
+            self._training_pg_state = PG_PAUSED_LIVE
+        elif preserved_process_groups and dist.get_rank() == 0:
+            logger.info("[weight-sync-pg] reusing live training process groups for weight export")
 
         if num_new_engines > 0 or reconnect_rollout_engines:
             self.weight_updater.connect_rollout_engines(
@@ -1660,10 +1778,22 @@ class MegatronTrainRayActor(TrainRayActor):
                     self.weights_backuper.backup("rollout_actor")
                 else:
                     self.weights_backuper.backup("old_actor")
+
+        if self._preserve_pg_for_weight_sync_eligible:
+            local_ipc_sync = isinstance(self.weight_updater, UpdateWeightFromTensor) and not getattr(
+                self.weight_updater, "use_distribute", True
+            )
+            self._preserve_pg_for_weight_sync_ready = self._all_ranks_agree(local_ipc_sync)
+            if self._preserve_pg_for_weight_sync_ready and dist.get_rank() == 0:
+                logger.info("[weight-sync-pg] local IPC sync validated; enabling short-window preservation")
+
         if reconnect_rollout_engines:
             self.sleep()
         elif self.args.offload_train:
-            destroy_process_groups()
+            device_utils.synchronize()
+            dist.barrier(group=get_gloo_group())
+            destroy_process_groups(defer_post_destroy_delay=preserved_process_groups)
+            self._training_pg_state = PG_DESTROYED
 
         # RL warms KV here for the next per-step generate. SFT's /predict
         # calls onload_kv itself. genRM (deferred from before the weight

--- a/relax/utils/reloadable_process_group.py
+++ b/relax/utils/reloadable_process_group.py
@@ -15,6 +15,27 @@ logger = get_logger(__name__)
 
 old_new_group_dict = {}
 _wrap_low_level_call_enabled = False
+_port_release_deadline_by_pid = {}
+
+
+def _defer_port_release_wait(pid: int, delay: float) -> None:
+    """Overlap NCCL socket cooldown with useful work before the next reload."""
+    if delay <= 0:
+        return
+    _port_release_deadline_by_pid[pid] = max(
+        _port_release_deadline_by_pid.get(pid, 0.0),
+        time.monotonic() + delay,
+    )
+
+
+def _wait_for_deferred_port_release(pid: int) -> None:
+    deadline = _port_release_deadline_by_pid.pop(pid, None)
+    if deadline is None:
+        return
+    remaining = deadline - time.monotonic()
+    if remaining > 0:
+        logger.info(f"Waiting {remaining:.2f}s for deferred NCCL socket port release")
+        time.sleep(remaining)
 
 
 def monkey_patch_torch_dist(args=None):
@@ -151,7 +172,11 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         return getattr(self.group, name)
 
     @staticmethod
-    def destroy_process_groups(post_destroy_delay: float = 2.0):
+    def destroy_process_groups(
+        post_destroy_delay: float = 2.0,
+        *,
+        defer_post_destroy_delay: bool = False,
+    ):
         pid = os.getpid()
         destroyed_count = 0
         for reloadable_group in ReloadableProcessGroup.GROUPS.get(pid, []):
@@ -172,15 +197,23 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         if destroyed_count > 0 and post_destroy_delay > 0:
             # Wait for OS to release NCCL socket ports (TCP TIME_WAIT),
             # preventing "Address already in use" on subsequent reload.
-            logger.info(
-                f"Destroyed {destroyed_count} process groups, waiting {post_destroy_delay}s "
-                "for NCCL socket port release"
-            )
-            time.sleep(post_destroy_delay)
+            if defer_post_destroy_delay:
+                logger.info(
+                    f"Destroyed {destroyed_count} process groups; deferring up to "
+                    f"{post_destroy_delay}s of NCCL socket cooldown until reload"
+                )
+                _defer_port_release_wait(pid, post_destroy_delay)
+            else:
+                logger.info(
+                    f"Destroyed {destroyed_count} process groups, waiting {post_destroy_delay}s "
+                    "for NCCL socket port release"
+                )
+                time.sleep(post_destroy_delay)
 
     @staticmethod
     def reload_process_groups(timeout_minutes: int = 30, max_retries: int = 3, retry_delay: float = 5.0):
         pid = os.getpid()
+        _wait_for_deferred_port_release(pid)
         reloadable_groups = ReloadableProcessGroup.GROUPS.get(pid, [])
         logger.info(f"Reloading {len(reloadable_groups)} process groups in pid {pid}")
         old_new_group = old_new_group_dict.get(pid)
@@ -334,11 +367,24 @@ def _should_skip_reload_and_destroy() -> bool:
     return device_utils.is_klx()
 
 
-def destroy_process_groups(post_destroy_delay: float = 2.0):
+def destroy_process_groups(
+    post_destroy_delay: float = 2.0,
+    *,
+    defer_post_destroy_delay: bool = False,
+):
     """Destroy all reloadable process groups."""
     if _should_skip_reload_and_destroy():
         return
-    ReloadableProcessGroup.destroy_process_groups(post_destroy_delay=post_destroy_delay)
+    ReloadableProcessGroup.destroy_process_groups(
+        post_destroy_delay=post_destroy_delay,
+        defer_post_destroy_delay=defer_post_destroy_delay,
+    )
+
+
+def all_process_groups_active() -> bool:
+    """Return whether this process has reloadable groups and all are live."""
+    groups = ReloadableProcessGroup.GROUPS.get(os.getpid(), [])
+    return bool(groups) and all(group.group is not None for group in groups)
 
 
 def reload_process_groups(timeout_minutes: int = 30, max_retries: int = 3, retry_delay: float = 5.0):

--- a/tests/backends/megatron/test_actor_pg_lifecycle.py
+++ b/tests/backends/megatron/test_actor_pg_lifecycle.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from types import SimpleNamespace
+
+import pytest
+
+
+pytest.importorskip("megatron")
+
+from relax.backends.megatron import actor as actor_module
+
+
+def _actor_for_sleep():
+    actor = object.__new__(actor_module.MegatronTrainRayActor)
+    actor.args = SimpleNamespace(offload_train=True, use_critic=False, colocate=True)
+    actor.role = "actor"
+    actor._training_pg_state = actor_module.PG_ACTIVE
+    actor._preserve_pg_for_weight_sync_ready = True
+    actor._preserved_pg_canary_passed = True
+    actor._torch_memory_saver_enabled = True
+    actor._all_ranks_agree = lambda value: value
+    return actor
+
+
+def test_sleep_preserves_live_groups_only_for_immediate_weight_sync(monkeypatch):
+    actor = _actor_for_sleep()
+    calls = []
+    monkeypatch.setattr(actor_module, "clear_memory", lambda **kwargs: calls.append("clear"))
+    monkeypatch.setattr(actor_module, "print_memory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(actor_module, "all_process_groups_active", lambda: True)
+    monkeypatch.setattr(actor_module.dist, "barrier", lambda **kwargs: calls.append("barrier"))
+    monkeypatch.setattr(actor_module, "get_gloo_group", lambda: object())
+    monkeypatch.setattr(actor_module, "destroy_process_groups", lambda **kwargs: calls.append("destroy"))
+    monkeypatch.setattr(actor_module.torch_memory_saver, "pause", lambda: calls.append("pause"))
+
+    actor_module.MegatronTrainRayActor.sleep.__wrapped__(actor, preserve_process_groups_for_weight_sync=True)
+
+    assert actor._training_pg_state == actor_module.PG_PAUSED_LIVE
+    assert calls == ["clear", "barrier", "pause"]
+
+
+def test_sleep_falls_back_to_destroy_when_post_pause_canary_fails(monkeypatch):
+    actor = _actor_for_sleep()
+    actor._preserved_pg_canary_passed = False
+    actor._run_preserved_pg_canary = lambda: False
+    calls = []
+    monkeypatch.setattr(actor_module, "clear_memory", lambda **kwargs: None)
+    monkeypatch.setattr(actor_module, "print_memory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(actor_module, "all_process_groups_active", lambda: True)
+    monkeypatch.setattr(actor_module.dist, "barrier", lambda **kwargs: None)
+    monkeypatch.setattr(actor_module, "get_gloo_group", lambda: object())
+    monkeypatch.setattr(actor_module, "destroy_process_groups", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(actor_module.torch_memory_saver, "pause", lambda: None)
+
+    actor_module.MegatronTrainRayActor.sleep.__wrapped__(actor, preserve_process_groups_for_weight_sync=True)
+
+    assert actor._training_pg_state == actor_module.PG_DESTROYED
+    assert not actor._preserve_pg_for_weight_sync_ready
+    assert calls == [{}]
+
+
+def test_update_exception_destroys_preserved_groups_without_cooldown(monkeypatch):
+    actor = object.__new__(actor_module.MegatronTrainRayActor)
+    actor.args = SimpleNamespace(debug_train_only=False, debug_rollout_only=False)
+    actor._training_pg_state = actor_module.PG_PAUSED_LIVE
+    actor._update_weights_impl = lambda preserved: (_ for _ in ()).throw(RuntimeError("sync failed"))
+    calls = []
+    monkeypatch.setattr(actor_module, "destroy_process_groups", lambda **kwargs: calls.append(kwargs))
+
+    with pytest.raises(RuntimeError, match="sync failed"):
+        actor_module.MegatronTrainRayActor.update_weights.__wrapped__(actor)
+
+    assert actor._training_pg_state == actor_module.PG_DESTROYED
+    assert calls == [{"post_destroy_delay": 0}]

--- a/tests/utils/test_reloadable_process_group.py
+++ b/tests/utils/test_reloadable_process_group.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from relax.utils import reloadable_process_group as rpg
+
+
+def test_deferred_port_release_wait_only_sleeps_for_remaining_time(monkeypatch):
+    clock = iter((10.0, 11.25))
+    sleeps = []
+    monkeypatch.setattr(rpg.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(rpg.time, "sleep", sleeps.append)
+    rpg._port_release_deadline_by_pid.clear()
+
+    rpg._defer_port_release_wait(pid=7, delay=2.0)
+    rpg._wait_for_deferred_port_release(pid=7)
+
+    assert sleeps == [0.75]
+    assert 7 not in rpg._port_release_deadline_by_pid
+
+
+def test_elapsed_deferred_wait_does_not_sleep(monkeypatch):
+    clock = iter((10.0, 13.0))
+    sleeps = []
+    monkeypatch.setattr(rpg.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(rpg.time, "sleep", sleeps.append)
+    rpg._port_release_deadline_by_pid.clear()
+
+    rpg._defer_port_release_wait(pid=7, delay=2.0)
+    rpg._wait_for_deferred_port_release(pid=7)
+
+    assert sleeps == []
+
+
+def test_later_destroy_extends_existing_deadline(monkeypatch):
+    clock = iter((10.0, 10.5, 11.0))
+    sleeps = []
+    monkeypatch.setattr(rpg.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(rpg.time, "sleep", sleeps.append)
+    rpg._port_release_deadline_by_pid.clear()
+
+    rpg._defer_port_release_wait(pid=7, delay=2.0)
+    rpg._defer_port_release_wait(pid=7, delay=2.0)
+    rpg._wait_for_deferred_port_release(pid=7)
+
+    assert sleeps == [1.5]
+
+
+def test_all_process_groups_active_requires_nonempty_live_registry(monkeypatch):
+    pid = 123
+    monkeypatch.setattr(rpg.os, "getpid", lambda: pid)
+    rpg.ReloadableProcessGroup.GROUPS[pid] = []
+    assert not rpg.all_process_groups_active()
+
+    live = type("Group", (), {"group": object()})()
+    dead = type("Group", (), {"group": None})()
+    rpg.ReloadableProcessGroup.GROUPS[pid] = [live]
+    assert rpg.all_process_groups_active()
+    rpg.ReloadableProcessGroup.GROUPS[pid] = [live, dead]
+    assert not rpg.all_process_groups_active()
+
+    del rpg.ReloadableProcessGroup.GROUPS[pid]


### PR DESCRIPTION
## What

- Reuse eligible Megatron training process groups across the short TMS pause-to-weight-sync window.
- Defer the post-destroy NCCL socket cooldown until the next process-group reload.
- Add lifecycle fallback/canary logic and focused unit tests.

## Why

In colocated actor/rollout training, the baseline lifecycle destroys the training process groups before TMS pause, reloads them for weight export, and destroys them again. This places process-group lifecycle work and two fixed cooldown waits on the per-step switch path.

Relates to #86 and #230.

## How

- Preserve process groups only for the immediate local-IPC weight-sync window and only when the conservative capability gate passes.
- Run TP/DP communicator canaries after TMS pause and aggregate the decision across ranks.
- Fall back to the original lifecycle on ineligibility or canary failure, and tear down preserved groups if weight synchronization raises.
- Record a deferred NCCL cooldown deadline and wait only for any remaining time at the next reload.

The branch contains commits `ad4af045f5ecdb80cafc3d8e2b8d13c235338ccf` and `053a6782fd961d1b4bf80e71cac2be8d398df61b`, rebased from the prototype by @Religious-J onto Relax `1f33585`.

## Measurements

One 4×A6000 Qwen3-4B run per configuration was measured; steady steps 2–5 were summarized:

| Metric | Baseline | Optimized | Observed difference |
| --- | ---: | ---: | ---: |
| `sleep` | 5.34 ± 0.14 s | 2.46 ± 0.02 s | −2.88 s |
| `update_weights` | 3.99 ± 0.17 s | 2.17 ± 0.20 s | −1.82 s |
| `wake_up` | 2.24 ± 0.06 s | 2.15 ± 0.16 s | −0.09 s |
| switch total | 11.56 ± 0.12 s | 6.79 ± 0.11 s | −4.77 s (−41.3%) |

These are within-run observations, not independent repetitions. They do not establish a cross-run confidence interval or a general end-to-end throughput improvement. Both mechanisms were enabled together, so their individual contributions were not isolated.

## Testing

- [ ] `pre-commit run --all-files` passes — not rerun in the current checkout because `pre-commit` is unavailable.
- [ ] Tests pass (`pytest tests/`) — not rerun in the current checkout because `pytest` is unavailable.
- [x] New focused tests added for deferred cooldown bookkeeping and process-group lifecycle fallback.
- [ ] Multi-GPU integration test — not rerun for PR submission; requires the colocated GPU environment.
- [x] Clean merge-tree check against current `redai-infra/Relax:main`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] CI/CD or build changes

## Limitations

- The 4B gate is limited to TMS, local IPC, PP/CP/EP size 1, no critic, and non-fully-async execution; unsupported configurations retain the original lifecycle.
- Preserving NCCL native resources can reduce memory headroom during the paused window.
- Additional independent, alternating-order runs are needed for an end-to-end performance conclusion.

