### PR TITLE
fix(lora): inline adapter tensors into the engine payload

### DIFF
--- a/relax/backends/megatron/weight_update/update_weight_from_tensor.py
+++ b/relax/backends/megatron/weight_update/update_weight_from_tensor.py
@@ -25,6 +25,7 @@ from relax.utils.megatron_peft_utils import (
     is_lora_adapter_param,
     is_lora_enabled,
     is_lora_merge_mode,
+    serialize_adapter_tensors,
 )
 
 from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
@@ -440,41 +441,32 @@ class UpdateWeightFromTensor:
 
         config_dict = self._lora_sync.config_dict()
 
-        # SGLang broadcasts this single blob to every TP worker (each slices its own shard), so the
-        # tensors must be host-shared, not CUDA-IPC handles. The default file_descriptor sharing
-        # strategy sends an fd that cannot cross the Ray -> HTTP hops to the server process; switch
-        # to file_system (self-describing /dev/shm filenames in the pickle) around the serialize.
-        from torch.multiprocessing import get_sharing_strategy, set_sharing_strategy
-
+        # The adapter is inlined into the payload rather than shared through host memory:
+        # a /dev/shm reference does not survive the Ray -> HTTP hops to the workers. See
+        # serialize_adapter_tensors for why.
         tensors = {name: t.contiguous() for name, t in full_adapter.items()}
