### PR TITLE
feat(klx):add klx XPU training support for Qwen3-9B sft and Qwen3.6-27B text-only training

### DIFF
--- a/scripts/models/qwen36-27B.sh
+++ b/scripts/models/qwen36-27B.sh
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+MODEL_ARGS=(
+    --disable-bias-linear
+    --qk-layernorm
+    --group-query-attention
+    --num-attention-heads 24
+    --num-query-groups 4
+    --kv-channels 256
+    --num-layers 64
+    --hidden-size 5120
+    --ffn-hidden-size 17408
+    --use-gated-attention
+
+    --normalization RMSNorm
+    --apply-layernorm-1p
+    --position-embedding-type rope
+    --norm-epsilon 1e-6
+    --rotary-percent 0.25
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --vocab-size 248320
+
+    --rotary-base 10000000
+
+    # qwen3.6 specific (same architecture as qwen3.5)
+    --attention-output-gate
+)

--- a/scripts/training/sft/run-qwen3.5-9B-8xklx.sh
+++ b/scripts/training/sft/run-qwen3.5-9B-8xklx.sh
@@ -144,24 +144,6 @@ MISC_ARGS=(
    --use-health-check
 )
 
-# infer cpu threads num
-NUM_GPUS_TOTAL="${NUM_GPUS_TOTAL:-8}"
-if [ -z "${CPU_THREADS_PER_ACTOR:-}" ]; then
-    _cores_per_socket=$(lscpu 2>/dev/null | awk -F: '/^Core\(s\) per socket:/ {gsub(/ /,"",$2); print $2; exit}')
-    _sockets=$(lscpu 2>/dev/null | awk -F: '/^Socket\(s\):/ {gsub(/ /,"",$2); print $2; exit}')
-    if [ -n "${_cores_per_socket}" ] && [ -n "${_sockets}" ] && [ "${_sockets}" -gt 0 ]; then
-        _total_phys=$((_cores_per_socket * _sockets))
-        CPU_THREADS_PER_ACTOR=$((_total_phys / NUM_GPUS_TOTAL))
-        # clamp to [4, 64], avoid bad values
-        [ "${CPU_THREADS_PER_ACTOR}" -lt 4 ] && CPU_THREADS_PER_ACTOR=4
-        [ "${CPU_THREADS_PER_ACTOR}" -gt 64 ] && CPU_THREADS_PER_ACTOR=64
-    else
-        CPU_THREADS_PER_ACTOR=24
-    fi
-fi
-echo "[cpu-threads] NUM_GPUS_TOTAL=${NUM_GPUS_TOTAL} CPU_THREADS_PER_ACTOR=${CPU_THREADS_PER_ACTOR}"
-export CPU_THREADS_PER_ACTOR
-
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
     \"PYTHONPATH\": \"${WORKDIR}/TransferQueue:${WORKDIR}/Megatron-LM/:${SCRIPT_DIR}:${WORKDIR}/Megatron-Bridge/src/:$PYTHONPATH\",

