### PR TITLE
【Task.01】多模态 Dense

### DIFF
--- a/scripts/training/multimodal/run-qwen3-vl-4B-2xgpu.sh
+++ b/scripts/training/multimodal/run-qwen3-vl-4B-2xgpu.sh
@@ -96,9 +96,6 @@ OPTIMIZER_ARGS=(
    --adam-beta1 0.9
    --adam-beta2 0.98
    --clip-grad 1.0
-   --optimizer-cpu-offload
-   --overlap-cpu-optimizer-d2h-h2d
-   --use-precision-aware-optimizer
    --no-rope-fusion
 )
 


### PR DESCRIPTION
## 变更说明

本 PR 针对 `scripts/training/multimodal/run-qwen3-vl-4B-2xgpu.sh` 的 Qwen3-VL-4B 双卡 colocate
GRPO 配置进行性能调优。在保持模型、数据、有效 global batch、prompt/response 长度、采样数、GRPO
超参数和 200-step 训练负载不变的前提下，移除经同环境实验确认不必要的性能开销。

关联 Issue：Closes #241

## 改动内容

- 移除 `--optimizer-cpu-offload`、`--overlap-cpu-optimizer-d2h-h2d` 和
  `--use-precision-aware-optimizer`，避免 4B 双卡配置中不必要的 optimizer 主机换入换出开销；
- 保留 full activation recompute 和 `--max-tokens-per-gpu 9216`。移除 recompute 的 A2 在正式运行
  step 9 发生 OOM，已否决且不进入本 PR；
- 补充同环境 200-step 前后对照结果、风险和回退说明。

## 固定实验环境

| 项目 | 内容 |
|---|---|
| Relax 基线 commit | `d52cd0aca9b347a57fb435bda3ae2db8fc6706a4` |
| 优化 commit | `96a48b6b0eb38716c0cd2c886681dc785cf1ee0d` |
| 容器 tag / repo digest | `ghcr.io/redai-infra/relaxrl:latest` / `sha256:8dc39af377a570e6cd7ec88c8b7fcd44c1eb820111e9d2069f1c7c3024b2ea23`（实验期间注册表解析值） |
| GPU | `2 × NVIDIA A100-SXM4-80GB；81920 MiB/卡；NV4；P2P 可用` |
| Driver / CUDA | `580.95.05 / 13.0（nvidia-smi）；PyTorch 2.11.0+cu129` |
| Python / PyTorch | `3.12.3 / 2.11.0+cu129` |
| Ray / SGLang / Transformers | `2.56.1 / 0.5.12.post1 / 5.6.0` |
| CPU / RAM / 磁盘 | `2 × AMD EPYC 7513（128 逻辑 CPU）/ 约 503 GiB / 实验开始时约 254 GB 可用` |
| 模型 manifest SHA-256 | `ecc13700f9394b8ce60593d635b7a56c06aeee70b7cfa5b8871c63ec9b6b4adf` |
| 数据 manifest SHA-256 | `f3376c4a3e4d536e778095fecc481a57d73e899db3b2473324ddb79cfb33865a` |

## 固定训练负载

| 参数 | 基线 | 优化版 |
|---|---:|---:|
| `--num-rollout` | `200` | `200` |
| `--rollout-batch-size` | `2` | `2` |
| `--n-samples-per-prompt` | `8` | `8` |
| `--global-batch-size` | `16` | `16` |
| `--rollout-max-prompt-len` | `2048` | `2048` |
| `--rollout-max-response-len` | `1024` | `1024` |
| `--rollout-temperature` | `0.8` | `0.8` |
| TP / PP / CP / EP / ETP | `2 / 1 / 1 / 1 / 1` | `2 / 1 / 1 / 1 / 1` |
| 模型 / 数据 / seed | 相同 | 相同 |

## 完整运行命令

### 基线

```bash
export MODEL_DIR=<模型父目录>
export DATA_DIR=<数据父目录>
export NUM_ROLLOUT=200
bash scripts/training/multimodal/run-qwen3-vl-4B-2xgpu.sh
```

### 优化版

```bash
export MODEL_DIR=<与基线相同的模型父目录>
export DATA_DIR=<与基线相同的数据父目录>
export NUM_ROLLOUT=200
bash scripts/training/multimodal/run-qwen3-vl-4B-2xgpu.sh
```

## 性能结果

正式运行均关闭 profiler。排除 step 0–19，将 step 20–199 固定划分为 W1=20–79、W2=80–139、
W3=140–199。主指标为 `perf/step_resp_token_per_s`。

