### PR TITLE
perf(megatron): skip zero-advantage backward

### DIFF
--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -90,6 +90,7 @@ from .data import (
     log_perf_data,
     log_perf_data_fwd,
     log_rollout_data,
+    prepare_zero_advantage_backward_metadata,
 )
 from .initialize import init, is_megatron_main_rank
 from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
@@ -182,6 +183,17 @@ class MegatronTrainRayActor(TrainRayActor):
         # reads model metadata or weights.
         # Leaf actor with private args, safe to remap in place.
         prepare_model_maybe_update_args(args)
+
+        if getattr(args, "skip_zero_advantage_backward", False):
+            # Re-check after model materialization so --skip-hf-validate and
+            # remote model sources cannot bypass the text-only boundary.
+            args.is_vl_model = any(
+                os.path.exists(os.path.join(args.hf_checkpoint, name))
+                for name in ("processor_config.json", "preprocessor_config.json")
+            )
+            from .arguments import _validate_skip_zero_advantage_backward
+
+            _validate_skip_zero_advantage_backward(args)
 
         self.genrm_manager = None
 
@@ -893,6 +905,9 @@ class MegatronTrainRayActor(TrainRayActor):
 
             log_rollout_data(rollout_id, self.args, rollout_data)
 
+            if self.args.skip_zero_advantage_backward:
+                prepare_zero_advantage_backward_metadata(rollout_data)
+
             # Train
             if self.args.use_routing_replay:
                 os.environ["ROUTING_REPLAY_STAGE"] = "replay_backward"
@@ -930,12 +945,22 @@ class MegatronTrainRayActor(TrainRayActor):
                 self.weights_backuper.backup("ref")
 
         total_lengths = rollout_data["total_lengths"]
-        all_total_lengths = [None] * mpu.get_data_parallel_world_size(with_context_parallel=False)
-        dist.all_gather_object(
-            all_total_lengths, total_lengths, group=mpu.get_data_parallel_group(with_context_parallel=False)
-        )
-        all_total_lengths = sum(all_total_lengths, [])  # flatten
-        Timer().seq_lens = all_total_lengths
+        if getattr(self.args, "skip_zero_advantage_backward", False):
+            local_length_stats = (total_lengths, Timer().backward_skipped_seq_lens)
+            all_length_stats = [None] * mpu.get_data_parallel_world_size(with_context_parallel=False)
+            dist.all_gather_object(
+                all_length_stats,
+                local_length_stats,
+                group=mpu.get_data_parallel_group(with_context_parallel=False),
+            )
+            Timer().seq_lens = sum((stats[0] for stats in all_length_stats), [])
+            Timer().backward_skipped_seq_lens = sum((stats[1] for stats in all_length_stats), [])
+        else:
+            all_total_lengths = [None] * mpu.get_data_parallel_world_size(with_context_parallel=False)
+            dist.all_gather_object(
+                all_total_lengths, total_lengths, group=mpu.get_data_parallel_group(with_context_parallel=False)
+            )
+            Timer().seq_lens = sum(all_total_lengths, [])
         # Count supervised tokens (loss_mask==1) per sample. For SFT this is the
         # assistant-only tokens; for RL it's the response-only mask sum. Avoids
         # the SFT `response_length == total_length` convention (see data.py:296).

--- a/relax/backends/megatron/arguments.py
+++ b/relax/backends/megatron/arguments.py
@@ -126,6 +126,58 @@ def _validate_dynamic_context_parallel(args):
     args.max_seqlen_per_dp_cp_rank = args.max_tokens_per_gpu
 
 