--- a/scripts/training/sft/run-qwen3.5-9B-8xklx.sh
+++ b/scripts/training/sft/run-qwen3.5-9B-8xklx.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3.5-9B 8xP800 colocate (sync) training script for DAPO math dataset.
+#
+# Usage:
+#   bash scripts/training/sft/run-qwen35-9B-8xklx.sh
+
+set -ex
+set -o pipefail
+
+gpus_num=8
+export WORLD_SIZE=$(( gpus_num / 8 ))
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+
+export WORKDIR="${WORKDIR:-/workspace}"
+export MODEL_DIR="${MODEL_DIR:-/workspace}"
+export DATA_DIR="${DATA_DIR:-/workspace}"
+export EXP_DIR="${EXP_DIR:-/workspace}"
+export WANDB_API_KEY="${WANDB_API_KEY:=YOUR-KEY}"
+export WEB_PROXY="${WEB_PROXY:-}"
+
+export XMLIR_USE_HYDRA_LINEAR=1
+export XMLIR_ENABLE_FAST_FC=1
+
+export RELAX_SKIP_TORCH_MEMORY_SAVER=1
+export XMLIR_MEMCPY_RETRY_SYNC=true
+export CUDA_ENABLE_P2P_NO_UVA=0
+export CUDA_FAKE_UVA_ENABLE=1
+export CUDA_ERROR_LEVEL=0
+export XPU_SUPPORT_IPC_EVENT=1
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-"eth0"}
+export TP_SOCKET_IFNAME=${TP_SOCKET_IFNAME:-"eth0"}
+export BKCL_RDMA_NICS=${BKCL_RDMA_NICS:-"eth1,eth2,eth3,eth4"}
+
+exp_target="${EXP_TARGET:-}"
+
+PROMPT_DATA="${PROMPT_DATA:=${DATA_DIR}/sft/data/OpenMathReasoning-mini/data/cot-00000-of-00001.parquet}"
+PROJECT_NAME="${PROJECT_NAME:="XHS_Relax"}"
+EXP_NAME="Qwen3.5-9B-MM-SFT-${gpus_num}xP800${exp_target}"
+
+unset http_proxy
+unset https_proxy
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../entrypoint/local-klx.sh"
+fi
+source "${SCRIPT_DIR}/../../models/qwen35-9B.sh"
+
+if [ -z "${SYSTEM_PROMPT:-}" ] && [ -n "${SYSTEM_PROMPT_FILE:-}" ]; then
+    SYSTEM_PROMPT="$(cat "${SYSTEM_PROMPT_FILE}")"
+fi
+SYSTEM_PROMPT="${SYSTEM_PROMPT:?SYSTEM_PROMPT is required — set it via env var or SYSTEM_PROMPT_FILE}"
+
+CKPT_ARGS=(
+   --hf-checkpoint ${MODEL_DIR}/Qwen3.5-9B
+   --ref-load ${MODEL_DIR}/Qwen3.5-9B
+   --megatron-to-hf-mode bridge
+   --load ${EXP_DIR}/sft/checkpoint/Qwen3-9B_mcore_${gpus_num}xklx/
+   --save ${EXP_DIR}/sft/checkpoint/Qwen3-9B_mcore_${gpus_num}xklx/
+   --save-interval 500
+   --max-actor-ckpt-to-keep 1
+   --num-epoch 1
+)
+
+SFT_ARGS=(
+   --loss-type sft
+   --prompt-data ${PROMPT_DATA}
+   --input-key ${INPUT_KEY:-problem}
+   --label-key ${LABEL_KEY:-generated_solution}
+   --global-batch-size 512
+   --use-dynamic-batch-size
+   # --max-tokens-per-gpu 20480
+   --max-tokens-per-gpu 10240
+   --balance-data
+   --system-prompt "${SYSTEM_PROMPT}"
+   --sft-prefetch-buffer-size 512
+   --sft-prefetch-num-workers 8
+   --use-distributed-optimizer
+   --overlap-grad-reduce
+   --overlap-param-gather
+   --cross-entropy-fusion-impl te
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+   --calculate-per-token-loss
+
+   # --recompute-granularity full
+   # --recompute-method block
+   # --recompute-num-layers 8
+
+   --no-rope-fusion
+   --colocate
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-05
+   --lr-decay-style cosine
+   --min-lr 1e-06
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --clip-grad 1.0
+
+   # --optimizer-cpu-offload
+   # --overlap-cpu-optimizer-d2h-h2d
+   # --use-precision-aware-optimizer
+)
+
+EVAL_ARGS=(
+   --eval-size 0.01
+   --eval-interval 200
+)
+
+PREDICT_ARGS=()
+
+WANDB_ARGS=(
+   --tb-experiment-name ${EXP_NAME}-${now}
+   --no-use-wandb
+   --wandb-project ${PROJECT_NAME}
+   --wandb-group ${EXP_NAME}-${now}
+   --wandb-key ${WANDB_API_KEY}
+   --disable-wandb-random-suffix
+   --no-use-metrics-service
+   --no-use-tensorboard
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --use-health-check
+)
+
+# infer cpu threads num
+NUM_GPUS_TOTAL="${NUM_GPUS_TOTAL:-8}"
+if [ -z "${CPU_THREADS_PER_ACTOR:-}" ]; then
+    _cores_per_socket=$(lscpu 2>/dev/null | awk -F: '/^Core\(s\) per socket:/ {gsub(/ /,"",$2); print $2; exit}')
+    _sockets=$(lscpu 2>/dev/null | awk -F: '/^Socket\(s\):/ {gsub(/ /,"",$2); print $2; exit}')
+    if [ -n "${_cores_per_socket}" ] && [ -n "${_sockets}" ] && [ "${_sockets}" -gt 0 ]; then
+        _total_phys=$((_cores_per_socket * _sockets))
+        CPU_THREADS_PER_ACTOR=$((_total_phys / NUM_GPUS_TOTAL))
+        # clamp to [4, 64], avoid bad values
+        [ "${CPU_THREADS_PER_ACTOR}" -lt 4 ] && CPU_THREADS_PER_ACTOR=4
+        [ "${CPU_THREADS_PER_ACTOR}" -gt 64 ] && CPU_THREADS_PER_ACTOR=64
+    else
+        CPU_THREADS_PER_ACTOR=24
+    fi
+fi
+echo "[cpu-threads] NUM_GPUS_TOTAL=${NUM_GPUS_TOTAL} CPU_THREADS_PER_ACTOR=${CPU_THREADS_PER_ACTOR}"
+export CPU_THREADS_PER_ACTOR
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${WORKDIR}/TransferQueue:${WORKDIR}/Megatron-LM/:${SCRIPT_DIR}:${WORKDIR}/Megatron-Bridge/src/:$PYTHONPATH\",
+    \"LD_LIBRARY_PATH\":\"${CONDA_PREFIX}/xcudart/lib:${CONDA_PREFIX}/lib/python3.10/site-packages/xtorch_ops:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/xre/so\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"TOKENIZERS_PARALLELISM\": \"true\",
+    \"NCCL_CUMEM_ENABLE\": \"0\",
+    \"NCCL_SOCKET_IFNAME\": \"eth0\",
+    \"GLOO_SOCKET_IFNAME\": \"eth0\",
+    \"NCCL_IB_HCA\": \"mlx5\",
+    \"NCCL_IB_GID_INDEX\": \"3\",
+    \"CUDA_DEVICE_ORDER\": \"OAM_ID\",
+    \"CUDA_ENABLE_P2P_NO_UVA\": \"0\",
+    \"CUDA_FAKE_UVA_ENABLE\": \"1\",
+    \"CUDART_DUMMY_REGISTER\": \"1\",
+    \"XPU_FORCE_USERMODE_LAUNCH\": \"1\",
+    \"XMLIR_DIST_SINGLETON_STREAM\": \"true\",
+    \"CUDA_VISIBLE_DEVICES\": \"0,1,2,3,4,5,6,7\",
+    \"XPU_VISIBLE_DEVICES\": \"0,1,2,3,4,5,6,7\",
+    \"XMLIR_FA_GEMM_TYPE\": \"float\",
+    \"XBLAS_FC_HBM_VERSION\": \"40\",
+    \"XMLIR_ENABLE_FAST_FC\": \"1\",
+    \"XMLIR_USE_HYDRA_LINEAR\": \"1\",
+    \"XTE_DISABLE_MOE_DW_FUSION\": \"0\",
+    \"XTE_RECOMPUTE_LN_OUT_TOTAL\": \"1\",
+    \"XMLIR_PARALLEL_SAVE_MEMORY\": \"false\",
+    \"XMLIR_DISABLE_CUDA_ALLOCATOR\": \"false\",
+    \"XMLIR_XDNN_PYTORCH_CHECK_ENABLE_FALLBACK_BOOL\": \"0\",
+    \"XMLIR_ENABLE_FALLBACK_TO_CPU_BOOL\": \"False\",
+    \"XMLIR_DUMP_FALLBACK_OP_LIST_BOOL\": \"true\",
+    \"XMLIR_DIST_ASYNC_ISEND_IRECV\": \"false\",
+    \"XMLIR_BATCH_PARALLEL\": \"false\",
+    \"XPU_FORCE_SHARED_DEVICE_CONTEXT\": \"1\",
+    \"BKCL_RDMA_PROXY_DISABLE\": \"1\",
+    \"BKCL_USE_AR\": \"1\",
+    \"BKCL_RING_OPT\": \"1\",
+    \"BKCL_FLAT_RING\": \"1\",
+    \"BKCL_CCIX_RING\": \"1\",
+    \"BKCL_TREE_THRESHOLD\": \"1048576\",
+    \"BKCL_CCIX_BUFFER_GM\": \"1\",
+    \"BKCL_FORCE_L3_RDMA\": \"0\",
+    \"BKCL_RING_BUFFER_GM\": \"1\",
+    \"BKCL_ENABLE_XDR\": \"1\",
+    \"BKCL_RDMA_FORCE_TREE\": \"1\",
+    \"BKCL_XLINK_D2D\": \"0\",
+    \"BKCL_XLINK_ETH\": \"0\",
+    \"BKCL_XLINK_C2C\": \"1\",
+    \"BKCL_TRANS_UNSUPPORTED_DATATYPE\": \"1\",
+    \"BKCL_KL3_TURBO_MODE\": \"1\",
+    \"BKCL_RING_BUFFER_SIZE\": \"2097152\",
+    \"ALLREDUCE_ASYNC\": \"false\",
+    \"ALLGATHER_ASYNC\": \"false\",
+    \"ALLREDUCE_FUSION\": \"0\",
+    \"BKCL_TIMEOUT\": \"400000\",
+    \"CUDA_DISABLE_PRINTF\": \"1\",
+    \"BKCL_RDMA_VERBS\": \"1\",
+    \"BKCL_RDMA_NICS\": \"${BKCL_RDMA_NICS}\",
+    \"NVTE_DEBUG\": \"1\",
+    \"NVTE_DEBUG_LEVEL\": \"1\",
+    \"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES\": \"1\",
+    \"TORCH_XCCL_DEFAUTL_PG_TIMEOUT_MILSEC\": \"7200000\",
+    \"CUDA_ERROR_LEVEL\": \"0\",
+    \"HYDRA_FULL_ERROR\": \"1\",
+    \"XMLIR_ENABLE_NEW_PG\": \"1\",
+    \"TORCH_XCCL_HEARTBEAT_TIMEOUT_SEC\": \"1800\",
+    \"TORCH_XCCL_ENABLE_TIMING\": \"1\",
+    \"TORCH_FR_BUFFER_SIZE\": \"2000\",
+    \"TORCH_XCCL_TRACE_BUFFER_SIZE\": \"2000\",
+    \"VERL_LOGGING_LEVEL\": \"DEBUG\",
+    \"BKCL_ALL_TO_ALL_OPT\": \"1\",
+    \"SGLANG_IS_FLASHINFER_AVAILABLE\": \"false\",
+    \"USE_MOE_FC_V3\": \"1\",
+    \"FLA_USE_NAIVE\": \"1\",
+    \"FORCE_DISABLE_FLA\": \"1\",
+    \"DISABLE_CAST_CACHE\": \"1\",
+    \"FORCE_NN_LINEAR\": \"0\",
+    \"XMLIR_USE_HYDRA_LINEAR\": \"1\",
+    \"SGL_CPU_QUANTIZATION\": \"1\",
+    \"XPU_ENABLE_CTX_LAZY_INIT\": \"1\",
+    \"XPU_SUPPORT_IPC_EVENT\": \"1\",
+    \"TRITON_SKIP_AUTOTUNE\": \"1\",
+    \"XMLIR_FORCE_USE_XPU_GRAPH\": \"1\",
+    \"XSGL_USE_TORCH_CAUSAL_CONV\": \"1\",
+    \"XSGL_FUSE_SPLIT_NORM_ROPE_NEOX\": \"1\",
+    \"XPU_FLASH_ATTENTION_DECODER_USE_BALANCE\": \"1\",
+    \"CUDA_ENABLE_P2P_NO_UVA\": \"0\",
+    \"CUDA_FAKE_UVA_ENABLE\": \"1\",
+    \"XSGL_TRANSPOSE_SSM_STATE\": \"1\",
+    \"XSGL_TRANSPOSE_CONV_STATE\": \"1\",
+    \"USE_FUSED_GATED_DELTA_RULE\": \"1\",
+    \"RAY_OVERRIDE_JOB_RUNTIME_ENV\":\"1\",
+    \"XMLIR_D_XPU_L3_SIZE\": \"0\",
+    \"XMLIR_MEMCPY_RETRY_SYNC\": \"true\",
+    \"DEBUG_DUMP_TOKENS\": \"0\",
+    \"RELAX_SKIP_TORCH_MEMORY_SAVER\":\"1\",
+    \"XMLIR_MATMUL_FAST_MODE\": \"1\",
+    \"XMLIR_ENABLE_FAST_FC\": \"1\",
+    \"HYDRAX_USE_PROTEUS\": \"0\",
+    \"http_proxy\": \"${WEB_PROXY}\",
+    \"https_proxy\": \"${WEB_PROXY}\"
+  }
+}"
+
+mkdir -p log
+
+RAY_JOB_ADDRESS="${RAY_JOB_ADDRESS:-http://127.0.0.1:8265}"
+
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="${RAY_JOB_ADDRESS}" \
+   ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 -m relax.entrypoints.train \
+   --resource '{"sft": [1, 0], "actor": [1, '"${gpus_num}"']}' \
+   --colocate \
+   --max-staleness 0 \
+   --num-data-storage-units 1 \
+   "${MODEL_ARGS[@]}" \
+   "${CKPT_ARGS[@]}" \
+   "${SFT_ARGS[@]}" \
+   "${EVAL_ARGS[@]}" \
+   "${PREDICT_ARGS[@]}" \
+   "${OPTIMIZER_ARGS[@]}" \
+   "${WANDB_ARGS[@]}" \
+   "${PERF_ARGS[@]}" \
+   "${MISC_ARGS[@]}" 2>&1 | tee log/qwen35-9B-mm-sft-${gpus_num}xklx-${now}.log

