### PR TITLE
perf(megatron): reduce colocated weight-sync transition overhead

### DIFF
--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -92,6 +92,7 @@ from .initialize import init, is_megatron_main_rank
 from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
 from .model import forward_only, initialize_model_and_optimizer, save, train
 from .weight_update.common import named_params_and_buffers
+from .weight_update.live_weight_sync import get_distributed_memory_status, run_live_weight_sync
 from .weight_update.train_offload import MegatronTrainStateOffloader
 from .weight_update.update_weight_from_distributed import UpdateWeightFromDistributed
 from .weight_update.update_weight_from_tensor import UpdateWeightFromTensor
@@ -285,6 +286,15 @@ class MegatronTrainRayActor(TrainRayActor):
                 getattr(self.hf_config, "quantization_config", None),
                 args.hf_checkpoint,
             )
+            update_weight_kwargs: dict[str, Any] = {}
+            if update_weight_cls is UpdateWeightFromTensor and getattr(args, "colocate_live_weight_sync", False):
+                update_weight_kwargs["live_weights_getter"] = lambda: dict(
+                    named_params_and_buffers(
+                        self.args,
+                        self.model,
+                        convert_to_global_name=self.args.megatron_to_hf_mode == "raw",
+                    )
+                )
             self.weight_updater = update_weight_cls(
                 self.args,
                 self.model,
@@ -293,6 +303,7 @@ class MegatronTrainRayActor(TrainRayActor):
                 if self.args.model_name is None
                 else self.args.model_name,
                 quantization_config=push_quant_config,
+                **update_weight_kwargs,
             )
         else:
             is_pp_src_rank = (
@@ -402,6 +413,36 @@ class MegatronTrainRayActor(TrainRayActor):
         clear_memory()
         reload_process_groups(timeout_minutes=self.args.distributed_timeout_minutes)
         print_memory("after wake_up model")
+
+    def _can_sync_live_actor_weights(self) -> bool:
+        clear_memory()
+        local_free_bytes, _ = device_utils.mem_get_info()
+        local_required_bytes = self.weight_updater.live_weight_sync_required_bytes
+        status = get_distributed_memory_status(
+            local_free_bytes=local_free_bytes,
+            local_required_bytes=local_required_bytes,
+            process_group=get_gloo_group(),
+        )
+        if dist.get_rank() == 0:
+            logger.info(
+                "colocate live-weight sync memory check: min_free=%.2f GiB, required=%.2f GiB, enabled=%s",
+                status.min_free_bytes / 1024**3,
+                status.max_required_bytes / 1024**3,
+                status.can_sync,
+            )
+        return status.can_sync
+
+    def _onload_rollout_after_weight_sync(self) -> None:
+        if not self.args.offload_rollout or dist.get_rank() != 0:
+            return
+
+        post_sync_handles = []
+        if self._per_step_rollout:
+            post_sync_handles.append(self.rollout_manager.onload_kv.remote())
+        if self.genrm_manager is not None and not getattr(self.args, "defer_reward_to_post_process", False):
+            post_sync_handles.append(self.genrm_manager.onload.remote())
+        if post_sync_handles:
+            ray.get(post_sync_handles)
 
     def _switch_model(self, target_tag: str) -> None:
         # Backend-specific bookkeeping is handled in device utils so this
@@ -959,10 +1000,22 @@ class MegatronTrainRayActor(TrainRayActor):
             self.save_model(rollout_id, force_sync=is_train_done)
         has_rollout = getattr(self, "rollout_manager", None) is not None
         if self._per_step_rollout:
-            if self.args.offload_train:
-                self.sleep()
-            if has_rollout:
-                self.update_weights()
+            use_live_weight_sync = (
+                has_rollout
+                and getattr(self.args, "colocate_live_weight_sync", False)
+                and self._can_sync_live_actor_weights()
+            )
+            if use_live_weight_sync:
+                run_live_weight_sync(
+                    update_weights=lambda: self.update_weights(use_live_weights=True),
+                    offload_actor=self.sleep,
+                    onload_rollout_kv=self._onload_rollout_after_weight_sync,
+                )
+            else:
+                if self.args.offload_train:
+                    self.sleep()
+                if has_rollout:
+                    self.update_weights()
         tracking_utils.flush_metrics(self.args, compute_rollout_step(self.args, rollout_id))
         # RL-only generative eval (uses SGLang via rollout_manager.eval). SFT
         # uses local eval/predict runner below.
@@ -1601,16 +1654,16 @@ class MegatronTrainRayActor(TrainRayActor):
             destroy_process_groups()
 
     @timer
-    def update_weights(self) -> None:
+    def update_weights(self, *, use_live_weights: bool = False) -> None:
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
 
         if self.args.offload_train:
-            # CRITICAL: Barrier before onload_weights to ensure ALL ranks have
-            # completed sleep() (and released GPU memory via tms.pause()) before
-            # SGLang's resume_memory_occupation tries to reclaim GPU memory.
-            # Without this, rank 0 may trigger SGLang resume while other ranks
-            # still hold GPU memory, causing cuMemCreate OOM in SGLang schedulers.
+            # CRITICAL: Before onload_weights, the legacy path must ensure every
+            # rank completed sleep() and released GPU memory via tms.pause(). The
+            # live path instead reaches here after its collective memory preflight.
+            # Without an all-rank transition, rank 0 may resume SGLang while other
+            # ranks still hold memory, causing cuMemCreate OOM in the schedulers.
             dist.barrier(group=get_gloo_group())
 
         if self.args.offload_rollout and dist.get_rank() == 0:
@@ -1638,7 +1691,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if reconnect_rollout_engines:
             self.wake_up()
-        elif self.args.offload_train:
+        elif self.args.offload_train and not use_live_weights:
             reload_process_groups(timeout_minutes=self.args.distributed_timeout_minutes)
 
         if num_new_engines > 0 or reconnect_rollout_engines:
@@ -1654,7 +1707,10 @@ class MegatronTrainRayActor(TrainRayActor):
 
         with self._train_state_offloader.disable_during_update():
             print_memory("before update_weights")
-            self.weight_updater.update_weights()
+            if use_live_weights:
+                self.weight_updater.update_weights(use_live_weights=True)
+            else:
+                self.weight_updater.update_weights()
             print_memory("after update_weights", clear_before_print=not device_utils.is_npu_available)
 
             if self.args.ci_test and len(rollout_engines) > 0:
@@ -1677,7 +1733,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     self.weights_backuper.backup("old_actor")
         if reconnect_rollout_engines:
             self.sleep()
-        elif self.args.offload_train:
+        elif self.args.offload_train and not use_live_weights:
             destroy_process_groups()
 
         # RL warms KV here for the next per-step generate. SFT's /predict
@@ -1687,14 +1743,8 @@ class MegatronTrainRayActor(TrainRayActor):
         # custom_reward_post_process function owns GenRM lifecycle, so skip
         # onloading GenRM here (it must stay offloaded for rollout to have
         # all GPUs during generate in shared-bundles mode).
-        if self.args.offload_rollout and dist.get_rank() == 0:
-            post_sync_handles = []
-            if self._per_step_rollout:
-                post_sync_handles.append(self.rollout_manager.onload_kv.remote())
-            if self.genrm_manager is not None and not getattr(self.args, "defer_reward_to_post_process", False):
-                post_sync_handles.append(self.genrm_manager.onload.remote())
-            if post_sync_handles:
-                ray.get(post_sync_handles)
+        if not use_live_weights:
+            self._onload_rollout_after_weight_sync()
 
     @timer("wait update_weights_fully_async")
     def _check_services_health(self) -> tuple[bool, bool]:

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -1009,6 +1009,11 @@ class MegatronTrainRayActor(TrainRayActor):
                 run_live_weight_sync(
                     update_weights=lambda: self.update_weights(use_live_weights=True),
                     offload_actor=self.sleep,
+                    # ``sleep`` destroys only reloadable accelerator process
+                    # groups. The dedicated Gloo group stays alive and keeps
+                    # rank 0 from restoring KV while another rank still owns
+                    # Actor memory.
+                    synchronize_after_offload=lambda: dist.barrier(group=get_gloo_group()),
                     onload_rollout_kv=self._onload_rollout_after_weight_sync,
                 )
             else:

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -92,7 +92,11 @@ from .initialize import init, is_megatron_main_rank
 from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
 from .model import forward_only, initialize_model_and_optimizer, save, train
 from .weight_update.common import named_params_and_buffers
-from .weight_update.live_weight_sync import get_distributed_memory_status, run_live_weight_sync
+from .weight_update.live_weight_sync import (
+    get_distributed_memory_status,
+    get_distributed_sync_success,
+    run_live_weight_sync,
+)
 from .weight_update.train_offload import MegatronTrainStateOffloader
 from .weight_update.update_weight_from_distributed import UpdateWeightFromDistributed
 from .weight_update.update_weight_from_tensor import UpdateWeightFromTensor
@@ -1016,7 +1020,10 @@ class MegatronTrainRayActor(TrainRayActor):
                     # groups. The dedicated Gloo group stays alive and keeps
                     # rank 0 from restoring KV while another rank still owns
                     # Actor memory.
-                    synchronize_after_offload=lambda: dist.barrier(group=get_gloo_group()),
+                    synchronize_after_offload=lambda local_success: get_distributed_sync_success(
+                        local_success=local_success,
+                        process_group=get_gloo_group(),
+                    ),
                     onload_rollout_kv=self._onload_rollout_after_weight_sync,
                 )
             else:

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -1001,7 +1001,10 @@ class MegatronTrainRayActor(TrainRayActor):
         has_rollout = getattr(self, "rollout_manager", None) is not None
         if self._per_step_rollout:
             use_live_weight_sync = (
-                has_rollout
+                # Final checkpointing destroys reloadable Megatron process
+                # groups, so preserve the CPU-backed path for that step.
+                not is_train_done
+                and has_rollout
                 and getattr(self.args, "colocate_live_weight_sync", False)
                 and self._can_sync_live_actor_weights()
             )