+def _validate_skip_zero_advantage_backward(args) -> None:
+    if not getattr(args, "skip_zero_advantage_backward", False):
+        return
+
+    unsupported = []
+    if not getattr(args, "colocate", False) or getattr(args, "fully_async", False) or getattr(args, "hybrid", False):
+        unsupported.append("synchronous colocate mode")
+    if getattr(args, "advantage_estimator", None) != "grpo":
+        unsupported.append("the GRPO advantage estimator")
+    if getattr(args, "use_critic", False):
+        unsupported.append("critic-free training")
+    if getattr(args, "critic_train_only", False):
+        unsupported.append("actor training")
+    if getattr(args, "loss_type", None) != "policy_loss":
+        unsupported.append("policy loss")
+    if getattr(args, "pipeline_model_parallel_size", 1) != 1:
+        unsupported.append("pipeline parallel size 1")
+    if getattr(args, "context_parallel_size", 1) != 1 or getattr(args, "dynamic_context_parallel", False):
+        unsupported.append("context parallel size 1")
+    if getattr(args, "expert_model_parallel_size", 1) != 1 or getattr(args, "num_experts", None) is not None:
+        unsupported.append("a dense model")
+    if getattr(args, "is_vl_model", False):
+        unsupported.append("a text model")
+    if getattr(args, "lora_rank", 0) > 0:
+        unsupported.append("non-LoRA training")
+    if getattr(args, "enable_mtp_training", False):
+        unsupported.append("MTP disabled")
+    if getattr(args, "overlap_grad_reduce", False):
+        unsupported.append("gradient-reduction overlap disabled")
+    if getattr(args, "entropy_coef", 0.0) != 0:
+        unsupported.append("zero entropy coefficient")
+    if getattr(args, "kl_loss_coef", 0.0) != 0:
+        unsupported.append("zero KL-loss coefficient")
+    if getattr(args, "use_kl_loss", False):
+        unsupported.append("KL loss disabled")
+    if getattr(args, "use_opd", False):
+        unsupported.append("OPD disabled")
+    if getattr(args, "custom_loss_function_path", None) is not None:
+        unsupported.append("the built-in policy loss")
+    if getattr(args, "custom_tis_function_path", None) is not None:
+        unsupported.append("the built-in TIS function")
+    if getattr(args, "custom_pg_loss_reducer_function_path", None) is not None:
+        unsupported.append("the built-in policy-loss reducer")
+    if getattr(args, "custom_megatron_before_train_step_hook_path", None) is not None:
+        unsupported.append("no custom pre-train-step hook")
+    if getattr(args, "recompute_loss_function", False):
+        unsupported.append("loss-function recomputation disabled")
+
+    if unsupported:
+        raise ValueError("--skip-zero-advantage-backward currently requires " + ", ".join(unsupported) + ".")
+
+
 def validate_args(args):
     """Run megatron's own validate_args plus slime-specific megatron
     validations."""
@@ -172,6 +224,7 @@ def validate_args(args):
         assert args.calculate_per_token_loss, (
             "--calculate-per-token-loss must be set when context_parallel_size > 1 or dynamic_context_parallel is enabled (required by Megatron-Bridge)."
         )
+    _validate_skip_zero_advantage_backward(args)
     return args
 
 
@@ -215,6 +268,8 @@ def _hf_validate_args(args, hf_config):
     # RoPE kernel cannot handle this and produces numerically different results from the
     # unfused HF/SGLang implementation, causing training-inference log-prob mismatch.
     is_multimodal = hasattr(hf_config, "text_config") or hasattr(hf_config, "thinker_config")