--- a/scripts/training/text/run-qwen36-27B-8xklx.sh
+++ b/scripts/training/text/run-qwen36-27B-8xklx.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3.6-27B 8xP800 colocate (sync) training script for DAPO math dataset.
+#
+# Usage:
+#   bash scripts/training/text/run-qwen36-27B-8xklx.sh
+
+set -ex
+set -o pipefail
+
+gpus_num=8
+export WORLD_SIZE=$(( gpus_num / 8 ))
+
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+
+WORKDIR="${WORKDIR:-/workspace}"
+MODEL_DIR="${MODEL_DIR:-/workspace}"
+DATA_DIR="${DATA_DIR:-/workspace}"
+EXP_DIR="${EXP_DIR:-${MODEL_DIR}}"
+WANDB_API_KEY="${WANDB_API_KEY:=YOUR-KEY}"
+WEB_PROXY="${WEB_PROXY:-}"
+NUM_ROLLOUT="${NUM_ROLLOUT:=1000}"
+
+export CUDA_ENABLE_P2P_NO_UVA=0
+export CUDA_FAKE_UVA_ENABLE=1
+export CUDA_ERROR_LEVEL=0
+export XMLIR_MEMCPY_RETRY_SYNC=true
+export XPU_SUPPORT_IPC_EVENT=1
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-"eth0"}
+export TP_SOCKET_IFNAME=${TP_SOCKET_IFNAME:-"eth0"}
+export BKCL_RDMA_NICS=${BKCL_RDMA_NICS:-"eth1,eth2,eth3,eth4"}
+
+PROMPT_DATA="${PROMPT_DATA:-${DATA_DIR}/dapo-math-17k/dapo-math-17k.jsonl}"
+EVAL_DATA="${EVAL_DATA:-${DATA_DIR}/aime-2024/aime-2024.jsonl}"
+PROJECT_NAME="${PROJECT_NAME:="XHS_Relax"}"
+EXP_NAME="${EXP_NAME:="Qwen3.6-27B-Text-${gpus_num}xklx"}"
+
+unset http_proxy
+unset https_proxy
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Auto-source local environment when not launched via an external entrypoint
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../entrypoint/local-klx.sh"
+fi
+source "${SCRIPT_DIR}/../../models/qwen36-27B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint ${MODEL_DIR}/Qwen3.6-27B
+   --ref-load ${MODEL_DIR}/Qwen3.6-27B
+   --megatron-to-hf-mode bridge
+   --warm-hf-checkpoint-page-cache
+   --load ${EXP_DIR}/text/Qwen3.6-27B_mcore_${gpus_num}xklx/
+   --save ${EXP_DIR}/text/Qwen3.6-27B_mcore_${gpus_num}xklx/
+   --save-interval 50
+   --max-actor-ckpt-to-keep 1
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data ${PROMPT_DATA}
+   --input-key ${INPUT_KEY:-prompt}
+   --label-key ${LABEL_KEY:-label}
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type dapo
+   --reward-key score
+   --num-rollout ${NUM_ROLLOUT}
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 10240
+   --rollout-max-prompt-len 2048
+   --rollout-max-context-len 12288
+   --rollout-temperature 0.8
+   --global-batch-size 256
+   --balance-data
+   --use-fault-tolerance
+)
+
+# EVAL_ARGS=(
+#    --log-passrate
+#    --skip-eval-before-train
+#    --eval-interval 20
+#    --eval-prompt-data aime ${EVAL_DATA}
+#    --n-samples-per-eval-prompt 8
+#    --eval-max-response-len 10240
+#    --eval-top-p 0.7
+# )
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 2
+
+
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   # --recompute-granularity full
+   # --recompute-method block
+   # --recompute-num-layers 16
+
+   --calculate-per-token-loss
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 12288
+   --no-rope-fusion
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 4
+   --sglang-mem-fraction-static 0.8
+   --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 128)
+
+   --sglang-router-policy round_robin
+
+   --sglang-disable-custom-all-reduce
+   --sglang-page-size 64
+   --sglang-attention-backend kunlun
+   --sglang-mm-attention-backend fa3
+   --sglang-disable-radix-cache
+   --sglang-max-running-requests 128
+   # --sglang-disable-cuda-graph
+   --sglang-reasoning-parser qwen3
+   --sglang-tool-call-parser qwen3_coder
+)
+
+WANDB_ARGS=(
+   --tb-experiment-name ${EXP_NAME}-${now}
+   --use-wandb
+   --wandb-project ${PROJECT_NAME}
+   --wandb-group ${EXP_NAME}-${now}
+   --wandb-key ${WANDB_API_KEY}
+   --disable-wandb-random-suffix
+   --no-use-metrics-service
+   --no-use-tensorboard
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   # need to comment this when using model with MLA
+   --attention-backend flash
+)
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${WORKDIR}/TransferQueue:${WORKDIR}/Megatron-LM/:${SCRIPT_DIR}:${WORKDIR}/Megatron-Bridge/src/:$PYTHONPATH\",
+    \"LD_LIBRARY_PATH\":\"${CONDA_PREFIX}/xcudart/lib:${CONDA_PREFIX}/lib/python3.10/site-packages/xtorch_ops:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/xre/so\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"TOKENIZERS_PARALLELISM\": \"true\",
+    \"NCCL_CUMEM_ENABLE\": \"0\",
+    \"NCCL_SOCKET_IFNAME\": \"eth0\",
+    \"GLOO_SOCKET_IFNAME\": \"eth0\",
+    \"NCCL_IB_HCA\": \"mlx5\",
+    \"NCCL_IB_GID_INDEX\": \"3\",
+    \"CUDA_DEVICE_ORDER\": \"OAM_ID\",
+    \"CUDA_ENABLE_P2P_NO_UVA\": \"0\",
+    \"CUDA_FAKE_UVA_ENABLE\": \"1\",
+    \"CUDART_DUMMY_REGISTER\": \"1\",
+    \"XPU_FORCE_USERMODE_LAUNCH\": \"1\",
+    \"XMLIR_DIST_SINGLETON_STREAM\": \"true\",
+    \"CUDA_VISIBLE_DEVICES\": \"0,1,2,3,4,5,6,7\",
+    \"XPU_VISIBLE_DEVICES\": \"0,1,2,3,4,5,6,7\",
+    \"XMLIR_FA_GEMM_TYPE\": \"float\",
+    \"XBLAS_FC_HBM_VERSION\": \"40\",
+    \"XMLIR_ENABLE_FAST_FC\": \"1\",
+    \"XMLIR_USE_HYDRA_LINEAR\": \"1\",
+    \"XTE_DISABLE_MOE_DW_FUSION\": \"0\",
+    \"XTE_RECOMPUTE_LN_OUT_TOTAL\": \"1\",
+    \"XMLIR_PARALLEL_SAVE_MEMORY\": \"false\",
+    \"XMLIR_DISABLE_CUDA_ALLOCATOR\": \"false\",
+    \"XMLIR_XDNN_PYTORCH_CHECK_ENABLE_FALLBACK_BOOL\": \"0\",
+    \"XMLIR_ENABLE_FALLBACK_TO_CPU_BOOL\": \"False\",
+    \"XMLIR_DUMP_FALLBACK_OP_LIST_BOOL\": \"true\",
+    \"XMLIR_DIST_ASYNC_ISEND_IRECV\": \"false\",
+    \"XMLIR_BATCH_PARALLEL\": \"false\",
+    \"XPU_FORCE_SHARED_DEVICE_CONTEXT\": \"1\",
+    \"BKCL_RDMA_PROXY_DISABLE\": \"1\",
+    \"BKCL_USE_AR\": \"1\",
+    \"BKCL_RING_OPT\": \"1\",
+    \"BKCL_FLAT_RING\": \"1\",
+    \"BKCL_CCIX_RING\": \"1\",
+    \"BKCL_TREE_THRESHOLD\": \"1048576\",
+    \"BKCL_CCIX_BUFFER_GM\": \"1\",
+    \"BKCL_FORCE_L3_RDMA\": \"0\",
+    \"BKCL_RING_BUFFER_GM\": \"1\",
+    \"BKCL_ENABLE_XDR\": \"1\",
+    \"BKCL_RDMA_FORCE_TREE\": \"1\",
+    \"BKCL_XLINK_D2D\": \"0\",
+    \"BKCL_XLINK_ETH\": \"0\",
+    \"BKCL_XLINK_C2C\": \"1\",
+    \"BKCL_TRANS_UNSUPPORTED_DATATYPE\": \"1\",
+    \"BKCL_KL3_TURBO_MODE\": \"1\",
+    \"BKCL_RING_BUFFER_SIZE\": \"2097152\",
+    \"ALLREDUCE_ASYNC\": \"false\",
+    \"ALLGATHER_ASYNC\": \"false\",
+    \"ALLREDUCE_FUSION\": \"0\",
+    \"BKCL_TIMEOUT\": \"400000\",
+    \"CUDA_DISABLE_PRINTF\": \"1\",
+    \"BKCL_RDMA_VERBS\": \"1\",
+    \"BKCL_RDMA_NICS\": \"${BKCL_RDMA_NICS}\",
+    \"NVTE_DEBUG\": \"1\",
+    \"NVTE_DEBUG_LEVEL\": \"1\",
+    \"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES\": \"1\",
+    \"TORCH_XCCL_DEFAUTL_PG_TIMEOUT_MILSEC\": \"7200000\",
+    \"CUDA_ERROR_LEVEL\": \"0\",
+    \"HYDRA_FULL_ERROR\": \"1\",
+    \"XMLIR_ENABLE_NEW_PG\": \"1\",
+    \"TORCH_XCCL_HEARTBEAT_TIMEOUT_SEC\": \"1800\",
+    \"TORCH_XCCL_ENABLE_TIMING\": \"1\",
+    \"TORCH_FR_BUFFER_SIZE\": \"2000\",
+    \"TORCH_XCCL_TRACE_BUFFER_SIZE\": \"2000\",
+    \"VERL_LOGGING_LEVEL\": \"DEBUG\",
+    \"BKCL_ALL_TO_ALL_OPT\": \"1\",
+    \"SGLANG_IS_FLASHINFER_AVAILABLE\": \"false\",
+    \"USE_MOE_FC_V3\": \"1\",
+    \"FLA_USE_NAIVE\": \"1\",
+    \"FORCE_DISABLE_FLA\": \"1\",
+    \"DISABLE_CAST_CACHE\": \"1\",
+    \"FORCE_NN_LINEAR\": \"0\",
+    \"XMLIR_USE_HYDRA_LINEAR\": \"1\",
+    \"SGL_CPU_QUANTIZATION\": \"1\",
+    \"XPU_ENABLE_CTX_LAZY_INIT\": \"1\",
+    \"XPU_SUPPORT_IPC_EVENT\": \"1\",
+    \"TRITON_SKIP_AUTOTUNE\": \"1\",
+    \"XMLIR_FORCE_USE_XPU_GRAPH\": \"1\",
+    \"XSGL_USE_TORCH_CAUSAL_CONV\": \"1\",
+    \"XSGL_FUSE_SPLIT_NORM_ROPE_NEOX\": \"1\",
+    \"XPU_FLASH_ATTENTION_DECODER_USE_BALANCE\": \"1\",
+    \"CUDA_ENABLE_P2P_NO_UVA\": \"0\",
+    \"CUDA_FAKE_UVA_ENABLE\": \"1\",
+    \"XSGL_TRANSPOSE_SSM_STATE\": \"1\",
+    \"XSGL_TRANSPOSE_CONV_STATE\": \"1\",
+    \"USE_FUSED_GATED_DELTA_RULE\": \"1\",
+    \"RAY_OVERRIDE_JOB_RUNTIME_ENV\":\"1\",
+    \"XMLIR_D_XPU_L3_SIZE\": \"0\",
+    \"XMLIR_MEMCPY_RETRY_SYNC\": \"true\",
+    \"DEBUG_DUMP_TOKENS\": \"0\",
+    \"RELAX_SKIP_TORCH_MEMORY_SAVER\":\"1\",
+    \"XMLIR_MATMUL_FAST_MODE\": \"1\",
+    \"XMLIR_ENABLE_FAST_FC\": \"1\",
+    \"HYDRAX_USE_PROTEUS\": \"0\",
+    \"RELAX_LOG_SEQ_LENS\": \"1\",
+    \"OPENBLAS_NUM_THREADS\": \"32\",
+    \"OMP_NUM_THREADS\": \"32\",
+    \"USE_FAST_BFP16_FC\":\"1\",
+    \"XSGL_USE_FAST_BFP16\":\"1\",
+    \"http_proxy\": \"${WEB_PROXY}\",
+    \"https_proxy\": \"${WEB_PROXY}\"
+  }
+}"
+
+mkdir -p log
+
+RAY_JOB_ADDRESS="${RAY_JOB_ADDRESS:-http://127.0.0.1:8265}"
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="${RAY_JOB_ADDRESS}" \
+   ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 -m relax.entrypoints.train \
+   --resource '{"actor": [1, '"${gpus_num}"'], "rollout": [1, '"${gpus_num}"']}' \
+   --colocate \
+   --max-staleness 0 \
+   --num-data-storage-units 1 \
+   --use-health-check \
+   "${MODEL_ARGS[@]}" \
+   "${CKPT_ARGS[@]}" \
+   "${ROLLOUT_ARGS[@]}" \
+   "${OPTIMIZER_ARGS[@]}" \
+   "${GRPO_ARGS[@]}" \
+   "${WANDB_ARGS[@]}" \
+   "${PERF_ARGS[@]}" \
+   "${EVAL_ARGS[@]}" \
+   "${SGLANG_ARGS[@]}" \
+   "${MISC_ARGS[@]}"  2>&1 | tee log/qwen36-27B-GRPO-${gpus_num}xklx-${now}.log