--- a/relax/backends/megatron/weight_update/live_weight_sync.py
+++ b/relax/backends/megatron/weight_update/live_weight_sync.py
@@ -84,6 +84,8 @@ def run_live_weight_sync(
     try:
         update_weights()
     finally:
-        offload_actor()
-    synchronize_after_offload()
+        try:
+            offload_actor()
+        finally:
+            synchronize_after_offload()
     onload_rollout_kv()

--- a/relax/backends/megatron/weight_update/live_weight_sync.py
+++ b/relax/backends/megatron/weight_update/live_weight_sync.py
@@ -77,11 +77,13 @@ def run_live_weight_sync(
     *,
     update_weights: Callable[[], None],
     offload_actor: Callable[[], None],
+    synchronize_after_offload: Callable[[], None],
     onload_rollout_kv: Callable[[], None],
 ) -> None:
-    """Keep Actor cleanup mandatory and restore KV only after a successful sync."""
+    """Offload every Actor rank before restoring rollout KV memory."""
     try:
         update_weights()
     finally:
         offload_actor()
+    synchronize_after_offload()
     onload_rollout_kv()

--- a/relax/backends/megatron/weight_update/live_weight_sync.py
+++ b/relax/backends/megatron/weight_update/live_weight_sync.py
@@ -73,19 +73,48 @@ def get_distributed_memory_status(
     )
 
 
+def get_distributed_sync_success(*, local_success: bool, process_group) -> bool:
+    """Synchronize ranks and return whether every rank completed locally."""
+    value = torch.tensor([int(local_success)], dtype=torch.int64)
+    dist.all_reduce(value, op=dist.ReduceOp.MIN, group=process_group)
+    return bool(value[0].item())
+
+
 def run_live_weight_sync(
     *,
     update_weights: Callable[[], None],
     offload_actor: Callable[[], None],
-    synchronize_after_offload: Callable[[], None],
+    synchronize_after_offload: Callable[[bool], bool],
     onload_rollout_kv: Callable[[], None],
 ) -> None:
-    """Offload every Actor rank before restoring rollout KV memory."""
+    """Restore rollout KV only after every Actor rank offloads successfully."""
+    update_succeeded = False
     try:
         update_weights()
+        update_succeeded = True
     finally:
-        try:
+        # update_weights contains collectives on the same Gloo group. After a
+        # local update failure, entering another collective could mismatch a
+        # peer that is still inside the update sequence. Offload locally and
+        # let the worker fail instead; successful peers cannot reach onload.
+        if not update_succeeded:
             offload_actor()
-        finally:
-            synchronize_after_offload()
+
+    offload_failure: Exception | None = None
+    try:
+        offload_actor()
+    except Exception as exc:
+        offload_failure = exc
+
+    try:
+        global_success = synchronize_after_offload(offload_failure is None)
+    except Exception:
+        if offload_failure is not None:
+            raise offload_failure
+        raise
+
+    if offload_failure is not None:
+        raise offload_failure
+    if not global_success:
+        raise RuntimeError("live weight sync offload failed on another rank")
     onload_rollout_kv()

--- a/relax/backends/megatron/weight_update/live_weight_sync.py
+++ b/relax/backends/megatron/weight_update/live_weight_sync.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+
+
+@dataclass(frozen=True)
+class LiveWeightSyncMemoryStatus:
+    min_free_bytes: int
+    max_required_bytes: int
+
+    @property
+    def can_sync(self) -> bool:
+        return self.min_free_bytes >= self.max_required_bytes
+
+
+def estimate_full_model_bytes(
+    named_tensors: Mapping[str, torch.Tensor],
+    *,
+    tensor_parallel_size: int,
+    expert_tensor_parallel_size: int,
+) -> tuple[int, int]:
+    """Estimate full-model bytes conservatively from one PP/EP rank."""
+    if tensor_parallel_size <= 0 or expert_tensor_parallel_size <= 0:
+        raise ValueError("tensor parallel sizes must be positive")
+
+    total_bytes = 0
+    largest_param_bytes = 0
+    for name, tensor in named_tensors.items():
+        tp_size = expert_tensor_parallel_size if ".experts." in name else tensor_parallel_size
+        param_bytes = tensor.numel() * tensor.element_size() * tp_size
+        total_bytes += param_bytes
+        largest_param_bytes = max(largest_param_bytes, param_bytes)
+    return total_bytes, largest_param_bytes
+
+
+def required_live_weight_sync_bytes(
+    *,
+    full_model_bytes: int,
+    largest_param_bytes: int,
+    update_weight_buffer_size: int,
+    memory_margin_bytes: int,
+) -> int:
+    """Estimate extra memory for rollout weights and two in-flight chunks."""
+    values = (full_model_bytes, largest_param_bytes, update_weight_buffer_size, memory_margin_bytes)
+    if any(value < 0 for value in values):
+        raise ValueError("live weight sync memory inputs must be non-negative")
+
+    chunk_bytes = max(largest_param_bytes, update_weight_buffer_size)
+    return full_model_bytes + 2 * chunk_bytes + memory_margin_bytes
+
+
+def get_distributed_memory_status(
+    *,
+    local_free_bytes: int,
+    local_required_bytes: int,
+    process_group,
+) -> LiveWeightSyncMemoryStatus:
+    """Use one CPU collective so every rank makes the same memory decision."""
+    if local_free_bytes < 0 or local_required_bytes < 0:
+        raise ValueError("live weight sync memory values must be non-negative")
+
+    # MIN(free, -required) gives the global minimum free bytes and the
+    # negated global maximum required bytes in one Gloo collective.
+    values = torch.tensor([local_free_bytes, -local_required_bytes], dtype=torch.int64)
+    dist.all_reduce(values, op=dist.ReduceOp.MIN, group=process_group)
+    return LiveWeightSyncMemoryStatus(
+        min_free_bytes=int(values[0].item()),
+        max_required_bytes=-int(values[1].item()),
+    )
+
+
+def run_live_weight_sync(
+    *,
+    update_weights: Callable[[], None],
+    offload_actor: Callable[[], None],
+    onload_rollout_kv: Callable[[], None],
+) -> None:
+    """Keep Actor cleanup mandatory and restore KV only after a successful sync."""
+    try:
+        update_weights()
+    finally:
+        offload_actor()
+    onload_rollout_kv()

--- a/relax/backends/megatron/weight_update/update_weight_from_tensor.py
+++ b/relax/backends/megatron/weight_update/update_weight_from_tensor.py
@@ -29,6 +29,7 @@ from relax.utils.megatron_peft_utils import (
 
 from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
 from .hf_weight_iterator_base import HfWeightIteratorBase
+from .live_weight_sync import estimate_full_model_bytes, required_live_weight_sync_bytes
 from .lora_adapter_sync import LoraAdapterSync
 from .update_weight_from_distributed import (
     connect_rollout_engines_from_distributed,
@@ -55,6 +56,7 @@ class UpdateWeightFromTensor:
         model: Sequence[torch.nn.Module],
         weights_getter: Callable[[], Mapping[str, torch.Tensor]],
         *,
+        live_weights_getter: Callable[[], Mapping[str, torch.Tensor]] | None = None,
         model_name: str,
         quantization_config: dict[str, int | str | list[str]] | None,
     ) -> None:
@@ -66,6 +68,7 @@ class UpdateWeightFromTensor:
         self.args = args
         self.model = model
         self.weights_getter = weights_getter
+        self.live_weights_getter = live_weights_getter
         self.model_name = model_name
         self.quantization_config = quantization_config
         self.weight_version = 0
@@ -87,6 +90,25 @@ class UpdateWeightFromTensor:
         self._ipc_engine = None
         self._model_update_groups = None
         self.distributed_rollout_engines: list[ActorHandle] = []
+        self._live_weight_sync_required_bytes: int | None = None
+
+    @property
+    def live_weight_sync_required_bytes(self) -> int:
+        if self.live_weights_getter is None:
+            raise RuntimeError("live weight sync requires a live_weights_getter")
+        if self._live_weight_sync_required_bytes is None:
+            full_model_bytes, largest_param_bytes = estimate_full_model_bytes(
+                self.live_weights_getter(),
+                tensor_parallel_size=mpu.get_tensor_model_parallel_world_size(),
+                expert_tensor_parallel_size=mpu.get_expert_tensor_parallel_world_size(),
+            )
+            self._live_weight_sync_required_bytes = required_live_weight_sync_bytes(
+                full_model_bytes=full_model_bytes,
+                largest_param_bytes=largest_param_bytes,
+                update_weight_buffer_size=self.args.update_weight_buffer_size,
+                memory_margin_bytes=self.args.train_memory_margin_bytes,
+            )
+        return self._live_weight_sync_required_bytes
 
     def connect_rollout_engines(
         self,
@@ -175,7 +197,7 @@ class UpdateWeightFromTensor:
                 self._ipc_engine = engine
 
     @torch.no_grad()
-    def update_weights(self) -> None:
+    def update_weights(self, *, use_live_weights: bool = False) -> None:
         """version++, flush caches, process buckets with pipelining.
 
         Pipelining: overlap chunk N's IPC transfer with chunk N+1's HF
@@ -187,6 +209,11 @@ class UpdateWeightFromTensor:
         HF export so the rollout engine serves one merged model; otherwise all
         weights are sent as-is.
         """
+        if use_live_weights and self.live_weights_getter is None:
+            raise RuntimeError("live weight sync requires a live_weights_getter")
+        if use_live_weights and self.lora_enabled:
+            raise RuntimeError("live weight sync does not support LoRA weight updates")
+
         # LoRA adapter mode has its own base-once + adapter-delta sync protocol.
         if self.lora_enabled and self.lora_adapter_mode:
             self._update_weights_adapter_mode()
@@ -210,7 +237,7 @@ class UpdateWeightFromTensor:
                 )
         dist.barrier(group=get_gloo_group())
 
-        megatron_local_weights = self.weights_getter()
+        megatron_local_weights = self.live_weights_getter() if use_live_weights else self.weights_getter()
 
         if self.lora_enabled and self.lora_merge_mode:
             renamed = {strip_param_name_prefix(k): v for k, v in megatron_local_weights.items()}

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -897,6 +897,14 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--colocate-live-weight-sync",
+                action="store_true",
+                help=(
+                    "Synchronize colocated rollout weights directly from the live Actor before train offload. "
+                    "Falls back to the existing sleep-first path when any rank lacks memory."
+                ),
+            )
+            parser.add_argument(
                 "--update-weights-interval",
                 type=int,
                 default=1,
@@ -3178,6 +3186,20 @@ def slime_validate_args(args):
                     "Add --selective-offload to use the application-level offload instead, "
                     "or drop expandable_segments."
                 )
+
+    if getattr(args, "colocate_live_weight_sync", False):
+        if not args.colocate or args.hybrid or not args.offload_train or not args.offload_rollout:
+            raise ValueError(
+                "--colocate-live-weight-sync requires synchronous colocate mode with train and rollout offload"
+            )
+        if args.megatron_to_hf_mode != "bridge":
+            raise ValueError("--colocate-live-weight-sync currently requires --megatron-to-hf-mode bridge")
+        if args.pipeline_model_parallel_size != 1 or args.expert_model_parallel_size != 1:
+            raise ValueError("--colocate-live-weight-sync currently requires pipeline and expert parallel size 1")
+        if args.use_critic or genrm_enabled or managed_opd_teacher_enabled:
+            raise ValueError("--colocate-live-weight-sync currently supports the Actor + rollout topology only")
+        if getattr(args, "lora_rank", 0) > 0:
+            raise ValueError("--colocate-live-weight-sync does not currently support LoRA")
 
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path

--- a/scripts/training/text/run-qwen3-4B-8xgpu.sh
+++ b/scripts/training/text/run-qwen3-4B-8xgpu.sh
@@ -115,6 +115,13 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.8
 )
 
