### PR TITLE
fix(lora): write exported adapters in PEFT's key layout

### DIFF
--- a/relax/utils/megatron_peft_utils.py
+++ b/relax/utils/megatron_peft_utils.py
@@ -134,6 +134,27 @@ def build_hf_peft_config_dict(
     }
 
 
+# PEFT wraps the base model as ``base_model.model``, so every key in a standard
+# ``adapter_model.safetensors`` carries that prefix. Bridge's adapter export yields bare
+# HF parameter names, which PEFT then cannot match: ``PeftModel.from_pretrained`` reports
+# the keys as missing (a warning, not an error) and leaves every ``lora_B`` at zero, i.e.
+# it silently loads an adapter that does nothing.
+PEFT_STATE_DICT_PREFIX = "base_model.model."
+
+
+def to_peft_state_dict(adapter_weights: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Return ``adapter_weights`` keyed the way standard PEFT writes them.
+
+    Idempotent: keys that already carry the prefix are left alone, so callers that
+    hand over an exporter's output and callers that hand over an existing PEFT state
+    dict both get the same result.
+    """
+    return {
+        name if name.startswith(PEFT_STATE_DICT_PREFIX) else PEFT_STATE_DICT_PREFIX + name: tensor
+        for name, tensor in adapter_weights.items()
+    }
+
+
 def write_hf_peft_adapter(
     merged: dict[str, torch.Tensor],
     adapter_dir,
@@ -147,10 +168,12 @@ def write_hf_peft_adapter(
 
     Produces ``adapter_config.json`` + ``adapter_model.safetensors`` — the on-disk
     format used by the checkpoint save, which Megatron-Bridge's ``load_peft_adapter``
-    can read back.
+    can read back. Keys are normalized to PEFT's ``base_model.model.`` layout so the
+    directory also loads with ``peft.PeftModel.from_pretrained``.
 
     Args:
-        merged: Full (TP-gathered, PP-merged) adapter tensors keyed by HF name.
+        merged: Full (TP-gathered, PP-merged) adapter tensors keyed by HF name, with
+            or without the PEFT prefix (see ``to_peft_state_dict``).
         adapter_dir: Target directory (created if missing).
         lora_rank/lora_alpha/target_modules/lora_dropout: PEFT config written to
             ``adapter_config.json`` (HF-style target module names).
@@ -177,7 +200,7 @@ def write_hf_peft_adapter(
         json.dump(config_dict, f)
 
     # safetensors requires contiguous CPU tensors.
-    state = {name: t.contiguous() for name, t in merged.items()}
+    state = {name: t.contiguous() for name, t in to_peft_state_dict(merged).items()}
     save_file(state, str(adapter_dir / "adapter_model.safetensors"))
     return str(adapter_dir)
 
@@ -302,6 +325,8 @@ __all__ = [
     "count_adapter_parameters",
     "convert_megatron_to_hf_target_modules",
     "MEGATRON_TO_HF_MODULES",
+    "PEFT_STATE_DICT_PREFIX",
+    "to_peft_state_dict",
     "write_hf_peft_adapter",
     "extract_lora_delta",
     "is_lora_enabled",

--- a/tests/utils/test_megatron_peft_utils.py
+++ b/tests/utils/test_megatron_peft_utils.py
@@ -29,6 +29,7 @@ from relax.utils.megatron_peft_utils import (
     is_lora_adapter_param,
     is_lora_enabled,
     is_lora_merge_mode,
+    to_peft_state_dict,
     write_hf_peft_adapter,
 )
 
@@ -144,6 +145,61 @@ class TestWriteHfPeftAdapter:
             lora_dropout=0.0,
         )
         assert (target / "adapter_config.json").is_file()
+
+    def test_write_hf_peft_adapter_adds_peft_prefix(self, tmp_path):
+        """Bare exporter names are written in PEFT's layout.
+
+        ``AutoBridge.export_adapter_weights`` yields bare HF parameter names.
+        Written as-is, ``peft.PeftModel.from_pretrained`` matches none of them:
+        it warns about missing adapter keys and leaves every ``lora_B`` at
+        zero, so the adapter loads as a no-op instead of failing.
+        """
+        from safetensors.torch import load_file
+
+        merged = {
+            "model.layers.0.self_attn.q_proj.lora_A.weight": torch.randn(8, 16),
+            "model.layers.0.self_attn.q_proj.lora_B.weight": torch.randn(16, 8),
+        }
+        adapter_dir = tmp_path / "lora_adapter"
+        write_hf_peft_adapter(
+            merged,
+            adapter_dir,
+            lora_rank=8,
+            lora_alpha=16,
+            target_modules=["q_proj"],
+            lora_dropout=0.0,
+        )
+
+        loaded = load_file(str(adapter_dir / "adapter_model.safetensors"))
+        assert set(loaded) == {
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight",
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight",
+        }
+        for name, tensor in merged.items():
+            assert torch.allclose(loaded[f"base_model.model.{name}"], tensor)
+
+
+class TestToPeftStateDict:
+    def test_bare_names_get_the_prefix(self):
+        state = to_peft_state_dict({"model.layers.0.self_attn.q_proj.lora_A.weight": torch.zeros(2, 2)})
+        assert list(state) == ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"]
+
+    def test_multimodal_names_keep_their_own_prefix(self):
+        """A submodel prefix (e.g. Qwen3-Omni's ``thinker.``) is part of the
+        parameter path and stays inside the PEFT prefix."""
+        state = to_peft_state_dict({"thinker.model.layers.0.self_attn.o_proj.lora_B.weight": torch.zeros(2, 2)})
+        assert list(state) == ["base_model.model.thinker.model.layers.0.self_attn.o_proj.lora_B.weight"]
+
+    def test_already_prefixed_names_are_left_alone(self):
+        """Idempotent, so a state dict that is already in PEFT form survives a
+        second pass unchanged."""
+        name = "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"
+        assert list(to_peft_state_dict({name: torch.zeros(2, 2)})) == [name]
+
+    def test_tensors_are_passed_through_unchanged(self):
+        tensor = torch.randn(4, 4)
+        state = to_peft_state_dict({"model.layers.0.self_attn.q_proj.lora_A.weight": tensor})
+        assert next(iter(state.values())) is tensor
 
 
 class TestLoraPredicates:


### PR DESCRIPTION
## What

`write_hf_peft_adapter` now writes adapter tensors under PEFT's `base_model.model.` key layout, via a small idempotent helper (`to_peft_state_dict`). The exported directory becomes a standard PEFT adapter rather than one that only looks like it.

## Why

`_save_lora_to_checkpoint` states the contract for the directory it produces:

> This is a portable *export* artifact (HF `adapter_model.safetensors` + `adapter_config.json`) for external / inference use — e.g. loading with `peft.PeftModel.from_pretrained`. It is NOT the resume source.

The docs repeat it in `docs/{en,zh}/guide/low-rank-adaptation-training.md`. The second sentence holds; the first does not.

`AutoBridge.export_adapter_weights` yields bare HF parameter names — `model.layers.0.self_attn.q_proj.lora_A.weight`, or `thinker.model.layers...` for a multimodal base such as Qwen3-Omni — and `write_hf_peft_adapter` hands them to `save_file` unchanged. PEFT, however, writes every key under the wrapper module it inserts, so its own files read `base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight`.

The result is worse than a load error. Measured with `peft 0.20.0` / `transformers 5.6.0`, `PeftModel.from_pretrained` accepts the directory, emits a single `UserWarning: Found missing adapter keys`, and leaves every `lora_B` at zero — an adapter that loads successfully and changes nothing. A user who exports a trained adapter and evaluates it through PEFT measures the base model and has only a warning to explain the result.

The blast radius is narrow and worth stating explicitly:

| Path | Affected | Why |
| --- | --- | --- |
| Resume from checkpoint | No | LoRA params are ordinary model parameters in the native `torch_dist` checkpoint, exactly as documented |
| Adapter sync to SGLang (disk or tensor) | No | SGLang resolves adapter keys by suffix and a `layers.(\d+)` regex, so the prefix is immaterial |
| Loading the export with standard PEFT | **Yes** | Silently yields an all-zero adapter |

So the only behavior that changes is the one the artifact advertises and currently fails to deliver.

## How

Add `PEFT_STATE_DICT_PREFIX` and `to_peft_state_dict`, and apply the latter in `write_hf_peft_adapter` just before serialization.

The transform is idempotent: keys already carrying the prefix pass through untouched, so callers that hand over an exporter's output and callers that hand over an existing PEFT state dict converge on the same file. A submodel prefix such as Qwen3-Omni's `thinker.` is part of the parameter path and stays inside the PEFT prefix, matching what PEFT itself would write for that base model.

Scope was kept deliberately tight. The in-memory transport (`load_lora_adapter_from_tensors`) is untouched, since SGLang is prefix-agnostic and there is no reason to perturb the per-step sync path to fix an artifact contract. Normalizing at the single point where bytes hit disk covers both writers — the checkpoint export and the live adapter directory — without changing any caller.

## Testing

Run inside the Relax training image (`sglang 0.5.12.post1`, `megatron.bridge 0.5.0`, `torch 2.11.0+cu129`):

```
pytest tests/utils/test_megatron_peft_utils.py \
       tests/backends/megatron/weight_update/test_lora_weight_sync.py
48 passed, 5 skipped
```

Added `TestToPeftStateDict` (bare names, a multimodal `thinker.` path, idempotency, tensor identity) and a `write_hf_peft_adapter` case asserting the exact key set on disk for a bare-named export. The existing round-trip test already passes prefixed keys and still passes unchanged, which is the idempotency guarantee stated above.

`ruff format --check` and `ruff check` are clean on both touched files.

- [x] `pre-commit run --all-files` passes (ruff format + ruff check run directly, see above)
- [x] Tests pass (`pytest tests/`)
- [x] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Keys in `adapter_model.safetensors` for the same exported adapter:

```
# before
model.layers.0.self_attn.q_proj.lora_A.weight
model.layers.0.self_attn.q_proj.lora_B.weight

# after
base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight
base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight
```

Loading the "before" layout with PEFT, which is what the docstring recommends:

```
UserWarning: Found missing adapter keys while loading the checkpoint: [...]
# every lora_B stays at zero
```
