### PR TITLE
fix(test): restore registry module after reinforce++ registry fixture

### DIFF
--- a/tests/core/test_registry_reinforce_plus_plus.py
+++ b/tests/core/test_registry_reinforce_plus_plus.py
@@ -25,10 +25,18 @@ def registry_module(monkeypatch):
         classes[class_name] = component_class
         monkeypatch.setitem(sys.modules, module.__name__, module)
 
+    original_registry = sys.modules.get("relax.core.registry")
     sys.modules.pop("relax.core.registry", None)
     module = importlib.import_module("relax.core.registry")
     yield module, classes
     sys.modules.pop("relax.core.registry", None)
+    # Restore the pre-test registry module so later tests in the same process
+    # keep importing a single module instance. Popping without restoring made
+    # ``process_role`` (old instance) return a ``ROLES_COLOCATE`` that fails
+    # ``is`` comparison against the re-imported one in test_registry_sft.py /
+    # test_registry_rloo.py.
+    if original_registry is not None:
+        sys.modules["relax.core.registry"] = original_registry
 
 
 @pytest.mark.parametrize("estimator", ["reinforce_plus_plus", "reinforce_plus_plus_baseline"])


### PR DESCRIPTION
该问题由 #202 新增的 `tests/core/test_registry_reinforce_plus_plus.py` 引入。

其 `registry_module` fixture 在 teardown 中执行 `sys.modules.pop("relax.core.registry")`，但没有恢复原始模块。在同一个 pytest 进程中，任何后续测试再次触发 `import relax.core.registry` 时都会重新导入并得到一个新的模块实例：

- 测试文件模块级 `from relax.core.registry import process_role` 绑定的是旧实例；
- 测试函数内 `from relax.core.registry import ROLES_COLOCATE` 拿到的是新实例；
- 旧实例的 `process_role` 返回的 `ROLES_COLOCATE` 与新实例做 `is` 比较必然失败。

因此 `test_registry_sft.py` 的两个测试在全量测试运行时受执行顺序影响而失败（单独运行不受影响）；该问题在纯 main 上同样可复现，与任何 PR 的改动无关。

## What

修复 `tests/core/test_registry_reinforce_plus_plus.py` 中 `registry_module` fixture 的测试隔离问题。该 fixture 在 teardown 中弹出 `sys.modules["relax.core.registry"]` 后未恢复原始模块，导致同一 pytest 进程内的后续测试重新导入得到新的模块实例，最终使依赖 `is` 比较的断言失败。

## Why

- #202 新增的该 fixture 是问题源头，纯 main 上即可复现，与任何特定 PR 的改动无关。
- 在全量测试运行时，`test_registry_sft.py` 的两个测试（以及 #205 将新增的 `test_registry_rloo.py`）会因模块实例不一致而失败；单独运行或分文件运行则不受影响。
- 这是测试间状态泄漏，属于测试基础设施缺陷，需要从 fixture 侧修复。

## How

在 fixture 中先保存 `sys.modules` 中原有的 `relax.core.registry` 引用，teardown 弹出测试期模块后，若存在原始引用则恢复之。这样后续测试始终拿到同一个模块实例，`process_role` 返回的 `ROLES_COLOCATE` 与测试内导入的枚举保持同一对象。

## Testing

- `pytest tests/core/`：全部通过（此前 3 个失败消除）
- `pytest tests/core/test_registry_reinforce_plus_plus.py tests/core/test_registry_sft.py`：此前失败的组合全部通过
- `pre-commit run --all-files`：全部通过

- [x] `pre-commit run --all-files` passes
- [x] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] CI/CD or build changes