+LIVE_WEIGHT_SYNC_ARGS=()
+case "${COLOCATE_LIVE_WEIGHT_SYNC:-0}" in
+   0) ;;
+   1) LIVE_WEIGHT_SYNC_ARGS+=(--colocate-live-weight-sync) ;;
+   *) echo "COLOCATE_LIVE_WEIGHT_SYNC must be 0 or 1" >&2; exit 2 ;;
+esac
+
 WANDB_ARGS=(
    --use-clearml
    --use-metrics-service
@@ -156,4 +163,5 @@ ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://127.0.0.1:8265" \
     "${PERF_ARGS[@]}" \
     "${EVAL_ARGS[@]}" \
     "${SGLANG_ARGS[@]}" \
+    "${LIVE_WEIGHT_SYNC_ARGS[@]}" \
     "${MISC_ARGS[@]}"  2>&1 | tee log/qwen3-4b-GRPO-gpu8-${now}.log

--- a/tests/backends/megatron/weight_update/test_live_weight_sync.py
+++ b/tests/backends/megatron/weight_update/test_live_weight_sync.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import pytest
+import torch
+
+from relax.backends.megatron.weight_update.live_weight_sync import (
+    estimate_full_model_bytes,
+    get_distributed_memory_status,
+    required_live_weight_sync_bytes,
+    run_live_weight_sync,
+)
+
+
+def test_estimate_full_model_bytes_accounts_for_tensor_and_expert_parallel_sizes():
+    tensors = {
+        "decoder.layers.0.linear.weight": torch.empty(25, dtype=torch.float32),
+        "decoder.layers.0.mlp.experts.0.weight": torch.empty(10, dtype=torch.float32),
+    }
+
+    total_bytes, largest_param_bytes = estimate_full_model_bytes(
+        tensors,
+        tensor_parallel_size=2,
+        expert_tensor_parallel_size=4,
+    )
+
+    assert total_bytes == 360
+    assert largest_param_bytes == 200
+
+
+def test_required_live_weight_sync_bytes_reserves_two_chunks():
+    required_bytes = required_live_weight_sync_bytes(
+        full_model_bytes=1_000,
+        largest_param_bytes=600,
+        update_weight_buffer_size=512,
+        memory_margin_bytes=100,
+    )
+
+    assert required_bytes == 2_300
+
+
+def test_get_distributed_memory_status_uses_global_worst_case(monkeypatch):
+    group = object()
+
+    def fake_all_reduce(values, *, op, group: object):
+        assert op == torch.distributed.ReduceOp.MIN
+        assert group is not None
+        values[0] = 900
+        values[1] = -950
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    status = get_distributed_memory_status(
+        local_free_bytes=1_000,
+        local_required_bytes=800,
+        process_group=group,
+    )
+
+    assert status.min_free_bytes == 900
+    assert status.max_required_bytes == 950
+    assert status.can_sync is False
+
+
+def test_run_live_weight_sync_orders_update_offload_and_onload():
+    calls = []
+
+    run_live_weight_sync(
+        update_weights=lambda: calls.append("update"),
+        offload_actor=lambda: calls.append("offload"),
+        onload_rollout_kv=lambda: calls.append("onload_kv"),
+    )
+
+    assert calls == ["update", "offload", "onload_kv"]
+
+
+def test_run_live_weight_sync_offloads_actor_when_update_fails():
+    calls = []
+
+    def fail_update():
+        calls.append("update")
+        raise RuntimeError("update failed")
+
+    with pytest.raises(RuntimeError, match="update failed"):
+        run_live_weight_sync(
+            update_weights=fail_update,
+            offload_actor=lambda: calls.append("offload"),
+            onload_rollout_kv=lambda: calls.append("onload_kv"),
+        )
+
+    assert calls == ["update", "offload"]

--- a/tests/backends/megatron/weight_update/test_live_weight_sync.py
+++ b/tests/backends/megatron/weight_update/test_live_weight_sync.py
@@ -88,7 +88,7 @@ def test_run_live_weight_sync_offloads_actor_when_update_fails():
             onload_rollout_kv=lambda: calls.append("onload_kv"),
         )
 