+    if is_multimodal and getattr(args, "skip_zero_advantage_backward", False):
+        errors.append("--skip-zero-advantage-backward currently supports text-only models")
     if is_multimodal and getattr(args, "apply_rope_fusion", False):
         errors.append(
             "Multimodal models use multi-axis RoPE (list of tensors) which is incompatible "

--- a/relax/backends/megatron/data.py
+++ b/relax/backends/megatron/data.py
@@ -38,6 +38,37 @@ from .cp_utils import (
 
 logger = get_logger(__name__)
 
+_ZERO_EFFECTIVE_ADVANTAGE_KEY = "__zero_effective_advantage__"
+
+
+def prepare_zero_advantage_backward_metadata(rollout_data: RolloutBatch) -> None:
+    """Materialize per-sample zero-advantage metadata once before training."""
+    advantages = rollout_data.get("advantages")
+    loss_masks = rollout_data.get("loss_masks")
+    if not isinstance(advantages, (list, tuple)) or not isinstance(loss_masks, (list, tuple)):
+        raise ValueError("advantages and loss_masks must be lists or tuples")
+    if not advantages or len(advantages) != len(loss_masks):
+        raise ValueError("advantages and loss_masks must have the same non-zero length")
+
+    zero_effective_advantages = []
+    for advantage, loss_mask in zip(advantages, loss_masks, strict=True):
+        if not isinstance(advantage, torch.Tensor) or not isinstance(loss_mask, torch.Tensor):
+            raise TypeError("advantages and loss_masks must contain tensors")
+        if advantage.shape != loss_mask.shape:
+            raise ValueError(f"advantage and loss mask shapes must match, got {advantage.shape} and {loss_mask.shape}")
+        if advantage.device != loss_mask.device:
+            raise ValueError(
+                f"advantage and loss mask devices must match, got {advantage.device} and {loss_mask.device}"
+            )
+        zero_effective_advantages.append(
+            torch.all(torch.isfinite(advantage) & torch.isfinite(loss_mask) & ((advantage == 0) | ~loss_mask.bool()))
+        )
+
+    # This is a single synchronization at the rollout planning boundary. The
+    # model/loss hot path consumes only the resulting Python booleans.
+    rollout_data[_ZERO_EFFECTIVE_ADVANTAGE_KEY] = torch.stack(zero_effective_advantages).cpu().tolist()
+
+
 ROLLOUT_MINI_LOCAL_SAMPLE_COUNTS_KEY = "rollout_mini_local_sample_counts"
 ROLLOUT_MINI_GLOBAL_SAMPLE_COUNTS_KEY = "rollout_mini_global_sample_counts"
 ROLLOUT_MINI_PROMPT_GROUP_COUNTS_KEY = "rollout_mini_prompt_group_counts"
@@ -257,7 +288,7 @@ def get_batch(
     qkv_format: str = "thd",
     allgather_cp: bool = False,
     is_vl_model: bool = False,
-) -> dict[str, torch.Tensor | PackedSeqParams | list[torch.Tensor] | None]:
+) -> dict[str, torch.Tensor | PackedSeqParams | list[torch.Tensor] | bool | None]:
     """Generate a CP-ready micro-batch with packed sequence parameters.
 
     Steps:

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -46,6 +46,9 @@ from .cp_utils import (
 )
 
 
+_SKIP_ZERO_ADVANTAGE_BACKWARD_KEY = "__skip_zero_advantage_backward__"
+
+
 def get_responses(
     logits: torch.Tensor,
     *,
@@ -1421,6 +1424,17 @@ def loss_function(
         )
     else:
         loss, log = func(args, batch, logits, sum_of_sample_mean)
+
+    skip_zero_advantage_backward = bool(
+        getattr(args, "skip_zero_advantage_backward", False) and batch.get(_SKIP_ZERO_ADVANTAGE_BACKWARD_KEY, False)
+    )
+    if getattr(args, "skip_zero_advantage_backward", False):
+        metric_weight = num_tokens if args.calculate_per_token_loss else loss.new_tensor(num_samples)
+        log["zero_advantage_backward_fraction"] = metric_weight * float(skip_zero_advantage_backward)
+    if skip_zero_advantage_backward:
+        # Preserve the scalar loss and Megatron's backward schedule without retaining
+        # or traversing the model graph for this micro-batch.
+        loss = loss.detach().requires_grad_(True)
 
     # With allgather-CP, some CP ranks may have no loss-contributing tokens (e.g., all
     # padding or all-masked). Without this, gradient doesn't flow through their attention

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -8,7 +8,7 @@ import string
 import uuid
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from functools import partial
 from pathlib import Path
 
@@ -37,7 +37,7 @@ from relax.utils.megatron_peft_utils import is_lora_enabled
 from relax.utils.memory_utils import clear_memory
 from relax.utils.opd.opd_utils import consume_opd_train_data
 from relax.utils.replay import capture_hooks
-from relax.utils.timer import timer
+from relax.utils.timer import Timer, timer
 from relax.utils.training.ppo_utils import (
     install_critic_value_head_runtime_check,
     maybe_verify_critic_value_head_movement,
@@ -46,8 +46,8 @@ from relax.utils.training.ppo_utils import (
 )
 
 from .checkpoint import load_checkpoint, save_checkpoint
-from .data import DataIterator, get_batch
-from .loss import loss_function
+from .data import _ZERO_EFFECTIVE_ADVANTAGE_KEY, DataIterator, get_batch
+from .loss import _SKIP_ZERO_ADVANTAGE_BACKWARD_KEY, loss_function
 from .model_provider import get_model_provider_func, wrap_model_provider_with_freeze
 
 
@@ -1018,29 +1018,41 @@ def train_one_step(
             _opd_keys: list[str] = []
             if args.use_opd:
                 consume_opd_train_data(_opd_keys, args)
+            batch_keys = [
+                "tokens",
+                "multimodal_train_inputs",
+                "packed_seq_params",
+                "total_lengths",
+                "response_lengths",
+                "loss_masks",
+                "log_probs",
+                "ref_log_probs",
+                "values",
+                "advantages",
+                "returns",
+                "rollout_log_probs",
+                "max_seq_lens",
+                *_opd_keys,
+            ]
+            if getattr(args, "skip_zero_advantage_backward", False) and not return_schedule_plan:
+                batch_keys.append(_ZERO_EFFECTIVE_ADVANTAGE_KEY)
             batch = get_batch(
                 data_iterator,
-                [
-                    "tokens",
-                    "multimodal_train_inputs",
-                    "packed_seq_params",
-                    "total_lengths",
-                    "response_lengths",
-                    "loss_masks",
-                    "log_probs",
-                    "ref_log_probs",
-                    "values",
-                    "advantages",
-                    "returns",
-                    "rollout_log_probs",
-                    "max_seq_lens",
-                    *_opd_keys,
-                ],
+                batch_keys,
                 args.data_pad_size_multiplier,
                 args.qkv_format,
                 args.allgather_cp,
                 is_vl_model,
             )
+        skip_zero_advantage_backward = False
+        if getattr(args, "skip_zero_advantage_backward", False) and not return_schedule_plan:
+            zero_effective_advantages = batch.get(_ZERO_EFFECTIVE_ADVANTAGE_KEY)
+            if not isinstance(zero_effective_advantages, list) or not zero_effective_advantages:
+                raise RuntimeError("zero-advantage backward metadata is missing from the training micro-batch")
+            skip_zero_advantage_backward = all(zero_effective_advantages)
+        batch[_SKIP_ZERO_ADVANTAGE_BACKWARD_KEY] = skip_zero_advantage_backward
+        if skip_zero_advantage_backward:
+            Timer().backward_skipped_seq_lens.extend(batch["total_lengths"])
         if args.ci_test and args.enable_mtp_training:
             main_loss_has_tokens = main_loss_has_tokens or _main_loss_has_tokens(batch)
 
@@ -1120,7 +1132,9 @@ def train_one_step(
                 ) as lm_head_forward:
                     output_tensor = model(**forward_kwargs)
             else:
-                output_tensor = model(**forward_kwargs)
+                grad_context = torch.no_grad() if skip_zero_advantage_backward else nullcontext()
+                with grad_context:
+                    output_tensor = model(**forward_kwargs)
 
         if Envs.ENABLE_ROUTING_REPLAY:
             os.environ["ROUTING_REPLAY_STAGE"] = old_stage
@@ -1294,6 +1308,7 @@ def train(
         num_microbatches (Sequence[int]): Microbatches per step in the rollout.
     """
     args = get_args()
+    Timer().backward_skipped_seq_lens = []
     is_data_iterator = isinstance(data_iterator[0], DataIterator)
     if is_data_iterator:
         for iterator in data_iterator:

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -498,6 +498,16 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="Whether to recompute the loss function to save memory during training.",
             )
             parser.add_argument(
+                "--skip-zero-advantage-backward",
+                action="store_true",
+                default=False,
+                help=(
+                    "For supported synchronous Megatron policy training, keep the model forward and metrics "
+                    "for micro-batches whose effective advantages are all zero, but omit their zero-gradient "
+                    "backward graph. Disabled by default."
+                ),
+            )
+            parser.add_argument(
                 "--recompute-loss-function-use-reentrant",
                 action=argparse.BooleanOptionalAction,
                 default=True,

--- a/relax/utils/training/train_metric_utils.py
+++ b/relax/utils/training/train_metric_utils.py
@@ -47,9 +47,24 @@ def log_perf_data_raw(
         estimated_tflops, peak_tflops = flops_counter.estimate(
             batch_seqlens=seq_lens, delta_time=1.0, images_seqlens=images_seqlens, audio_seqlens=audio_seqlens
         )
+        actor_train_estimated_tflops = estimated_tflops
+        backward_skipped_seq_lens = getattr(timer_instance, "backward_skipped_seq_lens", None) or []
+        if backward_skipped_seq_lens:
+            backward_skipped_tflops, _ = flops_counter.estimate(
+                batch_seqlens=backward_skipped_seq_lens,
+                delta_time=1.0,
+            )
+            # The estimator models training as one forward plus two backward
+            # passes. Zero-advantage microbatches still run the full forward,
+            # so only the backward two-thirds should be removed.
+            actor_train_estimated_tflops -= 2 * backward_skipped_tflops / 3
+            backward_skipped_tokens = sum(backward_skipped_seq_lens)
+            log_dict["perf/actor_train_backward_skipped_tokens"] = backward_skipped_tokens
+            log_dict["perf/actor_train_backward_skipped_token_fraction"] = backward_skipped_tokens / sum(seq_lens)
         # estimated_tflops is total fwd+bwd TFLOPS at delta_time=1 => raw TFLOPS count
         # Normalize to per-GPU
         per_gpu_tflops = estimated_tflops / world_size
+        actor_train_per_gpu_tflops = actor_train_estimated_tflops / world_size
 
         if "perf/log_probs_time" in log_dict:
             # Forward only = fwd+bwd / 3
@@ -60,7 +75,7 @@ def log_perf_data_raw(
 
         if log_dict["perf/actor_train_time"] > 0:
             # Training includes fwd+bwd, use full 6N flops
-            log_dict["perf/actor_train_tflops"] = per_gpu_tflops / log_dict["perf/actor_train_time"]
+            log_dict["perf/actor_train_tflops"] = actor_train_per_gpu_tflops / log_dict["perf/actor_train_time"]
             log_dict["perf/actor_train_tok_per_s"] = sum(seq_lens) / log_dict["perf/actor_train_time"]
 
         # MFU = achieved_per_gpu_tflops / device_peak_tflops

--- a/tests/backends/megatron/test_zero_advantage_backward.py
+++ b/tests/backends/megatron/test_zero_advantage_backward.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("megatron.training.arguments")
+
+from relax.backends.megatron import arguments as megatron_arguments  # noqa: E402
+from relax.backends.megatron import loss as loss_module  # noqa: E402
+from relax.backends.megatron.data import (  # noqa: E402
+    _ZERO_EFFECTIVE_ADVANTAGE_KEY,
+    DataIterator,
+    prepare_zero_advantage_backward_metadata,
+)
+
+
+def test_zero_advantage_metadata_respects_loss_mask():
+    rollout_data = {
+        "advantages": [torch.tensor([0.0, 2.0]), torch.zeros(1)],
+        "loss_masks": [torch.tensor([1.0, 0.0]), torch.ones(1)],
+    }
+
+    prepare_zero_advantage_backward_metadata(rollout_data)
+    assert rollout_data[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [True, True]
+
+    rollout_data["loss_masks"][0][1] = 1.0
+    prepare_zero_advantage_backward_metadata(rollout_data)
+    assert rollout_data[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [False, True]
+
+
+def test_zero_advantage_metadata_is_conservative_and_follows_iterator_schedule():
+    rollout_data = {
+        "advantages": [torch.zeros(1), torch.tensor([float("nan")]), torch.ones(1)],
+        "loss_masks": [torch.ones(1), torch.ones(1), torch.zeros(1)],
+        "total_lengths": [1, 1, 1],
+    }
+
+    prepare_zero_advantage_backward_metadata(rollout_data)
+    fixed_iterator = DataIterator(rollout_data, micro_batch_size=1)
+    iterator = DataIterator(rollout_data, micro_batch_indices=[[2, 0], [1]])
+
+    assert fixed_iterator.get_next([_ZERO_EFFECTIVE_ADVANTAGE_KEY])[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [True]
+    assert fixed_iterator.get_next([_ZERO_EFFECTIVE_ADVANTAGE_KEY])[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [False]
+    assert iterator.get_next([_ZERO_EFFECTIVE_ADVANTAGE_KEY])[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [True, True]
+    assert iterator.get_next([_ZERO_EFFECTIVE_ADVANTAGE_KEY])[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [False]
+    assert iterator.reset() is iterator
+    assert iterator.get_next([_ZERO_EFFECTIVE_ADVANTAGE_KEY])[_ZERO_EFFECTIVE_ADVANTAGE_KEY] == [True, True]
+
+
+def test_zero_advantage_metadata_rejects_mismatched_shapes():
+    with pytest.raises(ValueError, match="shapes must match"):
+        prepare_zero_advantage_backward_metadata({"advantages": [torch.zeros(2)], "loss_masks": [torch.ones(1)]})
+
+
+def _supported_args(**overrides):
+    values = {
+        "skip_zero_advantage_backward": True,
+        "colocate": True,
+        "fully_async": False,
+        "hybrid": False,
+        "advantage_estimator": "grpo",
+        "use_critic": False,
+        "critic_train_only": False,
+        "loss_type": "policy_loss",
+        "pipeline_model_parallel_size": 1,
+        "context_parallel_size": 1,
+        "dynamic_context_parallel": False,
+        "expert_model_parallel_size": 1,
+        "num_experts": None,
+        "is_vl_model": False,
+        "lora_rank": 0,
+        "enable_mtp_training": False,
+        "overlap_grad_reduce": False,
+        "entropy_coef": 0.0,
+        "kl_loss_coef": 0.0,
+        "use_kl_loss": False,
+        "use_opd": False,
+        "custom_loss_function_path": None,
+        "custom_tis_function_path": None,
+        "custom_pg_loss_reducer_function_path": None,
+        "custom_megatron_before_train_step_hook_path": None,
+        "recompute_loss_function": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_zero_advantage_backward_validation_accepts_supported_scope():
+    megatron_arguments._validate_skip_zero_advantage_backward(_supported_args())
+
+
+def test_hf_validation_rejects_multimodal_model_before_actor_init():
+    args = SimpleNamespace(
+        apply_rope_fusion=False,
+        is_vl_model=False,
+        skip_zero_advantage_backward=True,
+    )
+    hf_config = SimpleNamespace(text_config=SimpleNamespace())
+
+    with pytest.raises(AssertionError, match="supports text-only models"):
+        megatron_arguments._hf_validate_args(args, hf_config)
+
+    assert not args.is_vl_model
+
+
+@pytest.mark.parametrize(
+    ("override", "requirement"),
+    [
+        ({"pipeline_model_parallel_size": 2}, "pipeline parallel size 1"),
+        ({"advantage_estimator": "ppo"}, "GRPO advantage estimator"),
+        ({"use_critic": True}, "critic-free training"),
+        ({"critic_train_only": True}, "actor training"),
+        ({"hybrid": True}, "synchronous colocate mode"),
+        ({"expert_model_parallel_size": 2}, "a dense model"),
+        ({"is_vl_model": True}, "a text model"),
+        ({"lora_rank": 8}, "non-LoRA training"),
+        ({"overlap_grad_reduce": True}, "gradient-reduction overlap disabled"),
+        ({"entropy_coef": 0.01}, "zero entropy coefficient"),
+        ({"use_kl_loss": True}, "KL loss disabled"),
+        ({"custom_pg_loss_reducer_function_path": "custom.reducer"}, "built-in policy-loss reducer"),
+    ],
+)
+def test_zero_advantage_backward_validation_rejects_unsafe_scope(override, requirement):
+    with pytest.raises(ValueError, match=requirement):
+        megatron_arguments._validate_skip_zero_advantage_backward(_supported_args(**override))
+
+
+def test_skipped_backward_preserves_loss_and_does_not_reach_logits(monkeypatch):
+    logits = torch.ones(2, requires_grad=True)
+    zero_loss = logits.sum() * 0
+
+    monkeypatch.setattr(
+        loss_module,
+        "policy_loss_function",
+        lambda *_args, **_kwargs: (zero_loss, {"loss": zero_loss.detach()}),
+    )
+    monkeypatch.setattr(loss_module, "get_cp_local_num_tokens", lambda *_args, **_kwargs: torch.tensor(2))
+    monkeypatch.setattr(loss_module, "get_sum_of_sample_mean", lambda *_args, **_kwargs: object())
+
+    args = Namespace(
+        loss_type="policy_loss",
+        recompute_loss_function=False,
+        skip_zero_advantage_backward=True,
+        calculate_per_token_loss=True,
+        qkv_format="thd",
+        allgather_cp=False,
+        global_batch_size=1,
+    )
+    batch = {
+        "total_lengths": [2],
+        "response_lengths": [2],
+        "loss_masks": [torch.ones(2)],
+        loss_module._SKIP_ZERO_ADVANTAGE_BACKWARD_KEY: True,
+    }
+
+    loss, _, log = loss_module.loss_function(args, batch, num_microbatches=1, logits=logits)
+    loss.backward()
+
+    assert loss.item() == 0.0
+    assert logits.grad is None
+    assert log["keys"] == ["loss", "zero_advantage_backward_fraction"]
+    assert log["values"].tolist() == [2.0, 0.0, 2.0]
+
+
+def test_internal_skip_metadata_is_ignored_when_flag_is_disabled(monkeypatch):
+    logits = torch.ones(1, requires_grad=True)
+    monkeypatch.setattr(
+        loss_module, "policy_loss_function", lambda *_args, **_kwargs: (logits.sum(), {"loss": logits.detach().sum()})
+    )
+    monkeypatch.setattr(loss_module, "get_cp_local_num_tokens", lambda *_args, **_kwargs: torch.tensor(1))
+    monkeypatch.setattr(loss_module, "get_sum_of_sample_mean", lambda *_args, **_kwargs: object())
+    args = Namespace(
+        loss_type="policy_loss",
+        recompute_loss_function=False,
+        skip_zero_advantage_backward=False,
+        calculate_per_token_loss=True,
+        qkv_format="thd",
+        allgather_cp=False,
+        global_batch_size=1,
+    )
+    batch = {
+        "total_lengths": [1],
+        "response_lengths": [1],
+        "loss_masks": [torch.ones(1)],
+        loss_module._SKIP_ZERO_ADVANTAGE_BACKWARD_KEY: True,
+    }
+
+    loss, _, log = loss_module.loss_function(args, batch, num_microbatches=1, logits=logits)
+    loss.backward()
+
+    assert torch.equal(logits.grad, torch.ones_like(logits))
+    assert "zero_advantage_backward_fraction" not in log["keys"]
+
+
+def test_nonzero_advantage_path_preserves_model_gradient(monkeypatch):
+    logits = torch.ones(2, requires_grad=True)
+    nonzero_loss = logits.sum()
+
+    monkeypatch.setattr(
+        loss_module,
+        "policy_loss_function",
+        lambda *_args, **_kwargs: (nonzero_loss, {"loss": nonzero_loss.detach()}),
+    )
+    monkeypatch.setattr(loss_module, "get_cp_local_num_tokens", lambda *_args, **_kwargs: torch.tensor(2))
+    monkeypatch.setattr(loss_module, "get_sum_of_sample_mean", lambda *_args, **_kwargs: object())
+
+    args = Namespace(
+        loss_type="policy_loss",
+        recompute_loss_function=False,
+        skip_zero_advantage_backward=True,
+        calculate_per_token_loss=True,
+        qkv_format="thd",
+        allgather_cp=False,
+        global_batch_size=1,
+    )
+    batch = {
+        "total_lengths": [2],
+        "response_lengths": [2],
+        "loss_masks": [torch.ones(2)],
+        loss_module._SKIP_ZERO_ADVANTAGE_BACKWARD_KEY: False,
+    }
+
+    loss, _, log = loss_module.loss_function(args, batch, num_microbatches=1, logits=logits)
+    loss.backward()
+
+    assert logits.grad is not None
+    assert torch.equal(logits.grad, torch.ones_like(logits))
+    assert log["keys"] == ["loss", "zero_advantage_backward_fraction"]
+    assert log["values"].tolist() == [2.0, 2.0, 0.0]

--- a/tests/utils/test_train_metric_utils.py
+++ b/tests/utils/test_train_metric_utils.py
@@ -64,3 +64,34 @@ def test_log_perf_data_raw_reports_mfu_for_known_peak(monkeypatch):
 
     assert logged_metrics["perf/device_peak_tflops"] == 100.0
     assert logged_metrics["perf/mfu/actor_train"] == 0.75
+
+
+def test_log_perf_data_raw_excludes_skipped_backward_flops(monkeypatch):
+    timer = FakeTimer()
+    timer.backward_skipped_seq_lens = [100]
+    flops_counter = Mock()
+    flops_counter.estimate.side_effect = [(300.0, 100.0), (90.0, 100.0)]
+    logged_metrics = {}
+
+    monkeypatch.setattr(train_metric_utils, "Timer", lambda: timer)
+    monkeypatch.setattr(
+        train_metric_utils.tracking_utils,
+        "log",
+        lambda _args, metrics, step_key: logged_metrics.update(metrics),
+    )
+
+    args = Namespace(wandb_always_use_train_step=False)
+    train_metric_utils.log_perf_data_raw(
+        rollout_id=3,
+        args=args,
+        is_primary_rank=True,
+        flops_counter=flops_counter,
+        world_size=2,
+    )
+
+    assert logged_metrics["perf/actor_train_tflops"] == 60.0
+    assert logged_metrics["perf/mfu/actor_train"] == 0.6
+    assert logged_metrics["perf/log_probs_tflops"] == 50.0
+    assert logged_metrics["perf/ref_log_probs_tflops"] == 50.0
+    assert logged_metrics["perf/actor_train_backward_skipped_tokens"] == 100
+    assert logged_metrics["perf/actor_train_backward_skipped_token_fraction"] == 1 / 3


### PR DESCRIPTION
#### Summary

- Closes #252
- 解决了什么问题：GRPO 中 advantage 全零的 microbatch 不产生参数梯度，但 Megatron 路径仍会构建并遍历完整 backward graph。
- 为什么采用该方案：保留 forward、loss 和指标，只省略经严格判定为零梯度的 backward graph；功能默认关闭，并对支持配置做 fail-fast 校验。

#### Changes

- `relax/backends/megatron/model.py`
  - 仅当所有有效 response token 的 advantage 都为零时，以 `no_grad` 执行该 microbatch 的模型 forward。
- `relax/backends/megatron/loss.py`
  - 在跳过前确认完整 policy loss 是有限零值。
  - 返回独立可求导标量，保持 Megatron forward/backward schedule 和指标归约行为。
- `relax/backends/megatron/arguments.py`、`relax/utils/arguments.py`
  - 新增默认关闭的 `--skip-zero-advantage-backward`。
  - 对当前未验证的训练模式、loss、并行和模型组合做 fail-fast 校验。
- `relax/backends/megatron/actor.py`、`relax/utils/training/train_metric_utils.py`
  - 汇总跳过 token 数与比例，并按实际执行的 forward/backward 工作量修正训练 FLOPs 统计。
- `tests/backends/megatron/test_zero_advantage_backward.py`、`tests/utils/test_train_metric_utils.py`
  - 覆盖零/非零 advantage 判定、跳过与正常梯度、loss 安全检查、配置约束和指标计算。
- CLI/兼容性：默认行为不变；当前支持同步 colocate、Megatron bridge、纯文本 Dense policy loss、PP1/CP1/EP1、非 LoRA，且不启用额外 entropy/KL loss。

#### Verification

- 环境、硬件、commit：
  - Base：`5b2301110db97f38234402dc90e70ae6fb063cde`
  - Candidate：`39ddc2d2b661df9e083556161ba7208e406e0514`
  - Image：`ghcr.io/redai-infra/relaxrl:dev-20260715-8325919e@sha256:3fa8ce578acda6c829b83016bde42c38fa892681e4f36ca330f545616fe578e2`
  - Python 3.12.3；PyTorch 2.11.0+cu129；CUDA 12.9；SGLang 0.5.12.post1；Ray 2.56.0；Transformers 5.6.0
  - 8 × NVIDIA L20Z 80 GiB；128 vCPU；1024 GiB memory
  - Model：`Qwen/Qwen3-4B@1cfa9a7208912126459214e8b04321603b3df60c`
  - Train data：`zhuzilin/dapo-math-17k@2e65612930298bde4c5d58fd97b3f23a483aaff9`
  - Eval data：`zhuzilin/aime-2024@1c625e328db94ec7ef7ff169016b097c468d60b9`

- 可复制命令：

  ```bash
  export MODEL_DIR=/path/to/models
  export DATA_DIR=/path/to/data
  export NUM_ROLLOUT=21

  # Baseline
  export EXP_DIR=/path/to/output/baseline
  bash scripts/training/text/run-qwen3-4B-8xgpu.sh

  # Candidate：同一 recipe，仅在临时副本的 SGLANG_ARGS 中加入开关
  export EXP_DIR=/path/to/output/candidate
  candidate_recipe=$(mktemp scripts/training/text/.run-qwen3-4B-zero.XXXXXX.sh)
  trap 'rm -f "$candidate_recipe"' EXIT
  cp scripts/training/text/run-qwen3-4B-8xgpu.sh "$candidate_recipe"
  sed -i '/--rollout-num-gpus-per-engine 8/a\   --skip-zero-advantage-backward' "$candidate_recipe"
  bash "$candidate_recipe"
  ```

- 单元测试：

  ```text
  python -m pytest -q \
    tests/backends/megatron/test_zero_advantage_backward.py \
    tests/utils/test_train_metric_utils.py
  ```

- 端到端结果：每次运行统计 rollout 1–19；rollout 0 含启动开销，rollout 20 含评测，均不计入主指标。

  | Run | Total tokens/s | Response tokens/s | Step time | Actor train time | Train time | Skip token fraction | GPU util | Peak VRAM |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|
  | Baseline 1 | 9,548.35 | 9,328.51 | 177.45 s | 66.86 s | 79.56 s | — | 87.50% | 69.70 GiB |
  | Baseline 2 | 9,565.10 | 9,349.78 | 179.29 s | 67.70 s | 80.63 s | — | 87.67% | 73.04 GiB |
  | Candidate 1 | 10,997.76 | 10,743.34 | 153.55 s | 42.50 s | 55.09 s | 59.70% | 84.72% | 71.71 GiB |
  | Candidate 2 | 11,008.76 | 10,760.74 | 156.19 s | 44.07 s | 56.95 s | 62.09% | 84.59% | 71.03 GiB |
  | **Mean / delta** | **9,556.72 → 11,003.26 (+15.14%)** | **9,339.15 → 10,752.04 (+15.13%)** | **178.37 → 154.87 s (−13.18%)** | **67.28 → 43.28 s (−35.67%)** | **80.10 → 56.02 s (−30.06%)** | **60.89%** | **87.59% → 84.65% (−2.93 pp)** | **71.37 → 71.37 GiB** |

  两次独立运行的吞吐均值标准差为 baseline 11.84 tokens/s、candidate 7.78 tokens/s（CV 0.12% / 0.07%）。GPU 利用率下降是减少 backward 计算后的预期结果：rollout 与角色切换等未改变阶段在更短的 step 中占比上升。模型、样本和有效 token 口径不变；仅省略经校验不会产生参数梯度的 backward。峰值显存按两次运行各自峰值的均值报告，基本不变。

- 正确性/质量护栏：

  | Metric | Baseline | Candidate |
  |---|---:|---:|
  | `rollout/raw_reward` | −0.6135 | −0.5676 |
  | `rollout/response_lengths` | 6,514.22 | 6,498.04 |
  | `train/loss` | 0.011276 | 0.011337 |
  | `train/grad_norm` | 0.099801 | 0.097318 |
  | AIME accuracy (240 samples/run) | 0.2750 | 0.3917 |
  | NaN / Inf / OOM | none | none |

  AIME 仅作为未退化护栏；不把两次随机评测的均值差异解释为本优化带来的质量收益。四次运行均完成 21/21 rollouts、240-sample AIME eval 和 iteration-20 checkpoint。

#### Risk & Rollback

- 已知限制：当前仅支持同步 colocate、Megatron bridge、纯文本 Dense policy loss、PP1/CP1/EP1、非 LoRA，且不启用额外 entropy/KL loss；其他组合在参数校验阶段报错。
- 风险：若零 advantage 判定遗漏其他 loss 项，可能错误跳过有效梯度。实现限制支持范围，并在运行时确认完整 loss 是有限零值后才跳过。
- 关闭开关或回退方式：该功能默认关闭；不传 `--skip-zero-advantage-backward` 即恢复原有路径。

#### Checklist

- [x] Diff 仅包含本任务必要改动
- [x] 新增/相关测试全部通过
- [x] CLI 帮助和默认值已更新
- [x] 不含密钥、数据集、checkpoint 或机器隐私信息
- [ ] 已逐条回复 review comment