| 指标 | 基线 | 优化版 | 变化 |
|---|---:|---:|---:|
| response tokens/s | `250.177` | `301.918` | `+20.682%` |
| total tokens/s | `430.526` | `524.496` | `+21.827%` |
| step time mean / p95 | `31.989 / 36.958s` | `25.939 / 31.136s` | mean `-18.914%` |
| actor train time | `10.681s` | `4.060s` | `-61.991%` |
| GPU utilization mean | `50.688%` | `66.042%` | `+30.292%` |
| peak VRAM / GPU | `73152 MiB` | `72766 MiB` | `-0.528%` |
| 完成 step | `200` | `200` | 不变 |

### 三个稳定窗口

| 窗口 | step | 基线 response tokens/s | 优化版 response tokens/s | 变化 |
|---|---|---:|---:|---:|
| W1 | 20–79 | `252.688` | `309.073` | `+22.314%` |
| W2 | 80–139 | `244.723` | `312.423` | `+27.664%` |
| W3 | 140–199 | `253.119` | `284.259` | `+12.302%` |

## 曲线

以下曲线均由正式 200-step 原始日志生成。

### 性能曲线

<img width="2501" height="1644" alt="performance-curves" src="https://github.com/user-attachments/assets/dde9eaaf-031f-414a-800e-897fae7dd226" />

展示 response/total tokens/s、step time 和 actor train time。

### 训练质量曲线

<img width="2501" height="1644" alt="quality-curves" src="https://github.com/user-attachments/assets/6ea5e591-5166-40f2-822e-ce07eedc1a7d" />

展示 train loss、raw reward、grad norm 和 response length，用于确认优化前后训练质量正常。

### GPU 曲线

<img width="2499" height="1466" alt="gpu-curves" src="https://github.com/user-attachments/assets/eda952f7-35cf-427a-9004-aaacc119ecb3" />

展示 steps 20–199 的双卡平均 GPU utilization 与逐时刻单卡最大显存。

## 复核材料

补充复核材料见 [task01-evidence-summary.zip](https://github.com/user-attachments/files/30730416/task01-evidence-summary.zip)，
其中包含环境清单、统计 JSON、质量摘要、GPU 采样、脱敏后的正式日志、曲线生成数据与脚本、
profiler manifest 和 checksum。

## 正确性与质量护栏

- [x] 基线和优化版均完成 200/200 step；
- [x] 无 OOM、NaN/Inf、未解释异常或静默 fallback；
- [x] global batch、长度上限、采样数和累计有效 token 口径不变；
- [x] 每边 200 个 batch、每 batch 16 samples，无样本丢失；
- [x] loss、reward、response length、KL、clip fraction 和 grad norm 均为有限值；
- [x] 优化版主指标总体提升，且 W1/W2/W3 均未反向；
- [x] profiler trace 支持所声明的瓶颈与优化解释。
- [x] 提供性能、loss/reward/grad norm/response length 和 GPU 曲线及可复现绘图数据。

profiler steps 2–4 中，基线 `HybridDeviceOptimizer.step` 两 rank 平均约 20.15s；优化版切换为
`FusedAdam.step`，对应约 19.29ms。正式运行的 actor train time 同时下降 61.99%。GPU memcpy 总时长
未下降，因此不把结论扩展为所有 H2D/D2H 传输减少。

## 验证

```text
python -m pytest -q task1/tests/test_analyze_results.py task1/tests/test_plot_curves.py
8 passed

git diff --check
通过

bash -n scripts/training/multimodal/run-qwen3-vl-4B-2xgpu.sh
通过（容器内 LF checkout）

Ray baseline:  raysubmit_R9yGNsWNaNaqNyF6  SUCCEEDED, 200/200
Ray optimized: raysubmit_BCR2J8wihysLCVaJ  SUCCEEDED, 200/200
Ray profiler baseline/optimized: SUCCEEDED, 5/5 + 5/5

GitHub CI: Lint、Pre-commit Checks、Python 3.10/3.11/3.12 Tests 全部通过
```

未运行全量 `pytest tests/`：本改动只调整现有 GPU recipe 的三项启动参数；已用目标双卡 GPU 的完整
200-step 前后对照、脚本语法检查和本地统计脚本测试覆盖本次风险。

## 风险与回退

| 风险 | 缓解措施 |
|---|---|
| 其他显存更小的硬件可能需要 optimizer offload | 本次 A100 80GB 优化版峰值 72766 MiB；回退时恢复三项参数 |
| 误删 full recompute 会导致尾部 OOM | A2 已在正式 step 9 复现 OOM；最终 diff 明确保留 full recompute |
| 随机 rollout 造成窗口波动 | 使用预定义三个 60-step 窗口，三个窗口均正向，不挑选区间 |

回退时恢复该 recipe 在基线 commit 中的参数组合。本 PR 不修改数据格式、checkpoint 格式、公共 API、
Controller、Service 或 Launcher，无需迁移。