-    assert calls == ["update", "offload"]
+    assert calls == ["update", "offload", "sync"]
 
 
 def test_run_live_weight_sync_does_not_onload_kv_when_offload_sync_fails():

--- a/tests/backends/megatron/weight_update/test_live_weight_sync.py
+++ b/tests/backends/megatron/weight_update/test_live_weight_sync.py
@@ -6,6 +6,7 @@ import torch
 from relax.backends.megatron.weight_update.live_weight_sync import (
     estimate_full_model_bytes,
     get_distributed_memory_status,
+    get_distributed_sync_success,
     required_live_weight_sync_bytes,
     run_live_weight_sync,
 )
@@ -60,17 +61,35 @@ def test_get_distributed_memory_status_uses_global_worst_case(monkeypatch):
     assert status.can_sync is False
 
 
+def test_get_distributed_sync_success_requires_every_rank(monkeypatch):
+    group = object()
+
+    def fake_all_reduce(value, *, op, group: object):
+        assert value.tolist() == [1]
+        assert op == torch.distributed.ReduceOp.MIN
+        assert group is not None
+        value[0] = 0
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    assert get_distributed_sync_success(local_success=True, process_group=group) is False
+
+
 def test_run_live_weight_sync_orders_update_offload_sync_and_onload():
     calls = []