### PR DESCRIPTION
## What

Add Qwen3.5-9B / Qwen3.6-27B training launch scripts targeting P800 KLX (Kunlun) clusters, plus the Qwen3.6-27B Megatron model config.

- `scripts/models/qwen36-27B.sh` — Qwen3.6-27B Megatron `MODEL_ARGS` (same architecture as Qwen3.5, with the new `--attention-output-gate` flag)
- `scripts/training/sft/run-qwen3.5-9B-8xklx.sh` — Qwen3.5-9B SFT on single-node 8×P800 (TP=4, PP=1)
- `scripts/training/sft/run-qwen36-27B-8xklx.sh` — Qwen3.6-27B GRPO (DAPO math) on 8×P800 (TP=4, PP=2)

## Why

Fill in the missing launch scripts for Qwen3.5-9B / Qwen3.6-27B on P800 KLX clusters

## How

- **Qwen3.6-27B model config**: reuses the Qwen3.5 architecture (64 layers / hidden 5120 / GQA 24-4 / kv 256 / vocab 248320 / rope-base 1e7) and adds `--attention-output-gate` to reflect the Qwen3.6 architectural delta.
- **KLX runtime env**: the scripts bootstrap through the existing `scripts/entrypoint/local-klx.sh`; `RUNTIME_ENV_JSON` carries the P800/XPU-specific env vars (`XMLIR_*` / `XTE_*` / `BKCL_*` / `XPU_*` / `SGL_*`), with NICs pinned to `eth0` for control-plane and `eth1..eth4` for BKCL RDMA.
- **Qwen3.5-9B SFT**:
  - `TP=4, PP=1, CP=1`, `sequence-parallel`, `use-dynamic-batch-size`
  - 8xklx: `global-batch-size=512`, `max-tokens-per-gpu=10240`, includes auto-inference of CPU threads per actor
  - `loss-type=sft`; business system prompt injected via heredoc (short-video ad like/no-like binary prediction)
- **Qwen3.6-27B GRPO**: `TP=4, PP=2`, DAPO math data (`dapo-math-17k`), `n-samples-per-prompt=8`, `rollout-max-response-len=10240`; SGLang engine with `TP=4`, `kunlun` attention backend, `qwen3` reasoning parser and `qwen3_coder` tool parser; `optimizer-cpu-offload` + `use-precision-aware-optimizer` to relieve KV/optimizer memory pressure.

## Testing

- [x] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`) — shell-only change, no Python unit tests cover these files
- [ ] New tests added (if applicable) — N/A
- [ ] Documentation updated (if applicable) — N/A

Manually validated on a P800 KLX node by submitting Ray jobs via `bash scripts/training/sft/run-qwen3.5-9B-8xklx.sh`, and `run-qwen36-27B-8xklx.sh`; training comes up and enters the rollout / SFT step normally.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

N/A