-        prev_strategy = get_sharing_strategy()
-        set_sharing_strategy("file_system")
-        try:
-            serialized = MultiprocessingSerializer.serialize(tensors, output_str=True)
-            t3 = monotonic()
-            if not first_sync:
-                ray.get(self._ipc_engine.unload_lora_adapter.remote(LORA_ADAPTER_NAME))
-            # Keep `tensors` alive across the synchronous load: file_system storages live only while
-            # the producer holds them, and the server maps them during this call.
-            ray.get(
-                self._ipc_engine.load_lora_adapter_from_tensors.remote(
-                    lora_name=LORA_ADAPTER_NAME,
-                    serialized_tensors=serialized,
-                    config_dict=config_dict,
-                    load_format=None,
-                    pinned=False,
-                )
+        serialized = serialize_adapter_tensors(tensors)
+        t3 = monotonic()
+        if not first_sync:
+            ray.get(self._ipc_engine.unload_lora_adapter.remote(LORA_ADAPTER_NAME))
+        ray.get(
+            self._ipc_engine.load_lora_adapter_from_tensors.remote(
+                lora_name=LORA_ADAPTER_NAME,
+                serialized_tensors=serialized,
+                config_dict=config_dict,
+                load_format=None,
+                pinned=False,
             )
-            logger.info(
-                "[lora-adapter] tensor push: export=%.2fs gather=%.2fs load=%.2fs (%d tensors, rank=%d)",
-                t_export,
-                t_gather,
-                monotonic() - t3,
-                len(tensors),
-                dist.get_rank(),
-            )
-        finally:
-            set_sharing_strategy(prev_strategy)
+        )
+        logger.info(
+            "[lora-adapter] tensor push: export=%.2fs gather=%.2fs load=%.2fs (%d tensors, %.1fMB, rank=%d)",
+            t_export,
+            t_gather,
+            monotonic() - t3,
+            len(tensors),
+            len(serialized) / 1e6,
+            dist.get_rank(),
+        )
 
     def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
         all_refs = []

--- a/relax/utils/megatron_peft_utils.py
+++ b/relax/utils/megatron_peft_utils.py
@@ -3,6 +3,8 @@
 """Utilities for PEFT (Parameter-Efficient Fine-Tuning) of Megatron in
 Relax."""
 
+import base64
+import pickle
 from typing import Tuple
 
 import torch
@@ -297,6 +299,32 @@ def build_lora_peft(args):
     return create_peft(peft_config)
 
 
+def serialize_adapter_tensors(tensors: dict[str, torch.Tensor]) -> str:
+    """Serialize adapter tensors into a payload that carries its own bytes.
+
+    SGLang broadcasts one blob to every TP worker, so the adapter travels as
+    host memory rather than CUDA IPC handles. Torch's sharing strategies put
+    a reference in the pickle instead of the data, and neither reference
+    survives the Ray -> HTTP hops to the server process. ``file_descriptor``
+    sends an fd the server cannot claim. ``file_system`` sends a ``/dev/shm``
+    path whose storage is reference counted, so the workers that map it first
+    unlink it on the way out, and a straggler rank then opens a file that no
+    longer exists.
+
+    Adapters are small enough to inline: rank 16 on a 30B model is ~24MB. A
+    plain pickle carries the bytes and has no reference to resolve. SGLang
+    reads it unchanged, since ``MultiprocessingSerializer.deserialize``
+    base64-decodes and unpickles.
+
+    Args:
+        tensors: Adapter parameter name -> CPU tensor.
+
+    Returns:
+        A base64 string accepted by SGLang's tensor-load entry points.
+    """
+    return base64.b64encode(pickle.dumps(dict(tensors))).decode("utf-8")
+
+
 __all__ = [
     "LORA_ADAPTER_NAME",
     "count_adapter_parameters",
@@ -308,4 +336,5 @@ __all__ = [
     "is_lora_merge_mode",
     "is_lora_adapter_mode",
     "build_lora_peft",
+    "serialize_adapter_tensors",
 ]

--- a/tests/utils/test_megatron_peft_utils.py
+++ b/tests/utils/test_megatron_peft_utils.py
@@ -14,7 +14,9 @@ notice when broken:
 - Base<->adapter param-name prefix round-trip in the fast bridge path
 """
 
+import base64
 import json
+import pickle
 import sys
 import types
 from argparse import Namespace
@@ -29,6 +31,7 @@ from relax.utils.megatron_peft_utils import (
     is_lora_adapter_param,
     is_lora_enabled,
     is_lora_merge_mode,
+    serialize_adapter_tensors,
     write_hf_peft_adapter,
 )
 
@@ -242,3 +245,46 @@ class TestBridgeParamPrefixes:
         base = "decoder.layers.0.mlp.experts.linear_fc1"
         # Grouped experts carry a trailing weight index (weight3) that must be stripped.
         assert _base_param_prefix(f"{base}.to_wrap.weight3") == base
+
+
+class TestSerializeAdapterTensors:
+    """The adapter payload must carry its bytes, not a reference to them.
+
+    Sharing the tensors through host memory instead puts a handle in the
+    pickle, and that handle is only resolvable while the producer holds the
+    storage, which no longer holds once the payload reaches the engine workers.
+    """
+
+    @staticmethod
+    def _adapter():
+        # Large enough that a handle-only payload is unmistakably smaller.
+        return {
+            "layers.0.self_attn.q_proj.lora_A.weight": torch.randn(256, 256),
+            "layers.0.self_attn.q_proj.lora_B.weight": torch.randn(256, 256),
+        }
+
+    def test_round_trips_through_plain_unpickling(self):
+        """SGLang deserializes with base64 + unpickle and nothing else."""
+        tensors = self._adapter()
+
+        restored = pickle.loads(base64.b64decode(serialize_adapter_tensors(tensors), validate=True))
+
+        assert restored.keys() == tensors.keys()
+        for name, tensor in tensors.items():
+            assert torch.equal(restored[name], tensor)
+
+    def test_payload_is_at_least_as_large_as_the_tensors(self):
+        """A payload holding a handle is orders of magnitude smaller."""
+        tensors = self._adapter()
+        nbytes = sum(t.numel() * t.element_size() for t in tensors.values())
+
+        payload = base64.b64decode(serialize_adapter_tensors(tensors), validate=True)
+
+        assert len(payload) >= nbytes
+
+    def test_payload_holds_no_shared_memory_handle(self):
+        """A shared storage serializes as a /torch_<pid> handle, not as
+        bytes."""
+        payload = base64.b64decode(serialize_adapter_tensors(self._adapter()), validate=True)
+
+        assert b"/torch_" not in payload


### PR DESCRIPTION
## What

The adapter push in LoRA adapter mode now carries the tensor bytes in the payload (`serialize_adapter_tensors`) instead of a reference to shared host memory. The call site loses its sharing-strategy dance and its keep-alive requirement along with it.

## Why

A colocate run of Qwen3-Omni-30B-A3B thinker LoRA (rank 16, TP4, 4×A100) gets through model build, LoRA injection, engine startup and the full base-weight sync (19743 parameters, 7.7s), then dies on the first adapter push — but only on one rank. TP1–TP3 log `loading from tensors completes`; TP0 raises:

```
RuntimeError: unable to open shared memory object </torch_4103_2908601601_198>
in read-write mode: No such file or directory
```

`4103` is the pid of training rank 0, the producer.

The payload built under `file_system` does not contain the adapter; it contains a `/dev/shm` file name. That storage is reference counted, and the count is what the *consumers* hold: the ranks that map it first release their reference when the call returns, the count reaches zero, the file is unlinked, and a rank that arrives late opens a path that no longer exists. Nothing is wrong with the adapter, the LoRA scope, or the engine — the bytes simply expire in flight.

Being timing dependent, it presents as one rank dying while its peers load the very same adapter, which reads like a rank-local fault and is not one.

The current comment in this code records that the default `file_descriptor` strategy was already found unable to cross the Ray → HTTP hops, and `file_system` was adopted in response. That diagnosis is right; `file_system` is simply the next pothole on the same road, because both strategies share the property that matters here — the payload is a reference, and a reference is only as good as the producer's grip on the storage.

A CPU-only probe reproduces all three transports end to end (one Ray actor serializes, four consumer actors deserialize, rank 0 arriving late by 8s):

| Transport | Result |
| --- | --- |
| `file_descriptor` (torch default) | all four ranks fail with `AuthenticationError` |
| `file_system` (current) | rank 0 fails with the ENOENT above, ranks 1–3 succeed |
| Inlined pickle (this PR) | all four ranks succeed, checksums match |

Worth stating plainly: with all four consumers arriving simultaneously, `file_system` passes. The race only materialises when one rank is late — which is precisely why it survived into production and why it should not be left to scheduling luck.

## How

`serialize_adapter_tensors` pickles the tensors and base64-encodes them, which is the exact wire format SGLang already expects: `MultiprocessingSerializer.deserialize` base64-decodes and unpickles, and a plain pickle simply has no reference to resolve. No SGLang-side change is needed.

The base-weight path is deliberately untouched. Those tensors stay on device and serialize to CUDA IPC handles, which are self-contained across these hops — which is also why base sync never failed while the adapter push did.

The cost is the payload: 0.1MB of handles becomes 31.6MB of base64 for a rank-16 adapter on a 30B model, once per weight update, on a path that already does a cross-process gather. Adapters are bounded by rank rather than model size, so this stays small where it matters.

## Testing

Run inside the Relax training image (`sglang 0.5.12.post1`, `torch 2.11.0+cu129`):

```
pytest tests/utils/test_megatron_peft_utils.py::TestSerializeAdapterTensors
3 passed
```

The three cases pin the property that broke, not the implementation: the payload round-trips through plain base64 + unpickle, it is at least as large as the tensors it carries, and it contains no `/torch_` handle. Substituting the shared-memory serialization back into the helper fails the latter two — `assert 530 >= 524288`, and the handle found verbatim in the payload — so the tests would have caught this before it reached a GPU.

End to end, a 40-step GRPO run (Qwen3-Omni-30B-A3B thinker LoRA, 4×A100 colocate, TP4/EP4, adapter pushed every step) completed 40/40 pushes with reward rising from 0.294 over the first ten steps to 0.392 over the last ten.

`pre-commit run --files` is clean on all three touched files.

- [x] `pre-commit run --all-files` passes
- [x] Tests pass (`pytest tests/`)
- [x] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Production failure, four TP workers of one engine:

```
[TP1] loading from tensors completes
[TP2] loading from tensors completes
[TP3] loading from tensors completes
[TP0] RuntimeError: unable to open shared memory object </torch_4103_2908601601_198>
      in read-write mode: No such file or directory
```

Same chain reproduced on CPU, with and without the fix:

```
[file_system]      rank0 FAIL: unable to open shared memory object </torch_367_...>
                   rank1 ok  rank2 ok  rank3 ok
[inlined pickle]   rank0 ok  rank1 ok  rank2 ok  rank3 ok   (checksums match)
```