+
+    def synchronize(local_success):
+        calls.append(f"sync:{local_success}")
+        return local_success
 
     run_live_weight_sync(
         update_weights=lambda: calls.append("update"),
         offload_actor=lambda: calls.append("offload"),
-        synchronize_after_offload=lambda: calls.append("sync"),
+        synchronize_after_offload=synchronize,
         onload_rollout_kv=lambda: calls.append("onload_kv"),
     )
 
-    assert calls == ["update", "offload", "sync", "onload_kv"]
+    assert calls == ["update", "offload", "sync:True", "onload_kv"]
 
 
 def test_run_live_weight_sync_offloads_actor_when_update_fails():
@@ -80,21 +99,66 @@ def test_run_live_weight_sync_offloads_actor_when_update_fails():
         calls.append("update")
         raise RuntimeError("update failed")
 
+    def synchronize(local_success):
+        calls.append(f"sync:{local_success}")
+        return local_success
+
     with pytest.raises(RuntimeError, match="update failed"):
         run_live_weight_sync(
             update_weights=fail_update,
             offload_actor=lambda: calls.append("offload"),
-            synchronize_after_offload=lambda: calls.append("sync"),
+            synchronize_after_offload=synchronize,
             onload_rollout_kv=lambda: calls.append("onload_kv"),
         )
 
-    assert calls == ["update", "offload", "sync"]
+    assert calls == ["update", "offload"]
+
+
+def test_run_live_weight_sync_skips_onload_when_another_rank_offload_fails():
+    calls = []
+
+    def synchronize(local_success):
+        calls.append(f"sync:{local_success}")
+        return False
+
+    with pytest.raises(RuntimeError, match="offload failed on another rank"):
+        run_live_weight_sync(
+            update_weights=lambda: calls.append("update"),
+            offload_actor=lambda: calls.append("offload"),
+            synchronize_after_offload=synchronize,
+            onload_rollout_kv=lambda: calls.append("onload_kv"),
+        )
+
+    assert calls == ["update", "offload", "sync:True"]
+
+
+def test_run_live_weight_sync_synchronizes_when_offload_fails():
+    calls = []
+
+    def fail_offload():
+        calls.append("offload")
+        raise RuntimeError("offload failed")
+
+    def synchronize(local_success):
+        calls.append(f"sync:{local_success}")
+        return local_success
+
+    with pytest.raises(RuntimeError, match="offload failed"):
+        run_live_weight_sync(
+            update_weights=lambda: calls.append("update"),
+            offload_actor=fail_offload,
+            synchronize_after_offload=synchronize,
+            onload_rollout_kv=lambda: calls.append("onload_kv"),
+        )
+
+    assert calls == ["update", "offload", "sync:False"]
 
 
 def test_run_live_weight_sync_does_not_onload_kv_when_offload_sync_fails():
     calls = []
 
-    def fail_sync():
+    def fail_sync(local_success):
+        assert local_success is True
         calls.append("sync")
         raise RuntimeError("offload sync failed")
 

--- a/tests/backends/megatron/weight_update/test_live_weight_sync.py
+++ b/tests/backends/megatron/weight_update/test_live_weight_sync.py
@@ -60,16 +60,17 @@ def test_get_distributed_memory_status_uses_global_worst_case(monkeypatch):
     assert status.can_sync is False
 
 
-def test_run_live_weight_sync_orders_update_offload_and_onload():
+def test_run_live_weight_sync_orders_update_offload_sync_and_onload():
     calls = []
 
     run_live_weight_sync(
         update_weights=lambda: calls.append("update"),
         offload_actor=lambda: calls.append("offload"),
+        synchronize_after_offload=lambda: calls.append("sync"),
         onload_rollout_kv=lambda: calls.append("onload_kv"),
     )
 
-    assert calls == ["update", "offload", "onload_kv"]
+    assert calls == ["update", "offload", "sync", "onload_kv"]
 
 
 def test_run_live_weight_sync_offloads_actor_when_update_fails():
@@ -83,7 +84,26 @@ def test_run_live_weight_sync_offloads_actor_when_update_fails():
         run_live_weight_sync(
             update_weights=fail_update,
             offload_actor=lambda: calls.append("offload"),
+            synchronize_after_offload=lambda: calls.append("sync"),
             onload_rollout_kv=lambda: calls.append("onload_kv"),
         )
 
     assert calls == ["update", "offload"]
+
+
+def test_run_live_weight_sync_does_not_onload_kv_when_offload_sync_fails():
+    calls = []
+
+    def fail_sync():
+        calls.append("sync")
+        raise RuntimeError("offload sync failed")
+
+    with pytest.raises(RuntimeError, match="offload sync failed"):
+        run_live_weight_sync(
+            update_weights=lambda: calls.append("update"),
+            offload_actor=lambda: calls.append("offload"),
+            synchronize_after_offload=fail_sync,
+            onload_rollout_kv=lambda: calls.append("onload_kv"),
+        )
+
+    assert calls == ["update", "offload", "sync"]


### PR DESCRIPTION
#### Summary

- Closes #240
- 解决了什么问题：同步 colocate 模式下，Actor 训练结束后原有路径需要先 offload Actor，再从 CPU 备份恢复权重并更新 SGLang；这使每轮权重更新平均耗时约 5 秒。
- 为什么采用该方案：显存允许时，直接使用训练后的 live Actor tensor 复用现有 Megatron-to-HF 转换和 SGLang 更新链路，随后再 offload Actor。所有 rank 通过一次 Gloo collective 做一致的显存判断；显存不足和最终 checkpoint step 保持原有 CPU-backed 路径。

#### Changes

- `relax/backends/megatron/actor.py`
  - 增加 `update weights → offload Actor → all-rank success agreement → restore rollout KV` 的 live-weight 路径。
  - 权重更新异常时执行本地 Actor offload 并终止当前 worker；任一 rank 的 Actor offload 失败时，所有 rank 均不会恢复 rollout KV。
  - 显存不足或最终 checkpoint step 自动使用原有路径。
- `relax/backends/megatron/weight_update/live_weight_sync.py`
  - 估算完整模型、两个传输 chunk 和配置 margin 所需显存。
  - 通过全局最小 free memory 和最大 required memory 保证所有 rank 作出相同决策。
- `relax/backends/megatron/weight_update/update_weight_from_tensor.py`
  - 允许现有 tensor weight-update pipeline 从 live Actor parameters/buffers 读取权重。
- `relax/utils/arguments.py`
  - 新增默认关闭的 `--colocate-live-weight-sync`。
  - 对运行模式、Megatron bridge、PP/EP、拓扑和 LoRA 组合做 fail-fast 校验。
- `scripts/training/text/run-qwen3-4B-8xgpu.sh`
  - 支持通过 `COLOCATE_LIVE_WEIGHT_SYNC=1` 显式启用。
- `tests/backends/megatron/weight_update/test_live_weight_sync.py`
  - 覆盖显存估算、全 rank 决策、执行顺序和异常清理。
- CLI、配置或兼容性变化：默认行为不变；当前支持同步 colocate、Megatron bridge、Actor + rollout、train/rollout offload、PP1/EP1、非 LoRA。

#### Verification

- 环境、硬件、commit：
  - Base：`d52cd0aca9b347a57fb435bda3ae2db8fc6706a4`
  - Performance candidate：`8eba10f02307b16f283f81bcbd96d5f4f12f8586`
  - PR head：`dde0053`（补充异常路径的 all-rank 成功确认；成功路径的数据流不变）
  - Image：`ghcr.io/redai-infra/relaxrl:dev-20260715-8325919e@sha256:3fa8ce578acda6c829b83016bde42c38fa892681e4f36ca330f545616fe578e2`
  - Python 3.12.3；PyTorch 2.11.0+cu129；CUDA 12.9；SGLang 0.5.12.post1；Ray 2.56.0；Transformers 5.6.0
  - 8 × NVIDIA L20Z 80 GiB；128 CPU；1024 GiB memory
  - Model：`Qwen/Qwen3-4B@1cfa9a7208912126459214e8b04321603b3df60c`
  - Train data：`zhuzilin/dapo-math-17k@2e65612930298bde4c5d58fd97b3f23a483aaff9`
  - Eval data：`zhuzilin/aime-2024@1c625e328db94ec7ef7ff169016b097c468d60b9`

- 可复制命令：

  ```bash
  export MODEL_DIR=/path/to/models
  export DATA_DIR=/path/to/data
  export NUM_ROLLOUT=21

  # Baseline
  export EXP_DIR=/path/to/output/baseline
  bash scripts/training/text/run-qwen3-4B-8xgpu.sh

  # Candidate
  export EXP_DIR=/path/to/output/live-weight-sync
  export COLOCATE_LIVE_WEIGHT_SYNC=1
  bash scripts/training/text/run-qwen3-4B-8xgpu.sh
  ```

- 单元/相关测试：

  ```text
  python -m pytest -q tests/backends/megatron/weight_update/test_live_weight_sync.py
  9 passed

  python -m pytest -q \
    tests/backends/megatron/weight_update/test_live_weight_sync.py \
    tests/backends/megatron/weight_update/test_lora_weight_sync.py \
    tests/backends/megatron/test_actor_http_timeout.py \
    tests/backends/sglang/test_arguments.py \
    tests/utils/test_arguments_opd_teacher_colocate.py
  44 passed, 4 skipped

  pre-commit run --all-files
  passed
  ```

- 端到端结果：两臂各运行 2 次，每次 21 个 rollout；统计 rollout 2–19 的 18 个稳定 step。

  | Run | Total tokens/s | Response tokens/s | Step time | Weight update | Transition | GPU util | Peak VRAM |
  |---|---:|---:|---:|---:|---:|---:|---:|
  | Baseline 1 | 9573.72 | 9358.63 | 180.330 s | 4.961 s | 10.570 s | 87.47% | 70.73 GiB |
  | Baseline 2 | 9544.89 | 9331.30 | 181.434 s | 5.006 s | 10.731 s | 87.32% | 71.36 GiB |
  | Candidate 1 | 9736.30 | 9513.72 | 173.896 s | 0.864 s | 6.483 s | 89.06% | 72.54 GiB |
  | Candidate 2 | 9746.30 | 9524.83 | 175.828 s | 0.885 s | 6.788 s | 89.25% | 71.02 GiB |
  | **Mean / delta** | **9559.30 → 9741.30 (+1.90%)** | **9344.97 → 9519.27 (+1.87%)** | **180.882 → 174.862 s (-3.33%)** | **4.984 → 0.874 s (-82.45%)** | **10.651 → 6.636 s (-37.70%)** | **87.40% → 89.15% (+1.76 pp)** | **71.05 → 71.78 GiB** |

  `Transition = sleep + update_weights + wake_up`。Candidate 两次总吞吐相差 0.10%；四次运行均完成全部训练 step，无 OOM、NaN、Inf、异常退出或样本丢失。

- 正确性/质量护栏（稳定窗口均值）：

  | Metric | Baseline | Candidate |
  |---|---:|---:|
  | `rollout/raw_reward` | -0.6452 | -0.6185 |
  | `rollout/response_lengths` | 6609.20 | 6510.16 |
  | `train/loss` | 0.01177 | 0.01190 |
  | `train/grad_norm` | 0.08797 | 0.09781 |

- 日志、曲线、profile：性能数字来自框架逐 step `perf/*` 指标和每秒 GPU 采样；本改动不依赖 profiler 计时作为验收数据。

#### Risk & Rollback

- 已知限制：仅支持同步 colocate、Megatron bridge、Actor + rollout、train/rollout offload、PP1/EP1、非 LoRA；其他组合在参数校验阶段直接报错。
- 风险：live sync 期间 Actor 和 rollout weights 会短暂共存，可能增加峰值显存。实现使用保守的全 rank 显存预检；实测平均峰值增加 0.73 GiB。
- 关闭开关或回退方式：该功能默认关闭；不传 `--colocate-live-weight-sync`（或保持 `COLOCATE_LIVE_WEIGHT_SYNC=0`）即使用原有路径。启用后显存不足或最终 checkpoint step 也会自动回退。

#### Checklist

- [x] Diff 仅包含本任务必要改动
- [x] 新增/相关测试全部通过
- [x] CLI 帮助、脚本和默认值已更新
- [x] 不含密钥、数据集、checkpoint 或机器隐私信息
- [ ] 已逐条回复 review comment
