### PR TITLE
feat(replay): add deterministic trajectory replay

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -288,6 +288,7 @@ export default defineConfig({
               items: [
                 { text: 'How to Contribute', link: '/en/guide/how-to-contribute' },
                 { text: 'Debugging Guide', link: '/en/guide/debugging' },
+                { text: 'Trajectory Replay', link: '/en/guide/trajectory-replay' },
                 { text: 'Rollout Result Viewer', link: '/en/guide/rollout-result-viewer' }
               ]
             }
@@ -400,6 +401,7 @@ export default defineConfig({
               items: [
                 { text: '如何贡献', link: '/zh/guide/how-to-contribute' },
                 { text: '调试指南', link: '/zh/guide/debugging' },
+                { text: '轨迹重放', link: '/zh/guide/trajectory-replay' },
                 { text: 'Rollout 结果可视化', link: '/zh/guide/rollout-result-viewer' }
               ]
             }

--- a/docs/en/guide/trajectory-replay.md
+++ b/docs/en/guide/trajectory-replay.md
@@ -85,12 +85,12 @@ python -m relax.tools.trajectory_replay replay <bundle> [--stage all]
 
 # Select a single sample / group / micro-batch (repeatable), or assert the step coordinate.
 python -m relax.tools.trajectory_replay replay <bundle> \
-    [--sample s-0] [--group g-1] [--batch mb-0007] [--step 120:0]
+    [--sample s-0] [--group g-1] [--batch mb-0007] [--step 120:0] [--rollout 120]
 ```
 
 The `replay` report gives the first divergent stage, sample, field, token offset, expected/actual values and max absolute error. Skipped stages (`recorded-only` / `inspect-only` / `unsupported`) never count toward the first-divergence determination.
 
-**Selection granularity**: `--sample` / `--group` / `--batch` may be combined. Selecting any sample or micro-batch expands to its full semantic-group closure (reward/advantage normalization is group-level) and fails closed on missing membership. Under a partial selection, per-sample/per-token stages (sample → advantage.estimate) recompute normally while the cohort-level `loss.policy` stage is skipped — a subset scalar cannot be compared to a full-cohort expected value. `--step ROLLOUT_ID:STEP_ID` asserts identity on a single bundle (step bundles match `(rollout_id, step_id)`; rollout bundles match `rollout_id`); if the path is a capture directory (several bundles or `rank-*` children) it picks the matching one, preferring the step-level bundle. `--batch` selects by DataIterator micro-batch index (`mb-0000`, `mb-0001`, …), not by actor `step_id`.
+**Selection granularity**: `--sample` / `--group` / `--batch` may be combined. Selecting any sample or micro-batch expands to its full semantic-group closure (reward/advantage normalization is group-level) and fails closed on missing membership. Under a partial selection, per-sample/per-token stages (sample → advantage.estimate) recompute normally while the cohort-level `loss.policy` stage is skipped — a subset scalar cannot be compared to a full-cohort expected value. `--step ROLLOUT_ID:STEP_ID` accepts an exact `actor_step_id=(rollout_id, step_id)` match only; use `--rollout ROLLOUT_ID` for a rollout-level bundle. The two flags are mutually exclusive. If the path is a capture directory (several bundles or `rank-*` children) it picks the matching one. `--batch` selects by DataIterator micro-batch index (`mb-0000`, `mb-0001`, …), not by actor `step_id`.
 
 Example (the PR #65 bug):
 
@@ -105,7 +105,25 @@ bundle b-00001 — first divergent stage: reward.post_process
 
 ## Enabling production capture
 
-Capture is off by default and does not change training numerics. Turn it on with environment variables (no CLI argument-parsing change). The actor calls `maybe_enable_from_env` from `MegatronTrainRayActor.init` and writes per rank under `<DIR>/rank-<rank>/`:
+Capture is off by default and does not change training numerics. Turn it on with
+environment variables (no CLI argument-parsing change). The actor calls
+`maybe_enable_for_actor` from `MegatronTrainRayActor.init`, which enables capture
+only on last pipeline-stage ranks (they own the post-forward payloads). Other
+ranks stay silent. A single producer writes `<DIR>/<bundle>/`; multiple producers
+write `<DIR>/<bundle>/rank-<rank>/`. Each producer's writer thread
+**try-finalizes** after publishing `COMPLETE.<rank>` (returns immediately if
+peers are missing; writes the final `COMPLETE` once every producer has landed).
+The training thread never waits:
+
+```text
+<DIR>/
+  replay-0-0/
+    COMPLETE.0          # this rank's identity, owned payloads, checksums
+    COMPLETE.1
+    COMPLETE            # appears only after every expected rank has flushed
+    rank-0/             # rank-local complete bundle; replayable on its own
+    rank-1/
+```
 
 ```bash
 export RELAX_REPLAY_CAPTURE=1

--- a/docs/en/guide/trajectory-replay.md
+++ b/docs/en/guide/trajectory-replay.md
@@ -113,7 +113,10 @@ ranks stay silent. A single producer writes `<DIR>/<bundle>/`; multiple producer
 write `<DIR>/<bundle>/rank-<rank>/`. Each producer's writer thread
 **try-finalizes** after publishing `COMPLETE.<rank>` (returns immediately if
 peers are missing; writes the final `COMPLETE` once every producer has landed).
-The training thread never waits:
+Each rank-local `COMPLETE` records `expected_ranks`. `validate` / `replay`
+(and `BundleReader`) refuse a multi-rank `rank-*` path until the parent
+cohort's final `COMPLETE` exists — passing `rank-0/` directly does not bypass
+that check. The training thread never waits:
 
 ```text
 <DIR>/
@@ -121,7 +124,7 @@ The training thread never waits:
     COMPLETE.0          # this rank's identity, owned payloads, checksums
     COMPLETE.1
     COMPLETE            # appears only after every expected rank has flushed
-    rank-0/             # rank-local complete bundle; replayable on its own
+    rank-0/             # rank-local bundle; multi-rank replay needs parent COMPLETE
     rank-1/
 ```
 

--- a/docs/en/guide/trajectory-replay.md
+++ b/docs/en/guide/trajectory-replay.md
@@ -90,7 +90,7 @@ python -m relax.tools.trajectory_replay replay <bundle> \
 
 The `replay` report gives the first divergent stage, sample, field, token offset, expected/actual values and max absolute error. Skipped stages (`recorded-only` / `inspect-only` / `unsupported`) never count toward the first-divergence determination.
 
-**Selection granularity**: `--sample` / `--group` / `--batch` may be combined. Selecting any sample or micro-batch expands to its full semantic-group closure (reward/advantage normalization is group-level) and fails closed on missing membership. Under a partial selection, per-sample/per-token stages (sample → advantage.estimate) recompute normally while the cohort-level `loss.policy` stage is skipped — a subset scalar cannot be compared to a full-cohort expected value. `--step ROLLOUT_ID:STEP_ID` asserts the bundle's actor-step coordinate and errors on mismatch. Step-level production bundles record `micro_batch_id` as `mb-<step_id>`, so `--batch mb-0000` selects that step's samples.
+**Selection granularity**: `--sample` / `--group` / `--batch` may be combined. Selecting any sample or micro-batch expands to its full semantic-group closure (reward/advantage normalization is group-level) and fails closed on missing membership. Under a partial selection, per-sample/per-token stages (sample → advantage.estimate) recompute normally while the cohort-level `loss.policy` stage is skipped — a subset scalar cannot be compared to a full-cohort expected value. `--step ROLLOUT_ID:STEP_ID` asserts identity on a single bundle (step bundles match `(rollout_id, step_id)`; rollout bundles match `rollout_id`); if the path is a capture directory (several bundles or `rank-*` children) it picks the matching one, preferring the step-level bundle. `--batch` selects by DataIterator micro-batch index (`mb-0000`, `mb-0001`, …), not by actor `step_id`.
 
 Example (the PR #65 bug):
 
@@ -169,4 +169,4 @@ writer.finalize(ranks=[0])
 - Production capture is split into two bundle types: rollout-level (reward/advantage, identity `rollout_id`, instrumented in `train_actor`) and step-level (loss, identity `(rollout_id, step_id)`, instrumented in `train_one_step`); cross-bundle propagation of the "first divergent stage" is not yet unified. Enable with `RELAX_REPLAY_CAPTURE=1` and `RELAX_REPLAY_CAPTURE_DIR`.
 - Remote RM/GenRM results are treated as `recorded-only` and are not recomputed offline.
 
-See the RFC and the implementation spec for full design and implementation details.
+See [Task 34 RFC #171](https://github.com/redai-infra/Relax/issues/171) for the design discussion.

--- a/docs/en/guide/trajectory-replay.md
+++ b/docs/en/guide/trajectory-replay.md
@@ -1,0 +1,172 @@
+# Trajectory Replay
+
+> Status: the offline replay core (PR A) and production capture (PR B — `loss.policy` hot-path hook, async `CaptureManager` and GPU smoke) are implemented; the distributed layout (PR C) is landed. Capture is split into two bundle types: **rollout-level** (`reward.raw → reward.post_process → advantage.kl → advantage.estimate`, identity = `rollout_id`) and **step-level** (`loss.policy`, identity = `(rollout_id, step_id)`); `advantage.kl` uses rollout-vs-reference semantics and requires a `ref_log_probs` payload. Bundles are produced by the training side or built programmatically via `BundleWriter`.
+
+Trajectory Replay is a verifiable offline reproduction tool for async training. It packs the data, stage outputs and identity information that one training step actually consumed into a **self-describing, verifiable replay bundle**, then — on a plain CPU host without Ray Serve, SGLang, a rollout worker or a GPU — recomputes the reward, advantage, return and loss stages with the same stage semantics and reports the **first verifiable divergence**.
+
+Model forward, backward, gradient and optimizer steps are outside the replay boundary. The system stores the compact post-forward statistics the loss actually consumes (current/old log-probabilities, entropy, values, masks, advantages, returns), not full logits or a checkpoint.
+
+## Why it exists
+
+In synchronous training a rollout step and an Actor update are roughly one-to-one; in fully-async / hybrid modes this no longer holds:
+
+- rollout can lead the actor by several weight versions;
+- one rollout partition may be split into multiple TransferQueue consumer batches;
+- dynamic batching changes micro-batch boundaries;
+- one Actor update may consume samples from multiple rollout partitions.
+
+Replay therefore treats "generated together", "normalized together" and "consumed together" as independent identities. The historical PR #65 bug (streamed prompt groups normalized against the physical batch) is the canonical case of "physical batch ≠ semantic cohort": the final loss changes, but the **first faulty stage is `reward.post_process`**. Replay exists to locate that kind of error, not just to compare the final scalar.
+
+## Bundle layout
+
+A bundle is a directory:
+
+```text
+<bundle>/
+├── manifest.json    # versions, producer, stage contracts, payload specs + checksums, comparison policy
+├── index.json       # identity + per-sample records + recompute config
+├── expected.json    # JSON expected outputs per stage (scalars / lists)
+├── payloads/        # tensor payloads (inputs and expected tensors)
+│   ├── old_log_probs.pt
+│   ├── log_probs.pt
+│   ├── entropy.pt
+│   ├── kl.pt
+│   └── advantages.pt
+└── COMPLETE         # completion sentinel (COMPLETE.<rank> + final COMPLETE for multi-rank)
+```
+
+- **Text goes through JSON**: `index.json` holds only JSON-compatible metadata (sample_id, group_index, lengths, loss_mask, raw_reward, ...). Raw prompt/response text is replaced by hash/truncation per the redaction policy.
+- **Tensors use `weights_only=True`**: `payloads/` accepts only `torch.Tensor`; loading is `weights_only=True` and recursively rejects Python objects.
+- **Integrity**: the writer stages into a temp directory, writes payloads and manifest hashes, then atomically renames. A missing `COMPLETE`, payload, rank shard, or a checksum mismatch fails before any stage runs.
+
+## Identity model
+
+Replay identity is two-layered:
+
+- **Logical identity**: sample, semantic group, normalization cohort, actor step.
+- **Physical provenance**: rollout partition, consumer batch, micro-batch, rank shard, weight lineage.
+
+The training-step identity anchor is the **cohort an Actor update actually consumed**. `actor_step_id` is the `(rollout_id, step_id)` tuple (the `train_one_step` coordinate). The derived `accumulated_step_id` scalar is **not** a persisted identity: under dynamic batching and streaming schedules `num_steps_per_rollout` can vary per rollout.
+
+Selectors fail closed when a membership mapping is missing instead of inferring a semantic group from a physical batch size — the root cause of PR #65.
+
+## Stage contracts and the V1 capability matrix
+
+The pipeline is split into independently versioned stages:
+
+```text
+sample -> reward.raw -> reward.post_process -> advantage.kl -> advantage.estimate -> loss.policy
+```
+
+Each stage declares a capability:
+
+| Capability | Meaning |
+| --- | --- |
+| `recompute` | inputs and implementation are complete; can be recomputed and compared offline |
+| `recorded-only` | only the production output is viewable; the producer cannot be reliably recomputed |
+| `inspect-only` | partial inputs or summaries are viewable; contract incomplete |
+| `unsupported` | the stage is not supported by capture or reader |
+
+**Frozen V1 capability matrix**: only **GRPO with `CP=1`** declares `recompute` for `sample / reward.raw / reward.post_process / advantage.kl / advantage.estimate / loss.policy`. Every other topology (`CP>1`, PPO, SAPO/CISPO, OPD, agentic flattened) is `unsupported` and fails loudly in the runner — no best-effort guessing or silent downgrade.
+
+The advantage/loss adapters **reuse the production kernels** (`compute_approx_kl` / `get_grpo_returns` / `compute_policy_loss` in `relax/utils/training/ppo_utils.py`) as the single source of truth. `reward.post_process` is reimplemented offline (the production function lives in a module that imports Ray at module scope) and is marked `implementation="reimplemented"`, pinned by the PR #65 fixture.
+
+## CLI usage
+
+```bash
+# Show identity, capability, producer and payload summary (works on incomplete bundles).
+python -m relax.tools.trajectory_replay inspect <bundle>
+
+# Validate format, integrity, safety and dependency closure (no numerical replay).
+python -m relax.tools.trajectory_replay validate <bundle>
+
+# Recompute stages and compare against expected outputs; exit 0 on pass, 1 on divergence.
+python -m relax.tools.trajectory_replay replay <bundle> [--stage all]
+
+# Select a single sample / group / micro-batch (repeatable), or assert the step coordinate.
+python -m relax.tools.trajectory_replay replay <bundle> \
+    [--sample s-0] [--group g-1] [--batch mb-0007] [--step 120:0]
+```
+
+The `replay` report gives the first divergent stage, sample, field, token offset, expected/actual values and max absolute error. Skipped stages (`recorded-only` / `inspect-only` / `unsupported`) never count toward the first-divergence determination.
+
+**Selection granularity**: `--sample` / `--group` / `--batch` may be combined. Selecting any sample or micro-batch expands to its full semantic-group closure (reward/advantage normalization is group-level) and fails closed on missing membership. Under a partial selection, per-sample/per-token stages (sample → advantage.estimate) recompute normally while the cohort-level `loss.policy` stage is skipped — a subset scalar cannot be compared to a full-cohort expected value. `--step ROLLOUT_ID:STEP_ID` asserts the bundle's actor-step coordinate and errors on mismatch. Step-level production bundles record `micro_batch_id` as `mb-<step_id>`, so `--batch mb-0000` selects that step's samples.
+
+Example (the PR #65 bug):
+
+```text
+bundle b-00001 — first divergent stage: reward.post_process
+[   pass] sample
+[   pass] reward.raw
+[   fail] reward.post_process — normalized reward mismatch in 4 sample(s)
+          reward s-0: expected=-5.5 actual=-1.0 abs_err=4.5
+          ...
+```
+
+## Enabling production capture
+
+Capture is off by default and does not change training numerics. Turn it on with environment variables (no CLI argument-parsing change). The actor calls `maybe_enable_from_env` from `MegatronTrainRayActor.init` and writes per rank under `<DIR>/rank-<rank>/`:
+
+```bash
+export RELAX_REPLAY_CAPTURE=1
+export RELAX_REPLAY_CAPTURE_DIR=/path/to/replay-bundles
+# Optional: capture only the listed Actor steps / rollouts (comma-separated). Unset = all.
+export RELAX_REPLAY_CAPTURE_STEPS=0:0
+export RELAX_REPLAY_CAPTURE_ROLLOUTS=0
+```
+
+A training run then writes two bundle types: rollout-level (reward / advantage) and step-level (`loss.policy`). Replay them offline with the CLI above.
+
+## Building a bundle programmatically
+
+Bundles can still be built by hand with `BundleWriter` for offline validation (fixtures, injected faults, cross-version checks):
+
+```python
+import torch
+from relax.utils.replay.bundle import BundleWriter
+from relax.utils.replay.schema import (
+    ActorStepId, BundleIndex, Identity, Manifest, ProducerInfo,
+    RecomputeConfig, SampleRecord, StageCapability, StageContract, StageId,
+)
+
+index = BundleIndex(
+    bundle_id="b-00001",
+    identity=Identity(actor_step_id=ActorStepId(rollout_id=120, step_id=0), rank={"cp": 1}),
+    samples=[SampleRecord(sample_id="s-0", group_index=0, response_length=2, total_length=3,
+                          loss_mask=[1, 1], raw_reward=1.0, reward=1.0), ...],
+    config=RecomputeConfig(advantage_estimator="grpo", n_samples_per_prompt=2),
+)
+manifest = Manifest(
+    format_version="1.0.0", bundle_id="b-00001",
+    producer=ProducerInfo(commit="...", torch_version=torch.__version__),
+    stage_contracts={stage: StageContract(stage=stage, version="v1", capability=StageCapability.RECOMPUTE)
+                     for stage in (StageId.SAMPLE, StageId.REWARD_RAW, StageId.REWARD_POST_PROCESS,
+                                   StageId.ADVANTAGE_KL, StageId.ADVANTAGE_ESTIMATE, StageId.LOSS_POLICY)},
+    payloads={}, comparison_policy=..., redaction={"prompt": "hash"},
+)
+expected = {"reward.raw": {"raw_rewards": [...]}, "reward.post_process": {"rewards": [...]},
+            "loss.policy": {"loss": ...}}
+
+writer = BundleWriter("<path>", manifest, index, expected)
+writer.write_payload("old_log_probs", old_log_probs)
+writer.write_payload("log_probs", log_probs)
+writer.write_payload("entropy", entropy)
+writer.write_payload("kl", kl)
+writer.write_payload("advantages", advantages)
+writer.finalize(ranks=[0])
+```
+
+## Security and redaction
+
+- Public artifacts allow only JSON metadata + tensor payloads; tensors load with `weights_only=True`.
+- prompt/response/label/tool output/paths/endpoints follow an explicit redaction policy (`hash` / `truncate` / `drop`).
+- No full `Namespace`, environment variables, secrets, checkpoints or service credentials are stored.
+
+## Current limitations
+
+- Does **not** replay model forward/backward/gradient/optimizer; does not guarantee re-sampling the same trajectory; does not require bitwise identity across hardware/compilers.
+- **V1 supports GRPO `CP=1` only**; `CP>1`, PPO value loss, OPD and agentic flattened are `unsupported`.
+- Production capture is split into two bundle types: rollout-level (reward/advantage, identity `rollout_id`, instrumented in `train_actor`) and step-level (loss, identity `(rollout_id, step_id)`, instrumented in `train_one_step`); cross-bundle propagation of the "first divergent stage" is not yet unified. Enable with `RELAX_REPLAY_CAPTURE=1` and `RELAX_REPLAY_CAPTURE_DIR`.
+- Remote RM/GenRM results are treated as `recorded-only` and are not recomputed offline.
+
+See the RFC and the implementation spec for full design and implementation details.

--- a/docs/zh/guide/trajectory-replay.md
+++ b/docs/zh/guide/trajectory-replay.md
@@ -110,7 +110,9 @@ bundle b-00001 — first divergent stage: reward.post_process
 stage 的 rank 上启用捕获（这些 rank 持有 post-forward payload），其余 rank 保持沉默。
 单 producer 写 `<DIR>/<bundle>/`；多 producer 写 `<DIR>/<bundle>/rank-<rank>/`，各
 producer 的 writer 线程在写完 `COMPLETE.<rank>` 后 **try-finalize**（缺人就返回，
-到齐才写最终 `COMPLETE`），训练线程不等待：
+到齐才写最终 `COMPLETE`），训练线程不等待。rank-local 的 `COMPLETE` 会写入
+`expected_ranks`；`validate` / `replay`（以及 `BundleReader`）在父目录最终
+`COMPLETE` 出现前拒绝多 rank 的 `rank-*` 路径，直接传入 `rank-0/` 也不能绕过：
 
 ```text
 <DIR>/
@@ -118,7 +120,7 @@ producer 的 writer 线程在写完 `COMPLETE.<rank>` 后 **try-finalize**（缺
     COMPLETE.0          # 该 rank 的身份、owned payloads、checksum
     COMPLETE.1
     COMPLETE            # 全部预期 rank 到齐后才出现
-    rank-0/             # rank-local 完整 bundle，可单独 replay
+    rank-0/             # rank-local bundle；多 rank replay 需要父目录 COMPLETE
     rank-1/
 ```
 

--- a/docs/zh/guide/trajectory-replay.md
+++ b/docs/zh/guide/trajectory-replay.md
@@ -85,12 +85,12 @@ python -m relax.tools.trajectory_replay replay <bundle> [--stage all]
 
 # 选择单条 / 单 group / 单 micro-batch 重放（可重复），或断言 step 坐标
 python -m relax.tools.trajectory_replay replay <bundle> \
-    [--sample s-0] [--group g-1] [--batch mb-0007] [--step 120:0]
+    [--sample s-0] [--group g-1] [--batch mb-0007] [--step 120:0] [--rollout 120]
 ```
 
 `replay` 的分歧报告给出：首个分歧 stage、sample、field、token offset、expected/actual 值与最大绝对误差。被跳过（`recorded-only` / `inspect-only` / `unsupported`）的 stage 不计入分歧判定。
 
-**选择粒度**：`--sample`/`--group`/`--batch` 任选其一或多个。选择任何 sample 或 micro-batch 都会**展开到其完整 semantic-group closure**（因为 reward/advantage 归一化是 group 级），缺失 membership 时拒绝执行。部分选择下，per-sample/per-token 阶段（sample → advantage.estimate）正常重算，而 **cohort 级阶段（`loss.policy`）会跳过**——子集 scalar 无法与全 cohort 的期望值相比。`--step ROLLOUT_ID:STEP_ID` 在单个 bundle 上校验身份：step 级包匹配 `(rollout_id, step_id)`，rollout 级包匹配 `rollout_id`；若路径是抓包目录（含多个 bundle 或 `rank-*` 子目录），则选出匹配的那一份（优先 step 级）。`--batch` 按 DataIterator 的 micro-batch 序号选择（`mb-0000`、`mb-0001`、…），不是 actor `step_id`。
+**选择粒度**：`--sample`/`--group`/`--batch` 任选其一或多个。选择任何 sample 或 micro-batch 都会**展开到其完整 semantic-group closure**（因为 reward/advantage 归一化是 group 级），缺失 membership 时拒绝执行。部分选择下，per-sample/per-token 阶段（sample → advantage.estimate）正常重算，而 **cohort 级阶段（`loss.policy`）会跳过**——子集 scalar 无法与全 cohort 的期望值相比。`--step ROLLOUT_ID:STEP_ID` 只接受精确的 `actor_step_id=(rollout_id, step_id)` 匹配；rollout 级包用 `--rollout ROLLOUT_ID`。两者互斥。若路径是抓包目录（含多个 bundle 或 `rank-*` 子目录），则选出匹配的那一份。`--batch` 按 DataIterator 的 micro-batch 序号选择（`mb-0000`、`mb-0001`、…），不是 actor `step_id`。
 
 示例（PR #65 历史故障）：
 
@@ -105,7 +105,22 @@ bundle b-00001 — first divergent stage: reward.post_process
 
 ## 启用生产捕获
 
-捕获默认关闭，不改变训练数值。通过环境变量打开（不改 CLI 参数解析）；Actor 在 `MegatronTrainRayActor.init` 里调用 `maybe_enable_from_env`，每个 rank 写到 `<DIR>/rank-<rank>/`：
+捕获默认关闭，不改变训练数值。通过环境变量打开（不改 CLI 参数解析）；Actor 在
+`MegatronTrainRayActor.init` 里调用 `maybe_enable_for_actor`，只在 last pipeline
+stage 的 rank 上启用捕获（这些 rank 持有 post-forward payload），其余 rank 保持沉默。
+单 producer 写 `<DIR>/<bundle>/`；多 producer 写 `<DIR>/<bundle>/rank-<rank>/`，各
+producer 的 writer 线程在写完 `COMPLETE.<rank>` 后 **try-finalize**（缺人就返回，
+到齐才写最终 `COMPLETE`），训练线程不等待：
+
+```text
+<DIR>/
+  replay-0-0/
+    COMPLETE.0          # 该 rank 的身份、owned payloads、checksum
+    COMPLETE.1
+    COMPLETE            # 全部预期 rank 到齐后才出现
+    rank-0/             # rank-local 完整 bundle，可单独 replay
+    rank-1/
+```
 
 ```bash
 export RELAX_REPLAY_CAPTURE=1

--- a/docs/zh/guide/trajectory-replay.md
+++ b/docs/zh/guide/trajectory-replay.md
@@ -1,0 +1,172 @@
+# 轨迹重放（Trajectory Replay）
+
+> 状态：离线重放核心（PR A）与生产捕获（PR B，含 `loss.policy` 热路径 hook、异步 `CaptureManager` 与 GPU smoke）已实现；分布式布局（PR C）已落地。捕获拆分为两类 bundle：**rollout 级**（`reward.raw → reward.post_process → advantage.kl → advantage.estimate`，身份 = `rollout_id`）与 **step 级**（`loss.policy`，身份 = `(rollout_id, step_id)`）；`advantage.kl` 使用 rollout-vs-reference 语义，需 `ref_log_probs` payload。bundle 可由训练侧自动产出，也可通过 `BundleWriter` 以编程方式构造。
+
+轨迹重放是面向异步训练的可验证离线复现工具：它把一次训练 step 实际消费的数据、阶段输出与身份信息打包成**自描述、可校验的 replay bundle**，在不启动 Ray Serve、SGLang、Rollout Worker 或 GPU 的普通 CPU 环境里，按同样的阶段语义重算 reward、advantage、return 与 loss，并报告**首个可验证的分歧位置**。
+
+模型 forward、backward、gradient 与 optimizer step 不在重放边界内。系统保存 loss 实际消费的紧凑 post-forward 统计量（current/old log-probabilities、entropy、values、masks、advantages、returns），而不是完整 logits 或 checkpoint。
+
+## 为什么需要它
+
+在同步训练里 rollout step 与 Actor update 近似一一对应；在 fully-async / hybrid 模式下这个假设不成立：
+
+- Rollout 可以领先 Actor 多个权重版本；
+- 一个 rollout partition 可能被拆成多个 TransferQueue consumer batch；
+- dynamic batching 会改变 micro-batch 边界；
+- 一次 Actor update 可能消费来自多个 rollout partition 的样本。
+
+因此 replay 把「一起生成」「一起归一化」「一起被消费」视为彼此独立的身份。历史故障 PR #65（streamed prompt group 被错误地按物理 batch 做 reward 归一化）就是「物理传输 batch ≠ 语义归一化 cohort」的典型案例：最终 loss 会变，但**首个错误阶段是 `reward.post_process`**。轨迹重放正是用来定位这类错误，而不是只比较最终 scalar。
+
+## Bundle 结构
+
+一个 bundle 是一个目录：
+
+```text
+<bundle>/
+├── manifest.json    # 版本、producer、stage contract、payload 清单与 checksum、比较策略
+├── index.json       # 身份 + per-sample 记录 + 重算配置
+├── expected.json    # 各阶段的 JSON 期望输出（标量/列表）
+├── payloads/        # tensor payload（输入与期望张量）
+│   ├── old_log_probs.pt
+│   ├── log_probs.pt
+│   ├── entropy.pt
+│   ├── kl.pt
+│   └── advantages.pt
+└── COMPLETE         # 完成哨兵（多 rank 时为 COMPLETE.<rank> + 最终 COMPLETE）
+```
+
+- **文本走 JSON**：`index.json` 只存 JSON 兼容元数据（sample_id、group_index、长度、loss_mask、raw_reward 等），不存 prompt/response 原文（按 redaction policy 以 hash/截断代替）。
+- **张量走 `weights_only=True`**：`payloads/` 只允许 `torch.Tensor`，读取时 `weights_only=True` 并递归拒绝 Python object。
+- **完整性**：writer 先写临时目录、再写 payload 与 manifest hash、最后原子 rename；缺少 `COMPLETE`、payload、rank shard 或 checksum 不一致时，在 stage 执行前失败。
+
+## 身份模型
+
+重放身份分两层：
+
+- **逻辑身份**：sample、semantic group、normalization cohort、Actor step。
+- **物理 provenance**：rollout partition、consumer batch、micro-batch、rank shard、weight lineage。
+
+training step 的身份基准是 **Actor 实际消费的完整 cohort**。`actor_step_id` 用 `(rollout_id, step_id)` 二元组（对应 `train_one_step` 的入参坐标）；派生的 `accumulated_step_id` 标量在 dynamic batching / streaming schedule 下 `num_steps_per_rollout` 可变，因此**不作为持久化身份**。
+
+选择器在缺失 membership 映射时**拒绝执行**，而不是用物理 batch 大小猜测语义 group（这正是 PR #65 故障的根因）。
+
+## 阶段契约与 V1 capability
+
+流水线拆成独立版本化的 stage：
+
+```text
+sample -> reward.raw -> reward.post_process -> advantage.kl -> advantage.estimate -> loss.policy
+```
+
+每个 stage 声明 capability：
+
+| Capability | 含义 |
+| --- | --- |
+| `recompute` | 输入与实现完整，可离线重算并比较 |
+| `recorded-only` | 只能查看生产输出，不能可靠重算 producer |
+| `inspect-only` | 只能查看部分输入或摘要，contract 不完整 |
+| `unsupported` | capture 或 reader 不支持该阶段 |
+
+**冻结的 V1 capability matrix**：只有 **GRPO、`CP=1`** 的 `sample / reward.raw / reward.post_process / advantage.kl / advantage.estimate / loss.policy` 声明 `recompute`。其余拓扑（`CP>1`、PPO、SAPO/CISPO、OPD、Agentic flattened）一律 `unsupported`，在 runner 中显式失败，不做 best-effort 猜测或静默降级。
+
+advantage/loss 适配器**复用 production kernel**（`relax/utils/training/ppo_utils.py` 的 `compute_approx_kl` / `get_grpo_returns` / `compute_policy_loss`），单一事实来源。`reward.post_process` 因生产函数位于顶层 `import ray` 的模块中，离线侧以重实现方式提供（manifest 标记 `implementation="reimplemented"`），并由 PR #65 fixture 钉住语义。
+
+## CLI 用法
+
+```bash
+# 查看身份、capability、producer 与 payload 摘要（无需 COMPLETE，可查看不完整 bundle）
+python -m relax.tools.trajectory_replay inspect <bundle>
+
+# 校验格式、完整性、安全性与 dependency closure（不执行数值重放）
+python -m relax.tools.trajectory_replay validate <bundle>
+
+# 按 stage DAG 重算并比较期望输出；退出码 0 表示通过，1 表示存在分歧
+python -m relax.tools.trajectory_replay replay <bundle> [--stage all]
+
+# 选择单条 / 单 group / 单 micro-batch 重放（可重复），或断言 step 坐标
+python -m relax.tools.trajectory_replay replay <bundle> \
+    [--sample s-0] [--group g-1] [--batch mb-0007] [--step 120:0]
+```
+
+`replay` 的分歧报告给出：首个分歧 stage、sample、field、token offset、expected/actual 值与最大绝对误差。被跳过（`recorded-only` / `inspect-only` / `unsupported`）的 stage 不计入分歧判定。
+
+**选择粒度**：`--sample`/`--group`/`--batch` 任选其一或多个。选择任何 sample 或 micro-batch 都会**展开到其完整 semantic-group closure**（因为 reward/advantage 归一化是 group 级），缺失 membership 时拒绝执行。部分选择下，per-sample/per-token 阶段（sample → advantage.estimate）正常重算，而 **cohort 级阶段（`loss.policy`）会跳过**——子集 scalar 无法与全 cohort 的期望值相比。`--step ROLLOUT_ID:STEP_ID` 校验 bundle 的 actor-step 坐标，不匹配则报错退出。step 级生产 bundle 会把 `micro_batch_id` 记为 `mb-<step_id>`，因此 `--batch mb-0000` 可以选中该 step 的样本。
+
+示例（PR #65 历史故障）：
+
+```text
+bundle b-00001 — first divergent stage: reward.post_process
+[   pass] sample
+[   pass] reward.raw
+[   fail] reward.post_process — normalized reward mismatch in 4 sample(s)
+          reward s-0: expected=-5.5 actual=-1.0 abs_err=4.5
+          ...
+```
+
+## 启用生产捕获
+
+捕获默认关闭，不改变训练数值。通过环境变量打开（不改 CLI 参数解析）；Actor 在 `MegatronTrainRayActor.init` 里调用 `maybe_enable_from_env`，每个 rank 写到 `<DIR>/rank-<rank>/`：
+
+```bash
+export RELAX_REPLAY_CAPTURE=1
+export RELAX_REPLAY_CAPTURE_DIR=/path/to/replay-bundles
+# 可选：只抓指定 Actor step / rollout（逗号分隔）。未设置则抓全部。
+export RELAX_REPLAY_CAPTURE_STEPS=0:0
+export RELAX_REPLAY_CAPTURE_ROLLOUTS=0
+```
+
+打开后训练会写出两类 bundle：rollout 级（reward / advantage）和 step 级（`loss.policy`）。再用上面的 CLI 离线 `inspect` / `validate` / `replay`。
+
+## 编程构造 bundle
+
+除训练侧自动产出外，仍可用 `BundleWriter` 手工构造 bundle 用于离线验证（fixture、注入故障、跨版本校验）：
+
+```python
+import torch
+from relax.utils.replay.bundle import BundleWriter
+from relax.utils.replay.schema import (
+    ActorStepId, BundleIndex, Identity, Manifest, ProducerInfo,
+    RecomputeConfig, SampleRecord, StageCapability, StageContract, StageId,
+)
+
+index = BundleIndex(
+    bundle_id="b-00001",
+    identity=Identity(actor_step_id=ActorStepId(rollout_id=120, step_id=0), rank={"cp": 1}),
+    samples=[SampleRecord(sample_id="s-0", group_index=0, response_length=2, total_length=3,
+                          loss_mask=[1, 1], raw_reward=1.0, reward=1.0), ...],
+    config=RecomputeConfig(advantage_estimator="grpo", n_samples_per_prompt=2),
+)
+manifest = Manifest(
+    format_version="1.0.0", bundle_id="b-00001",
+    producer=ProducerInfo(commit="...", torch_version=torch.__version__),
+    stage_contracts={stage: StageContract(stage=stage, version="v1", capability=StageCapability.RECOMPUTE)
+                     for stage in (StageId.SAMPLE, StageId.REWARD_RAW, StageId.REWARD_POST_PROCESS,
+                                   StageId.ADVANTAGE_KL, StageId.ADVANTAGE_ESTIMATE, StageId.LOSS_POLICY)},
+    payloads={}, comparison_policy=..., redaction={"prompt": "hash"},
+)
+expected = {"reward.raw": {"raw_rewards": [...]}, "reward.post_process": {"rewards": [...]},
+            "loss.policy": {"loss": ...}}
+
+writer = BundleWriter("<path>", manifest, index, expected)
+writer.write_payload("old_log_probs", old_log_probs)
+writer.write_payload("log_probs", log_probs)
+writer.write_payload("entropy", entropy)
+writer.write_payload("kl", kl)
+writer.write_payload("advantages", advantages)
+writer.finalize(ranks=[0])
+```
+
+## 安全与脱敏
+
+- 公共 artifact 只允许 JSON 元数据 + tensor payload；tensor 用 `weights_only=True` 加载。
+- prompt/response/label/tool output/路径/endpoint 按显式 redaction policy 处理（`hash` / `truncate` / `drop`）。
+- 不保存完整 `Namespace`、环境变量、secret、checkpoint 或服务凭据。
+
+## 当前限制
+
+- **不重放** model forward/backward/gradient/optimizer；不保证重新采样得到相同 trajectory；不要求跨硬件/编译器 bitwise identical。
+- **V1 仅支持 GRPO `CP=1`**；`CP>1`、PPO value loss、OPD、Agentic flattened 为 `unsupported`。
+- 生产捕获拆成两类 bundle：rollout 级（reward/advantage，身份 `rollout_id`，在 `train_actor` 打点）与 step 级（loss，身份 `(rollout_id, step_id)`，在 `train_one_step` 打点）；两者尚未在同一 bundle 中打通「首个分歧阶段」的跨 bundle 传播。通过 `RELAX_REPLAY_CAPTURE=1` 与 `RELAX_REPLAY_CAPTURE_DIR` 打开。
+- 远端 RM/GenRM 结果按 `recorded-only` 处理，不在离线侧重算。
+
+相关设计与实现细节见 [RFC](../../draft/contributor-task-34-async-aware-trajectory-replay-rfc.zh.md) 与实现规格草案。

--- a/docs/zh/guide/trajectory-replay.md
+++ b/docs/zh/guide/trajectory-replay.md
@@ -90,7 +90,7 @@ python -m relax.tools.trajectory_replay replay <bundle> \
 
 `replay` 的分歧报告给出：首个分歧 stage、sample、field、token offset、expected/actual 值与最大绝对误差。被跳过（`recorded-only` / `inspect-only` / `unsupported`）的 stage 不计入分歧判定。
 
-**选择粒度**：`--sample`/`--group`/`--batch` 任选其一或多个。选择任何 sample 或 micro-batch 都会**展开到其完整 semantic-group closure**（因为 reward/advantage 归一化是 group 级），缺失 membership 时拒绝执行。部分选择下，per-sample/per-token 阶段（sample → advantage.estimate）正常重算，而 **cohort 级阶段（`loss.policy`）会跳过**——子集 scalar 无法与全 cohort 的期望值相比。`--step ROLLOUT_ID:STEP_ID` 校验 bundle 的 actor-step 坐标，不匹配则报错退出。step 级生产 bundle 会把 `micro_batch_id` 记为 `mb-<step_id>`，因此 `--batch mb-0000` 可以选中该 step 的样本。
+**选择粒度**：`--sample`/`--group`/`--batch` 任选其一或多个。选择任何 sample 或 micro-batch 都会**展开到其完整 semantic-group closure**（因为 reward/advantage 归一化是 group 级），缺失 membership 时拒绝执行。部分选择下，per-sample/per-token 阶段（sample → advantage.estimate）正常重算，而 **cohort 级阶段（`loss.policy`）会跳过**——子集 scalar 无法与全 cohort 的期望值相比。`--step ROLLOUT_ID:STEP_ID` 在单个 bundle 上校验身份：step 级包匹配 `(rollout_id, step_id)`，rollout 级包匹配 `rollout_id`；若路径是抓包目录（含多个 bundle 或 `rank-*` 子目录），则选出匹配的那一份（优先 step 级）。`--batch` 按 DataIterator 的 micro-batch 序号选择（`mb-0000`、`mb-0001`、…），不是 actor `step_id`。
 
 示例（PR #65 历史故障）：
 
@@ -169,4 +169,4 @@ writer.finalize(ranks=[0])
 - 生产捕获拆成两类 bundle：rollout 级（reward/advantage，身份 `rollout_id`，在 `train_actor` 打点）与 step 级（loss，身份 `(rollout_id, step_id)`，在 `train_one_step` 打点）；两者尚未在同一 bundle 中打通「首个分歧阶段」的跨 bundle 传播。通过 `RELAX_REPLAY_CAPTURE=1` 与 `RELAX_REPLAY_CAPTURE_DIR` 打开。
 - 远端 RM/GenRM 结果按 `recorded-only` 处理，不在离线侧重算。
 
-相关设计与实现细节见 [RFC](../../draft/contributor-task-34-async-aware-trajectory-replay-rfc.zh.md) 与实现规格草案。
+相关设计讨论见 [Task 34 RFC #171](https://github.com/redai-infra/Relax/issues/171)。

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -59,7 +59,6 @@ from relax.utils.opd.opd_utils import (
 )
 from relax.utils.reloadable_process_group import destroy_process_groups, monkey_patch_torch_dist, reload_process_groups
 from relax.utils.replay import capture_hooks
-from relax.utils.replay.capture import maybe_enable_from_env
 from relax.utils.rotate_ckpt import rotate_ckpt
 from relax.utils.s3_model_loader import prepare_model_maybe_update_args
 from relax.utils.timer import Timer, inverse_timer, timer, with_defer
@@ -370,7 +369,7 @@ class MegatronTrainRayActor(TrainRayActor):
         self.data_iterator = None
 
         if role == "actor":
-            maybe_enable_from_env(rank=dist.get_rank())
+            capture_hooks.maybe_enable_for_actor()
 
         if dist.get_rank() == 0:
             logger.info(
@@ -1294,6 +1293,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     "rollout_log_probs",
                     "rewards",
                     "raw_reward",
+                    "group_index",
                 ]
                 data_fields += ["rollout_routed_experts"] if self.args.use_rollout_routing_replay else []
                 if self.args.multimodal_keys is not None:
@@ -1477,6 +1477,7 @@ class MegatronTrainRayActor(TrainRayActor):
             "rollout_log_probs",
             "rewards",
             "raw_reward",
+            "group_index",
         ]
         # In true on-policy mode, actor_fwd is absent and old_log_probs is
         # recomputed inline from the train forward (see policy_loss_function).

--- a/relax/backends/megatron/actor.py
+++ b/relax/backends/megatron/actor.py
@@ -58,6 +58,8 @@ from relax.utils.opd.opd_utils import (
     has_managed_opd_teacher_manager,
 )
 from relax.utils.reloadable_process_group import destroy_process_groups, monkey_patch_torch_dist, reload_process_groups
+from relax.utils.replay import capture_hooks
+from relax.utils.replay.capture import maybe_enable_from_env
 from relax.utils.rotate_ckpt import rotate_ckpt
 from relax.utils.s3_model_loader import prepare_model_maybe_update_args
 from relax.utils.timer import Timer, inverse_timer, timer, with_defer
@@ -366,6 +368,9 @@ class MegatronTrainRayActor(TrainRayActor):
 
         self.prof.on_init_end()
         self.data_iterator = None
+
+        if role == "actor":
+            maybe_enable_from_env(rank=dist.get_rank())
 
         if dist.get_rank() == 0:
             logger.info(
@@ -877,7 +882,12 @@ class MegatronTrainRayActor(TrainRayActor):
                     raise RuntimeError("Actor training with critic requires 'values' in rollout data.")
                 # Calculate adv and returns. Need to performed before training (instead of on the fly),
                 # because we may need normalize the whole rollout.
-                compute_advantages_and_returns(self.args, rollout_data)
+                capture_hooks.begin_rollout_for(self.args, rollout_id)
+                try:
+                    compute_advantages_and_returns(self.args, rollout_data)
+                    capture_hooks.capture_rollout_advantage(rollout_data=rollout_data, args=self.args)
+                finally:
+                    capture_hooks.end_rollout_for()
 
             if self.rollout_data_postprocess is not None:
                 self.rollout_data_postprocess(self.args)

--- a/relax/backends/megatron/data.py
+++ b/relax/backends/megatron/data.py
@@ -666,7 +666,7 @@ class DataIterator:
         assert micro_batch_size is None or micro_batch_indices is None
         self.offset = 0
 
-    def get_next(self, keys: Sequence[str]) -> dict[str, list[object] | None]:
+    def get_next(self, keys: Sequence[str]) -> dict[str, Any]:
         """Return the next micro-batch for the requested keys.
 
         - If `micro_batch_indices` is provided, selects rows according to the current
@@ -676,6 +676,11 @@ class DataIterator:
 
         Returns a dict mapping each key to a list subset (or None if absent).
         """
+        if self.micro_batch_indices is not None:
+            micro_batch_index = self.offset
+        else:
+            micro_batch_index = self.offset // self.micro_batch_size
+
         batch = {}
         for key in keys:
             vals = self.rollout_data.get(key, None)
@@ -695,6 +700,9 @@ class DataIterator:
             self.offset += 1
         else:
             self.offset += self.micro_batch_size
+        # DataIterator micro-batch ordinal (0-based). Trajectory replay stamps
+        # this onto each sample so --batch selects a real training micro-batch.
+        batch["replay_micro_batch_index"] = micro_batch_index
         return batch
 
     def reset(self) -> "DataIterator":

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -1134,6 +1134,7 @@ def policy_loss_function(
         response_lengths=response_lengths,
         total_lengths=total_lengths,
         reported_loss=reported_loss,
+        micro_batch_index=batch.get("replay_micro_batch_index"),
     )
 
     if train_rollout_logprob_abs_diff is not None:

--- a/relax/backends/megatron/loss.py
+++ b/relax/backends/megatron/loss.py
@@ -18,6 +18,7 @@ from relax.utils.opd.opd_utils import (
     resolve_opd_gather_topk_token_ids,
     validate_opd_topk_gather,
 )
+from relax.utils.replay import capture_hooks
 from relax.utils.training.ppo_utils import (
     calculate_log_probs_and_entropy,
     compute_approx_kl,
@@ -1121,6 +1122,19 @@ def policy_loss_function(
         "pg_clipfrac": pg_clipfrac.clone().detach(),
         "ppo_kl": ppo_kl.clone().detach(),
     }
+
+    # Trajectory-replay capture: record the loss.policy stage. No-op unless
+    # capture is enabled and this step is selected (single global read).
+    capture_hooks.capture_policy_loss(
+        old_log_probs=old_log_probs,
+        log_probs=log_probs,
+        entropy=entropy,
+        advantages=advantages,
+        loss_masks=batch["loss_masks"],
+        response_lengths=response_lengths,
+        total_lengths=total_lengths,
+        reported_loss=reported_loss,
+    )
 
     if train_rollout_logprob_abs_diff is not None:
         reported_loss["train_rollout_logprob_abs_diff"] = train_rollout_logprob_abs_diff.clone().detach()

--- a/relax/backends/megatron/model.py
+++ b/relax/backends/megatron/model.py
@@ -36,6 +36,7 @@ from relax.utils.megatron_bridge_utils import patch_megatron_model
 from relax.utils.megatron_peft_utils import is_lora_enabled
 from relax.utils.memory_utils import clear_memory
 from relax.utils.opd.opd_utils import consume_opd_train_data
+from relax.utils.replay import capture_hooks
 from relax.utils.timer import timer
 from relax.utils.training.ppo_utils import (
     install_critic_value_head_runtime_check,
@@ -974,6 +975,10 @@ def train_one_step(
     """
     args = get_args()
 
+    # Trajectory-replay capture: open a per-step accumulator (no-op unless
+    # capture is enabled and this step is selected).
+    capture_hooks.begin_step_for(args, rollout_id, step_id)
+
     # Set grad to zero.
     for model_chunk in model:
         model_chunk.zero_grad_buffer()
@@ -1256,7 +1261,9 @@ def train_one_step(
             # CP degree under dynamic CP (and is a no-op under static CP, where the
             # count previously carried the cancelling cp factor).
             loss_reduced[key] = value / num_samples_or_tokens
+        capture_hooks.end_step_for()
         return loss_reduced, grad_norm
+    capture_hooks.end_step_for()
     return {}, grad_norm
 
 

--- a/relax/tools/__init__.py
+++ b/relax/tools/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Developer tooling (CLI entry points)."""

--- a/relax/tools/trajectory_replay/__init__.py
+++ b/relax/tools/trajectory_replay/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Trajectory replay CLI: inspect / validate / replay."""

--- a/relax/tools/trajectory_replay/__main__.py
+++ b/relax/tools/trajectory_replay/__main__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+import sys
+
+from relax.tools.trajectory_replay.cli import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/relax/tools/trajectory_replay/benchmark_capture.py
+++ b/relax/tools/trajectory_replay/benchmark_capture.py
@@ -2,14 +2,14 @@
 
 """Microbenchmark for the trajectory-replay capture hook overhead.
 
-Measures the per-call cost of ``capture_hooks.capture_policy_loss`` in the three
+Measures the per-call cost of capture_hooks.capture_policy_loss in the three
 modes that matter for the hot-path budget:
 
-- **disabled**: capture never enabled (default) — must be ~0.
-- **unselected**: capture enabled but the step is not selected.
-- **selected**: capture enabled and the step is captured.
+- disabled: capture never enabled (default) — must be ~0.
+- unselected: capture enabled but the step is not selected.
+- selected: capture enabled and the step is captured.
 
-This isolates the *hook* overhead only. The full step-latency budget (§7.3:
+This isolates the hook overhead only. The full step-latency budget (spec 7.3:
 disabled <0.5%, selected-step <3%) must be measured on a real training run,
 because this microbenchmark does not include forward/backward.
 
@@ -24,8 +24,12 @@ import time
 
 import torch
 
+from relax.utils.logging_utils import get_logger
 from relax.utils.replay import capture_hooks
 from relax.utils.replay.capture import CaptureConfig, disable, enable
+
+
+logger = get_logger(__name__)
 
 
 def _synthetic_loss_args(device: torch.device) -> dict:
@@ -63,7 +67,7 @@ def main() -> None:
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"device={device} iters={args.iters}")
+    logger.info("device=%s iters=%s", device, args.iters)
 
     disable()
     disabled_ns = _time_hook(args.iters, device) * 1e9
@@ -79,10 +83,10 @@ def main() -> None:
     capture_module.end_step()
     disable()
 
-    print(f"disabled   : {disabled_ns:8.1f} ns/call")
-    print(f"unselected : {unselected_ns:8.1f} ns/call")
-    print(f"selected   : {selected_ns:8.1f} ns/call")
-    print("(full step-latency budget must be measured on a real training run, see spec §7.3)")
+    logger.info("disabled   : %8.1f ns/call", disabled_ns)
+    logger.info("unselected : %8.1f ns/call", unselected_ns)
+    logger.info("selected   : %8.1f ns/call", selected_ns)
+    logger.info("full step-latency budget must be measured on a real training run")
 
 
 def _identity():

--- a/relax/tools/trajectory_replay/benchmark_capture.py
+++ b/relax/tools/trajectory_replay/benchmark_capture.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Microbenchmark for the trajectory-replay capture hook overhead.
+
+Measures the per-call cost of ``capture_hooks.capture_policy_loss`` in the three
+modes that matter for the hot-path budget:
+
+- **disabled**: capture never enabled (default) — must be ~0.
+- **unselected**: capture enabled but the step is not selected.
+- **selected**: capture enabled and the step is captured.
+
+This isolates the *hook* overhead only. The full step-latency budget (§7.3:
+disabled <0.5%, selected-step <3%) must be measured on a real training run,
+because this microbenchmark does not include forward/backward.
+
+Usage:
+    python -m relax.tools.trajectory_replay.benchmark_capture [--iters N] [--output-dir DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import torch
+
+from relax.utils.replay import capture_hooks
+from relax.utils.replay.capture import CaptureConfig, disable, enable
+
+
+def _synthetic_loss_args(device: torch.device) -> dict:
+    num_tokens = 8
+    return {
+        "old_log_probs": torch.zeros(num_tokens, device=device),
+        "log_probs": torch.zeros(num_tokens, device=device),
+        "entropy": torch.full((num_tokens,), 0.5, device=device),
+        "advantages": torch.ones(num_tokens, device=device),
+        "loss_masks": [torch.ones(2, device=device) for _ in range(4)],
+        "response_lengths": [2, 2, 2, 2],
+        "total_lengths": [3, 3, 3, 3],
+        "reported_loss": {
+            "loss": torch.tensor(0.0, device=device),
+            "pg_loss": torch.tensor(0.0, device=device),
+            "entropy_loss": torch.tensor(0.0, device=device),
+            "pg_clipfrac": torch.tensor(0.0, device=device),
+            "ppo_kl": torch.tensor(0.0, device=device),
+        },
+    }
+
+
+def _time_hook(iters: int, device: torch.device) -> float:
+    kwargs = _synthetic_loss_args(device)
+    start = time.perf_counter()
+    for _ in range(iters):
+        capture_hooks.capture_policy_loss(**kwargs)
+    return (time.perf_counter() - start) / iters
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=10_000)
+    parser.add_argument("--output-dir", type=str, default="/tmp/replay-benchmark")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"device={device} iters={args.iters}")
+
+    disable()
+    disabled_ns = _time_hook(args.iters, device) * 1e9
+
+    enable(CaptureConfig(enabled=True, output_dir=args.output_dir, selected_steps={(0, 0)}))
+    unselected_ns = _time_hook(args.iters, device) * 1e9
+
+    enable(CaptureConfig(enabled=True, output_dir=args.output_dir))
+    from relax.utils.replay import capture as capture_module
+
+    capture_module.begin_step((0, 0), identity=_identity(), config=_config(), bundle_id="bench")
+    selected_ns = _time_hook(args.iters, device) * 1e9
+    capture_module.end_step()
+    disable()
+
+    print(f"disabled   : {disabled_ns:8.1f} ns/call")
+    print(f"unselected : {unselected_ns:8.1f} ns/call")
+    print(f"selected   : {selected_ns:8.1f} ns/call")
+    print("(full step-latency budget must be measured on a real training run, see spec §7.3)")
+
+
+def _identity():
+    from relax.utils.replay.schema import ActorStepId, Identity
+
+    return Identity(actor_step_id=ActorStepId(rollout_id=0, step_id=0), rank={"dp": 1, "tp": 1, "pp": 1, "cp": 1})
+
+
+def _config():
+    from relax.utils.replay.schema import RecomputeConfig
+
+    return RecomputeConfig(advantage_estimator="grpo", n_samples_per_prompt=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/relax/tools/trajectory_replay/cli.py
+++ b/relax/tools/trajectory_replay/cli.py
@@ -2,18 +2,18 @@
 
 """Command-line entry point for offline trajectory replay.
 
-Usage::
+Usage:
 
     python -m relax.tools.trajectory_replay inspect  <bundle>
     python -m relax.tools.trajectory_replay validate <bundle>
     python -m relax.tools.trajectory_replay replay   <bundle> [--stage all]
         [--sample s-0 --group g-1 --batch mb-0007 --step 120:0]
 
-``inspect`` works on incomplete bundles (no ``COMPLETE`` required); ``validate``
-and ``replay`` require a complete, checksum-validated bundle. ``replay``
+inspect works on incomplete bundles (no COMPLETE required); validate
+and replay require a complete, checksum-validated bundle. replay
 supports selecting a single sample / group / micro-batch (each expands to its
 semantic-group closure); cohort-level stages (loss) are skipped for a partial
-selection. ``--step`` asserts the bundle's actor-step coordinate.
+selection. --step asserts the bundle's actor-step coordinate.
 """
 
 from __future__ import annotations

--- a/relax/tools/trajectory_replay/cli.py
+++ b/relax/tools/trajectory_replay/cli.py
@@ -27,6 +27,7 @@ import sys
 from pathlib import Path
 
 from relax.utils.logging_utils import get_logger
+from relax.utils.replay.bundle import cohort_expected_ranks
 from relax.utils.replay.report import ReplayReport
 from relax.utils.replay.runner import replay as run_replay
 from relax.utils.replay.schema import index_from_dict, manifest_from_dict
@@ -137,24 +138,13 @@ def _cohort_complete(cohort_dir: Path) -> bool:
     return (cohort_dir / "COMPLETE").is_file()
 
 
-def _cohort_expected_ranks(cohort_dir: Path) -> list[int] | None:
-    for path in sorted(cohort_dir.iterdir()):
-        if not path.name.startswith("COMPLETE.") or not path.is_file():
-            continue
-        shard = json.loads(path.read_text(encoding="utf-8"))
-        recorded = shard.get("expected_ranks")
-        if isinstance(recorded, list) and len(recorded) > 1:
-            return [int(rank) for rank in recorded]
-    return None
-
-
 def _select_matching_bundle(hits: list[Path], selector: str) -> Path:
     """Pick one hit; multi-rank rank-* siblings require the cohort COMPLETE."""
     parents = {path.parent for path in hits}
     rank_local = all(path.name.startswith("rank-") for path in hits)
     if rank_local and len(parents) == 1:
         parent = next(iter(parents))
-        needs_complete = len(hits) > 1 or _cohort_expected_ranks(parent) is not None
+        needs_complete = len(hits) > 1 or cohort_expected_ranks(parent) is not None
         if needs_complete and not _cohort_complete(parent):
             raise ValueError(f"cohort {parent} is incomplete (missing COMPLETE) for {selector}")
         return sorted(hits, key=lambda path: path.name)[0]

--- a/relax/tools/trajectory_replay/cli.py
+++ b/relax/tools/trajectory_replay/cli.py
@@ -7,15 +7,16 @@ Usage:
     python -m relax.tools.trajectory_replay inspect  <bundle>
     python -m relax.tools.trajectory_replay validate <bundle>
     python -m relax.tools.trajectory_replay replay   <bundle> [--stage all]
-        [--sample s-0 --group g-1 --batch mb-0007 --step 120:0]
+        [--sample s-0 --group g-1 --batch mb-0007 --step 120:0 --rollout 120]
 
 inspect works on incomplete bundles (no COMPLETE required); validate
 and replay require a complete, checksum-validated bundle. replay
 supports selecting a single sample / group / micro-batch (each expands to its
 semantic-group closure); cohort-level stages (loss) are skipped for a partial
-selection. --step ROLLOUT_ID:STEP_ID selects that actor step: on a single
-bundle it asserts identity (step bundles match actor_step_id; rollout bundles
-match rollout_id); on a capture directory it picks the matching bundle.
+selection. --step ROLLOUT_ID:STEP_ID selects that actor step by exact
+actor_step_id match. --rollout ROLLOUT_ID selects a rollout-level bundle.
+On a capture directory, the matching bundle is picked; the two flags are
+mutually exclusive.
 """
 
 from __future__ import annotations
@@ -108,8 +109,11 @@ def _is_bundle(path: Path) -> bool:
 
 
 def _iter_bundles(root: Path) -> list[Path]:
-    """Return bundle directories under root (root itself, children, or rank-*
-    children)."""
+    """Return bundle directories under root.
+
+    A capture directory has complete bundles as children, or cohort directories
+    whose rank-* children are complete bundles.
+    """
     if _is_bundle(root):
         return [root]
     if not root.is_dir():
@@ -121,68 +125,110 @@ def _iter_bundles(root: Path) -> list[Path]:
         if _is_bundle(child):
             found.append(child)
             continue
-        if child.name.startswith("rank-"):
-            found.extend(path for path in sorted(child.iterdir()) if path.is_dir() and _is_bundle(path))
+        found.extend(
+            grandchild
+            for grandchild in sorted(child.iterdir())
+            if grandchild.is_dir() and grandchild.name.startswith("rank-") and _is_bundle(grandchild)
+        )
     return found
+
+
+def _cohort_complete(cohort_dir: Path) -> bool:
+    return (cohort_dir / "COMPLETE").is_file()
+
+
+def _cohort_expected_ranks(cohort_dir: Path) -> list[int] | None:
+    for path in sorted(cohort_dir.iterdir()):
+        if not path.name.startswith("COMPLETE.") or not path.is_file():
+            continue
+        shard = json.loads(path.read_text(encoding="utf-8"))
+        recorded = shard.get("expected_ranks")
+        if isinstance(recorded, list) and len(recorded) > 1:
+            return [int(rank) for rank in recorded]
+    return None
+
+
+def _select_matching_bundle(hits: list[Path], selector: str) -> Path:
+    """Pick one hit; multi-rank rank-* siblings require the cohort COMPLETE."""
+    parents = {path.parent for path in hits}
+    rank_local = all(path.name.startswith("rank-") for path in hits)
+    if rank_local and len(parents) == 1:
+        parent = next(iter(parents))
+        needs_complete = len(hits) > 1 or _cohort_expected_ranks(parent) is not None
+        if needs_complete and not _cohort_complete(parent):
+            raise ValueError(f"cohort {parent} is incomplete (missing COMPLETE) for {selector}")
+        return sorted(hits, key=lambda path: path.name)[0]
+    if len(hits) == 1:
+        return hits[0]
+    names = ", ".join(path.name for path in hits)
+    raise ValueError(f"multiple bundles match {selector}: {names}")
 
 
 def _load_index(bundle_path: Path):
     return index_from_dict(json.loads((bundle_path / "index.json").read_text(encoding="utf-8")))
 
 
-def _identity_matches_step(index, rollout_id: int, step_id: int) -> str | None:
-    """Return step, rollout, or None for how index matches the requested actor
-    step."""
+def _identity_matches_step(index, rollout_id: int, step_id: int) -> bool:
+    """True when index is the requested actor step (exact actor_step_id)."""
     actual = index.identity.actor_step_id
-    if actual is not None:
-        return "step" if (actual.rollout_id, actual.step_id) == (rollout_id, step_id) else None
-    if index.identity.rollout_id == rollout_id:
-        return "rollout"
-    return None
+    return actual is not None and (actual.rollout_id, actual.step_id) == (rollout_id, step_id)
 
 
-def _resolve_bundle(bundle_path: Path, step: str | None) -> Path:
+def _identity_matches_rollout(index, rollout_id: int) -> bool:
+    """True when index is a rollout-level bundle for rollout_id."""
+    return index.identity.actor_step_id is None and index.identity.rollout_id == rollout_id
+
+
+def _resolve_bundle(bundle_path: Path, step: str | None, rollout: int | None) -> Path:
     """Resolve a bundle path or a capture directory to one bundle."""
     if _is_bundle(bundle_path):
         return bundle_path
     bundles = _iter_bundles(bundle_path)
     if not bundles:
         raise FileNotFoundError(f"{bundle_path} is not a replay bundle (missing index.json / manifest.json)")
-    if step is None:
+    if step is None and rollout is None:
         if len(bundles) == 1:
             return bundles[0]
         raise ValueError(
-            f"{bundle_path} contains {len(bundles)} bundles; pass a specific bundle or --step ROLLOUT_ID:STEP_ID"
+            f"{bundle_path} contains {len(bundles)} bundles; pass a specific bundle, "
+            "--step ROLLOUT_ID:STEP_ID, or --rollout ROLLOUT_ID"
         )
-    parsed = _parse_step(step)
-    if parsed is None:
-        raise ValueError(f"invalid --step {step!r} (expected ROLLOUT_ID:STEP_ID)")
-    rollout_id, step_id = parsed
-    step_hits: list[Path] = []
-    rollout_hits: list[Path] = []
-    for path in bundles:
-        kind = _identity_matches_step(_load_index(path), rollout_id, step_id)
-        if kind == "step":
-            step_hits.append(path)
-        elif kind == "rollout":
-            rollout_hits.append(path)
-    hits = step_hits or rollout_hits
-    if len(hits) == 1:
-        return hits[0]
-    if len(hits) > 1:
-        names = ", ".join(path.name for path in hits)
-        raise ValueError(f"multiple bundles match actor step {rollout_id}:{step_id}: {names}")
-    raise ValueError(f"no bundle in {bundle_path} matches actor step {rollout_id}:{step_id}")
+    if step is not None and rollout is not None:
+        raise ValueError("--step and --rollout are mutually exclusive")
+    hits: list[Path] = []
+    if step is not None:
+        parsed = _parse_step(step)
+        if parsed is None:
+            raise ValueError(f"invalid --step {step!r} (expected ROLLOUT_ID:STEP_ID)")
+        rollout_id, step_id = parsed
+        hits = [path for path in bundles if _identity_matches_step(_load_index(path), rollout_id, step_id)]
+        selector = f"actor step {rollout_id}:{step_id}"
+    else:
+        assert rollout is not None
+        hits = [path for path in bundles if _identity_matches_rollout(_load_index(path), rollout)]
+        selector = f"rollout {rollout}"
+    if not hits:
+        raise ValueError(f"no bundle in {bundle_path} matches {selector}")
+    return _select_matching_bundle(hits, selector)
 
 
 def _replay(
-    bundle_path: Path, stages: str, sample: list[str], group: list[str], batch: list[str], step: str | None
+    bundle_path: Path,
+    stages: str,
+    sample: list[str],
+    group: list[str],
+    batch: list[str],
+    step: str | None,
+    rollout: int | None,
 ) -> int:
+    if step is not None and rollout is not None:
+        logger.error("--step and --rollout are mutually exclusive")
+        return 1
     if step is not None and _parse_step(step) is None:
         logger.error("invalid --step %r (expected ROLLOUT_ID:STEP_ID)", step)
         return 1
     try:
-        bundle_path = _resolve_bundle(bundle_path, step)
+        bundle_path = _resolve_bundle(bundle_path, step, rollout)
     except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
         logger.error("%s", exc)
         return 1
@@ -190,19 +236,34 @@ def _replay(
         parsed = _parse_step(step)
         assert parsed is not None
         rollout_id, step_id = parsed
-        if _identity_matches_step(_load_index(bundle_path), rollout_id, step_id) is None:
+        if not _identity_matches_step(_load_index(bundle_path), rollout_id, step_id):
             logger.error("bundle is not the requested actor step %d:%d", rollout_id, step_id)
+            return 1
+    if rollout is not None and not _identity_matches_rollout(_load_index(bundle_path), rollout):
+        logger.error("bundle is not the requested rollout %d", rollout)
+        return 1
+
+    requested_stages: frozenset[str] | None = None
+    if stages != "all":
+        requested_stages = frozenset(part.strip() for part in stages.split(",") if part.strip())
+        if not requested_stages:
+            logger.error("empty --stage filter")
             return 1
 
     try:
-        report = run_replay(bundle_path, sample_ids=sample or None, group_ids=group or None, batch_ids=batch or None)
+        report = run_replay(
+            bundle_path,
+            sample_ids=sample or None,
+            group_ids=group or None,
+            batch_ids=batch or None,
+            requested_stages=requested_stages,
+        )
     except Exception as exc:  # noqa: BLE001 — surface any replay failure to the user
         logger.error("replay failed: %s", exc)
         return 1
 
-    if stages != "all":
-        selected = set(stages.split(","))
-        report.stages = [stage for stage in report.stages if stage.stage in selected]
+    if requested_stages is not None:
+        report.stages = [stage for stage in report.stages if stage.stage in requested_stages]
 
     for line in _format_report(report).splitlines():
         logger.info("%s", line)
@@ -227,7 +288,13 @@ def build_parser() -> argparse.ArgumentParser:
     replay_parser.add_argument("--batch", action="append", default=[], help="micro-batch id to replay (repeatable)")
     replay_parser.add_argument(
         "--step",
-        help="select actor step ROLLOUT_ID:STEP_ID (assert on a bundle; pick from a capture directory)",
+        help="select actor step ROLLOUT_ID:STEP_ID by exact actor_step_id",
+    )
+    replay_parser.add_argument(
+        "--rollout",
+        type=int,
+        default=None,
+        help="select a rollout-level bundle by rollout_id",
     )
 
     return parser
@@ -240,7 +307,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "validate":
         return _validate(args.bundle)
     if args.command == "replay":
-        return _replay(args.bundle, args.stage, args.sample, args.group, args.batch, args.step)
+        return _replay(args.bundle, args.stage, args.sample, args.group, args.batch, args.step, args.rollout)
     return 1
 
 

--- a/relax/tools/trajectory_replay/cli.py
+++ b/relax/tools/trajectory_replay/cli.py
@@ -13,7 +13,9 @@ inspect works on incomplete bundles (no COMPLETE required); validate
 and replay require a complete, checksum-validated bundle. replay
 supports selecting a single sample / group / micro-batch (each expands to its
 semantic-group closure); cohort-level stages (loss) are skipped for a partial
-selection. --step asserts the bundle's actor-step coordinate.
+selection. --step ROLLOUT_ID:STEP_ID selects that actor step: on a single
+bundle it asserts identity (step bundles match actor_step_id; rollout bundles
+match rollout_id); on a capture directory it picks the matching bundle.
 """
 
 from __future__ import annotations
@@ -93,18 +95,102 @@ def _format_report(report: ReplayReport) -> str:
     return "\n".join(lines)
 
 
+def _parse_step(step: str) -> tuple[int, int] | None:
+    try:
+        rollout_id, step_id = (int(part) for part in step.split(":"))
+    except ValueError:
+        return None
+    return rollout_id, step_id
+
+
+def _is_bundle(path: Path) -> bool:
+    return (path / "index.json").is_file() and (path / "manifest.json").is_file()
+
+
+def _iter_bundles(root: Path) -> list[Path]:
+    """Return bundle directories under root (root itself, children, or rank-*
+    children)."""
+    if _is_bundle(root):
+        return [root]
+    if not root.is_dir():
+        return []
+    found: list[Path] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        if _is_bundle(child):
+            found.append(child)
+            continue
+        if child.name.startswith("rank-"):
+            found.extend(path for path in sorted(child.iterdir()) if path.is_dir() and _is_bundle(path))
+    return found
+
+
+def _load_index(bundle_path: Path):
+    return index_from_dict(json.loads((bundle_path / "index.json").read_text(encoding="utf-8")))
+
+
+def _identity_matches_step(index, rollout_id: int, step_id: int) -> str | None:
+    """Return step, rollout, or None for how index matches the requested actor
+    step."""
+    actual = index.identity.actor_step_id
+    if actual is not None:
+        return "step" if (actual.rollout_id, actual.step_id) == (rollout_id, step_id) else None
+    if index.identity.rollout_id == rollout_id:
+        return "rollout"
+    return None
+
+
+def _resolve_bundle(bundle_path: Path, step: str | None) -> Path:
+    """Resolve a bundle path or a capture directory to one bundle."""
+    if _is_bundle(bundle_path):
+        return bundle_path
+    bundles = _iter_bundles(bundle_path)
+    if not bundles:
+        raise FileNotFoundError(f"{bundle_path} is not a replay bundle (missing index.json / manifest.json)")
+    if step is None:
+        if len(bundles) == 1:
+            return bundles[0]
+        raise ValueError(
+            f"{bundle_path} contains {len(bundles)} bundles; pass a specific bundle or --step ROLLOUT_ID:STEP_ID"
+        )
+    parsed = _parse_step(step)
+    if parsed is None:
+        raise ValueError(f"invalid --step {step!r} (expected ROLLOUT_ID:STEP_ID)")
+    rollout_id, step_id = parsed
+    step_hits: list[Path] = []
+    rollout_hits: list[Path] = []
+    for path in bundles:
+        kind = _identity_matches_step(_load_index(path), rollout_id, step_id)
+        if kind == "step":
+            step_hits.append(path)
+        elif kind == "rollout":
+            rollout_hits.append(path)
+    hits = step_hits or rollout_hits
+    if len(hits) == 1:
+        return hits[0]
+    if len(hits) > 1:
+        names = ", ".join(path.name for path in hits)
+        raise ValueError(f"multiple bundles match actor step {rollout_id}:{step_id}: {names}")
+    raise ValueError(f"no bundle in {bundle_path} matches actor step {rollout_id}:{step_id}")
+
+
 def _replay(
     bundle_path: Path, stages: str, sample: list[str], group: list[str], batch: list[str], step: str | None
 ) -> int:
+    if step is not None and _parse_step(step) is None:
+        logger.error("invalid --step %r (expected ROLLOUT_ID:STEP_ID)", step)
+        return 1
+    try:
+        bundle_path = _resolve_bundle(bundle_path, step)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        logger.error("%s", exc)
+        return 1
     if step is not None:
-        try:
-            rollout_id, step_id = (int(part) for part in step.split(":"))
-        except ValueError:
-            logger.error("invalid --step %r (expected ROLLOUT_ID:STEP_ID)", step)
-            return 1
-        index = index_from_dict(json.loads((bundle_path / "index.json").read_text(encoding="utf-8")))
-        actual = index.identity.actor_step_id
-        if actual is None or (actual.rollout_id, actual.step_id) != (rollout_id, step_id):
+        parsed = _parse_step(step)
+        assert parsed is not None
+        rollout_id, step_id = parsed
+        if _identity_matches_step(_load_index(bundle_path), rollout_id, step_id) is None:
             logger.error("bundle is not the requested actor step %d:%d", rollout_id, step_id)
             return 1
 
@@ -139,7 +225,10 @@ def build_parser() -> argparse.ArgumentParser:
     replay_parser.add_argument("--sample", action="append", default=[], help="sample_id to replay (repeatable)")
     replay_parser.add_argument("--group", action="append", default=[], help="semantic group id to replay (repeatable)")
     replay_parser.add_argument("--batch", action="append", default=[], help="micro-batch id to replay (repeatable)")
-    replay_parser.add_argument("--step", help="assert bundle actor step is ROLLOUT_ID:STEP_ID")
+    replay_parser.add_argument(
+        "--step",
+        help="select actor step ROLLOUT_ID:STEP_ID (assert on a bundle; pick from a capture directory)",
+    )
 
     return parser
 

--- a/relax/tools/trajectory_replay/cli.py
+++ b/relax/tools/trajectory_replay/cli.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Command-line entry point for offline trajectory replay.
+
+Usage::
+
+    python -m relax.tools.trajectory_replay inspect  <bundle>
+    python -m relax.tools.trajectory_replay validate <bundle>
+    python -m relax.tools.trajectory_replay replay   <bundle> [--stage all]
+        [--sample s-0 --group g-1 --batch mb-0007 --step 120:0]
+
+``inspect`` works on incomplete bundles (no ``COMPLETE`` required); ``validate``
+and ``replay`` require a complete, checksum-validated bundle. ``replay``
+supports selecting a single sample / group / micro-batch (each expands to its
+semantic-group closure); cohort-level stages (loss) are skipped for a partial
+selection. ``--step`` asserts the bundle's actor-step coordinate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.report import ReplayReport
+from relax.utils.replay.runner import replay as run_replay
+from relax.utils.replay.schema import index_from_dict, manifest_from_dict
+from relax.utils.replay.validate import validate_bundle
+
+
+logger = get_logger(__name__)
+
+
+def _inspect(bundle_path: Path) -> int:
+    try:
+        manifest = manifest_from_dict(json.loads((bundle_path / "manifest.json").read_text(encoding="utf-8")))
+        index = index_from_dict(json.loads((bundle_path / "index.json").read_text(encoding="utf-8")))
+    except FileNotFoundError as exc:
+        logger.error("incomplete bundle: %s", exc)
+        return 1
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.error("invalid bundle metadata: %s", exc)
+        return 1
+
+    identity = index.identity
+    logger.info("bundle %s (format %s)", manifest.bundle_id, manifest.format_version)
+    if identity.actor_step_id is not None:
+        logger.info(
+            "actor step: rollout_id=%s step_id=%s", identity.actor_step_id.rollout_id, identity.actor_step_id.step_id
+        )
+    else:
+        logger.info("rollout: rollout_id=%s", identity.rollout_id)
+    logger.info("samples: %d", len(index.samples))
+    logger.info("producer commit: %s", manifest.producer.commit or "<unset>")
+    for stage, contract in sorted(manifest.stage_contracts.items()):
+        logger.info("stage %-20s version=%-4s capability=%s", stage.value, contract.version, contract.capability.value)
+    for name, spec in sorted(manifest.payloads.items()):
+        logger.info("payload %-24s %s shape=%s bytes=%d", name, spec.dtype, spec.shape, spec.bytes)
+    return 0
+
+
+def _validate(bundle_path: Path) -> int:
+    result = validate_bundle(bundle_path)
+    for message in result.warnings:
+        logger.warning("%s", message)
+    for message in result.errors:
+        logger.error("%s", message)
+    if result.valid:
+        logger.info("bundle valid: %s", bundle_path)
+        return 0
+    logger.error("bundle invalid: %s", bundle_path)
+    return 1
+
+
+def _format_report(report: ReplayReport) -> str:
+    lines = [f"bundle {report.bundle_id} — first divergent stage: {report.first_divergent_stage or '<none>'}", ""]
+    for result in report.stages:
+        line = f"[{result.status.value:>7}] {result.stage}"
+        if result.message:
+            line += f" — {result.message}"
+        if result.max_abs_error is not None:
+            line += f" (max_abs_error={result.max_abs_error:.3e}, mismatches={result.mismatch_count})"
+        lines.append(line)
+        for divergence in result.divergences:
+            where = divergence.sample_id or "-"
+            offset = f"@{divergence.token_offset}" if divergence.token_offset is not None else ""
+            lines.append(
+                f"          {divergence.field} {where}{offset}: expected={divergence.expected} "
+                f"actual={divergence.actual} abs_err={divergence.abs_error}"
+            )
+    return "\n".join(lines)
+
+
+def _replay(
+    bundle_path: Path, stages: str, sample: list[str], group: list[str], batch: list[str], step: str | None
+) -> int:
+    if step is not None:
+        try:
+            rollout_id, step_id = (int(part) for part in step.split(":"))
+        except ValueError:
+            logger.error("invalid --step %r (expected ROLLOUT_ID:STEP_ID)", step)
+            return 1
+        index = index_from_dict(json.loads((bundle_path / "index.json").read_text(encoding="utf-8")))
+        actual = index.identity.actor_step_id
+        if actual is None or (actual.rollout_id, actual.step_id) != (rollout_id, step_id):
+            logger.error("bundle is not the requested actor step %d:%d", rollout_id, step_id)
+            return 1
+
+    try:
+        report = run_replay(bundle_path, sample_ids=sample or None, group_ids=group or None, batch_ids=batch or None)
+    except Exception as exc:  # noqa: BLE001 — surface any replay failure to the user
+        logger.error("replay failed: %s", exc)
+        return 1
+
+    if stages != "all":
+        selected = set(stages.split(","))
+        report.stages = [stage for stage in report.stages if stage.stage in selected]
+
+    for line in _format_report(report).splitlines():
+        logger.info("%s", line)
+    return 0 if report.passed else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="relax.tools.trajectory_replay", description="Offline trajectory replay")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = subparsers.add_parser("inspect", help="show identity, capability and payload summary")
+    inspect_parser.add_argument("bundle", type=Path)
+
+    validate_parser = subparsers.add_parser("validate", help="validate format, integrity and closure")
+    validate_parser.add_argument("bundle", type=Path)
+
+    replay_parser = subparsers.add_parser("replay", help="recompute stages and compare against expected outputs")
+    replay_parser.add_argument("bundle", type=Path)
+    replay_parser.add_argument("--stage", default="all", help="comma-separated stage filter (default: all)")
+    replay_parser.add_argument("--sample", action="append", default=[], help="sample_id to replay (repeatable)")
+    replay_parser.add_argument("--group", action="append", default=[], help="semantic group id to replay (repeatable)")
+    replay_parser.add_argument("--batch", action="append", default=[], help="micro-batch id to replay (repeatable)")
+    replay_parser.add_argument("--step", help="assert bundle actor step is ROLLOUT_ID:STEP_ID")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "inspect":
+        return _inspect(args.bundle)
+    if args.command == "validate":
+        return _validate(args.bundle)
+    if args.command == "replay":
+        return _replay(args.bundle, args.stage, args.sample, args.group, args.batch, args.step)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/relax/utils/env.py
+++ b/relax/utils/env.py
@@ -229,6 +229,16 @@ class Envs(metaclass=_EnvsMeta):
     RELAX_TGD_PROFILE = EnvProperty("RELAX_TGD_PROFILE", bool, False)
     RELAX_TGD_PROFILE_EVERY = EnvProperty("RELAX_TGD_PROFILE_EVERY", int, 50)
 
+    # ------------- Trajectory replay capture -------------
+    # Opt-in production capture. MegatronTrainRayActor.init calls
+    # maybe_enable_from_env — no CLI argument-parsing change.
+    RELAX_REPLAY_CAPTURE = EnvProperty("RELAX_REPLAY_CAPTURE", bool, False)
+    RELAX_REPLAY_CAPTURE_DIR = EnvProperty("RELAX_REPLAY_CAPTURE_DIR", str, None)
+    # Comma-separated actor steps as ROLLOUT_ID:STEP_ID (e.g. "0:0,0:1"). Unset = all.
+    RELAX_REPLAY_CAPTURE_STEPS = EnvProperty("RELAX_REPLAY_CAPTURE_STEPS", str, None)
+    # Comma-separated rollout ids (e.g. "0,1"). Unset = all.
+    RELAX_REPLAY_CAPTURE_ROLLOUTS = EnvProperty("RELAX_REPLAY_CAPTURE_ROLLOUTS", str, None)
+
     # ------------- SGLang Speculative Decoding & External Packages -----------
     SGLANG_ENABLE_SPEC_V2 = EnvProperty("SGLANG_ENABLE_SPEC_V2", str, "")
     SGLANG_EXTERNAL_MODEL_PACKAGE = EnvProperty("SGLANG_EXTERNAL_MODEL_PACKAGE", str, None)

--- a/relax/utils/replay/__init__.py
+++ b/relax/utils/replay/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Offline trajectory replay (Task 34) — versioned, self-verifying bundles.
+
+This package contains only additive, offline code. It must never import Ray
+Serve, SGLang, Megatron runtime or start a distributed process group so that a
+replay bundle can be inspected, validated and replayed on a plain CPU host.
+"""
+
+from relax.utils.replay.schema import FORMAT_MAJOR, FORMAT_VERSION
+
+
+__all__ = ["FORMAT_MAJOR", "FORMAT_VERSION"]

--- a/relax/utils/replay/adapters/__init__.py
+++ b/relax/utils/replay/adapters/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Replay adapters.
+
+Each adapter recomputes one pipeline stage from bundle inputs (``bundle.index``
++ ``bundle.tensors``) and upstream recomputed outputs (``ctx``), then compares
+against the bundle's expected outputs. Importing this package registers every
+adapter into :mod:`relax.utils.replay.stages`.
+"""
+
+from __future__ import annotations
+
+from relax.utils.replay.adapters import advantage, loss, reward, sample  # noqa: F401
+
+
+def register_all() -> None:
+    """Ensure every adapter module is imported (and thus registered)."""
+    # Importing this package at module import time already registers adapters;
+    # this function exists as an explicit, documented entry point.
+    return None

--- a/relax/utils/replay/adapters/__init__.py
+++ b/relax/utils/replay/adapters/__init__.py
@@ -2,10 +2,10 @@
 
 """Replay adapters.
 
-Each adapter recomputes one pipeline stage from bundle inputs (``bundle.index``
-+ ``bundle.tensors``) and upstream recomputed outputs (``ctx``), then compares
-against the bundle's expected outputs. Importing this package registers every
-adapter into :mod:`relax.utils.replay.stages`.
+Each adapter recomputes one pipeline stage from bundle inputs (bundle.index +
+bundle.tensors) and upstream recomputed outputs (ctx), then compares against
+the bundle's expected outputs. Importing this package registers every adapter
+into relax.utils.replay.stages.
 """
 
 from __future__ import annotations
@@ -14,7 +14,5 @@ from relax.utils.replay.adapters import advantage, loss, reward, sample  # noqa:
 
 
 def register_all() -> None:
-    """Ensure every adapter module is imported (and thus registered)."""
-    # Importing this package at module import time already registers adapters;
-    # this function exists as an explicit, documented entry point.
-    return None
+    """Adapters register on import of this package; this is the explicit
+    hook."""

--- a/relax/utils/replay/adapters/advantage.py
+++ b/relax/utils/replay/adapters/advantage.py
@@ -2,10 +2,8 @@
 
 """Advantage-stage replay adapters.
 
-These reuse the pure tensor kernels from ``relax.utils.training.ppo_utils``
-(``compute_approx_kl``, ``get_grpo_returns``) — single source of truth, no
-production math restated here. ``ppo_utils`` imports only ``torch`` and
-``torch.distributed`` at module scope, so it is safe to import offline.
+Reuses compute_approx_kl / get_grpo_returns from relax.utils.training.ppo_utils
+(torch-only imports, safe offline).
 """
 
 from __future__ import annotations
@@ -14,77 +12,45 @@ from typing import Any
 
 import torch
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.bundle import LoadedBundle
-from relax.utils.replay.compare import compare_tensors, tolerance_for
+from relax.utils.replay.compare import report_tensor, tolerance_for
 from relax.utils.replay.report import StageResult, StageStatus
 from relax.utils.replay.schema import StageId
 from relax.utils.replay.stages import register_adapter
 from relax.utils.training.ppo_utils import compute_approx_kl, get_grpo_returns
 
 
-logger = get_logger(__name__)
-
-
-def _sample_ids(bundle: LoadedBundle) -> list[str]:
-    return [record.sample_id for record in bundle.index.samples]
-
-
-def _response_lengths(bundle: LoadedBundle) -> list[int]:
-    return [record.response_length for record in bundle.index.samples]
-
-
 @register_adapter(StageId.ADVANTAGE_KL)
 def replay_advantage_kl(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
-    """Recompute per-token approximate KL between rollout and reference log-
-    probs.
-
-    Matches production ``compute_advantages_and_returns``: the operands are the
-    rollout/old-policy log-probs (``old_log_probs``) and the frozen reference-
-    policy log-probs (``ref_log_probs``) — *not* current vs old.
-    """
+    """Per-token KL between rollout/old log-probs and reference log-probs."""
     config = bundle.index.config
     result = StageResult(stage=StageId.ADVANTAGE_KL.value, status=StageStatus.PASS)
 
     old_log_probs = bundle.tensors["old_log_probs"]
-    ref_log_probs = bundle.tensors["ref_log_probs"]
-
     if config.kl_coef == 0:
         kl = torch.zeros_like(old_log_probs, dtype=torch.float32)
     else:
-        kl = compute_approx_kl(old_log_probs, ref_log_probs, kl_loss_type=config.kl_loss_type)
+        kl = compute_approx_kl(old_log_probs, bundle.tensors["ref_log_probs"], kl_loss_type=config.kl_loss_type)
 
     ctx[StageId.ADVANTAGE_KL.value] = kl
-
-    expected = bundle.tensors.get("kl")
-    if expected is None:
-        result.message = "no expected kl payload recorded"
-        return result
-
     atol, rtol = tolerance_for(bundle.manifest, StageId.ADVANTAGE_KL)
-    divergences, max_err, mismatches, non_finite = compare_tensors(
-        expected,
-        kl,
+    return report_tensor(
+        result,
+        expected=bundle.tensors.get("kl"),
+        actual=kl,
         field="kl",
         atol=atol,
         rtol=rtol,
-        sample_ids=_sample_ids(bundle),
-        response_lengths=_response_lengths(bundle),
+        sample_ids=bundle.sample_ids,
+        response_lengths=bundle.response_lengths,
+        missing="no expected kl payload recorded",
+        mismatch="{n} kl token(s) diverged",
     )
-    result.divergences = divergences
-    result.max_abs_error = max_err
-    result.mismatch_count = mismatches
-    result.non_finite_count = non_finite
-    if mismatches or non_finite:
-        result.status = StageStatus.FAIL
-        result.message = f"{mismatches} kl token(s) diverged"
-    return result
 
 
 @register_adapter(StageId.ADVANTAGE_ESTIMATE)
 def replay_advantage_estimate(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
-    """Recompute GRPO-family returns/advantages from normalized rewards +
-    KL."""
+    """GRPO-family returns/advantages from normalized rewards + KL."""
     result = StageResult(stage=StageId.ADVANTAGE_ESTIMATE.value, status=StageStatus.PASS)
 
     normalized_rewards = ctx.get(StageId.REWARD_POST_PROCESS.value)
@@ -92,7 +58,6 @@ def replay_advantage_estimate(bundle: LoadedBundle, ctx: dict[str, Any]) -> Stag
         result.status = StageStatus.FAIL
         result.message = "upstream reward.post_process output missing"
         return result
-
     kl = ctx.get(StageId.ADVANTAGE_KL.value)
     if kl is None:
         result.status = StageStatus.FAIL
@@ -100,32 +65,19 @@ def replay_advantage_estimate(bundle: LoadedBundle, ctx: dict[str, Any]) -> Stag
         return result
 
     rewards = torch.tensor(normalized_rewards, dtype=torch.float32)
-    kl_per_sample = list(torch.split(kl, _response_lengths(bundle)))
-    returns = get_grpo_returns(rewards, kl_per_sample)
-    advantages = torch.cat(returns)
-
+    advantages = torch.cat(get_grpo_returns(rewards, list(torch.split(kl, bundle.response_lengths))))
     ctx[StageId.ADVANTAGE_ESTIMATE.value] = advantages
 
-    expected = bundle.tensors.get("advantages")
-    if expected is None:
-        result.message = "no expected advantages payload recorded"
-        return result
-
     atol, rtol = tolerance_for(bundle.manifest, StageId.ADVANTAGE_ESTIMATE)
-    divergences, max_err, mismatches, non_finite = compare_tensors(
-        expected,
-        advantages,
+    return report_tensor(
+        result,
+        expected=bundle.tensors.get("advantages"),
+        actual=advantages,
         field="advantages",
         atol=atol,
         rtol=rtol,
-        sample_ids=_sample_ids(bundle),
-        response_lengths=_response_lengths(bundle),
+        sample_ids=bundle.sample_ids,
+        response_lengths=bundle.response_lengths,
+        missing="no expected advantages payload recorded",
+        mismatch="{n} advantage token(s) diverged",
     )
-    result.divergences = divergences
-    result.max_abs_error = max_err
-    result.mismatch_count = mismatches
-    result.non_finite_count = non_finite
-    if mismatches or non_finite:
-        result.status = StageStatus.FAIL
-        result.message = f"{mismatches} advantage token(s) diverged"
-    return result

--- a/relax/utils/replay/adapters/advantage.py
+++ b/relax/utils/replay/adapters/advantage.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Advantage-stage replay adapters.
+
+These reuse the pure tensor kernels from ``relax.utils.training.ppo_utils``
+(``compute_approx_kl``, ``get_grpo_returns``) — single source of truth, no
+production math restated here. ``ppo_utils`` imports only ``torch`` and
+``torch.distributed`` at module scope, so it is safe to import offline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.bundle import LoadedBundle
+from relax.utils.replay.compare import compare_tensors, tolerance_for
+from relax.utils.replay.report import StageResult, StageStatus
+from relax.utils.replay.schema import StageId
+from relax.utils.replay.stages import register_adapter
+from relax.utils.training.ppo_utils import compute_approx_kl, get_grpo_returns
+
+
+logger = get_logger(__name__)
+
+
+def _sample_ids(bundle: LoadedBundle) -> list[str]:
+    return [record.sample_id for record in bundle.index.samples]
+
+
+def _response_lengths(bundle: LoadedBundle) -> list[int]:
+    return [record.response_length for record in bundle.index.samples]
+
+
+@register_adapter(StageId.ADVANTAGE_KL)
+def replay_advantage_kl(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
+    """Recompute per-token approximate KL between rollout and reference log-
+    probs.
+
+    Matches production ``compute_advantages_and_returns``: the operands are the
+    rollout/old-policy log-probs (``old_log_probs``) and the frozen reference-
+    policy log-probs (``ref_log_probs``) — *not* current vs old.
+    """
+    config = bundle.index.config
+    result = StageResult(stage=StageId.ADVANTAGE_KL.value, status=StageStatus.PASS)
+
+    old_log_probs = bundle.tensors["old_log_probs"]
+    ref_log_probs = bundle.tensors["ref_log_probs"]
+
+    if config.kl_coef == 0:
+        kl = torch.zeros_like(old_log_probs, dtype=torch.float32)
+    else:
+        kl = compute_approx_kl(old_log_probs, ref_log_probs, kl_loss_type=config.kl_loss_type)
+
+    ctx[StageId.ADVANTAGE_KL.value] = kl
+
+    expected = bundle.tensors.get("kl")
+    if expected is None:
+        result.message = "no expected kl payload recorded"
+        return result
+
+    atol, rtol = tolerance_for(bundle.manifest, StageId.ADVANTAGE_KL)
+    divergences, max_err, mismatches, non_finite = compare_tensors(
+        expected,
+        kl,
+        field="kl",
+        atol=atol,
+        rtol=rtol,
+        sample_ids=_sample_ids(bundle),
+        response_lengths=_response_lengths(bundle),
+    )
+    result.divergences = divergences
+    result.max_abs_error = max_err
+    result.mismatch_count = mismatches
+    result.non_finite_count = non_finite
+    if mismatches or non_finite:
+        result.status = StageStatus.FAIL
+        result.message = f"{mismatches} kl token(s) diverged"
+    return result
+
+
+@register_adapter(StageId.ADVANTAGE_ESTIMATE)
+def replay_advantage_estimate(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
+    """Recompute GRPO-family returns/advantages from normalized rewards +
+    KL."""
+    result = StageResult(stage=StageId.ADVANTAGE_ESTIMATE.value, status=StageStatus.PASS)
+
+    normalized_rewards = ctx.get(StageId.REWARD_POST_PROCESS.value)
+    if normalized_rewards is None:
+        result.status = StageStatus.FAIL
+        result.message = "upstream reward.post_process output missing"
+        return result
+
+    kl = ctx.get(StageId.ADVANTAGE_KL.value)
+    if kl is None:
+        result.status = StageStatus.FAIL
+        result.message = "upstream advantage.kl output missing"
+        return result
+
+    rewards = torch.tensor(normalized_rewards, dtype=torch.float32)
+    kl_per_sample = list(torch.split(kl, _response_lengths(bundle)))
+    returns = get_grpo_returns(rewards, kl_per_sample)
+    advantages = torch.cat(returns)
+
+    ctx[StageId.ADVANTAGE_ESTIMATE.value] = advantages
+
+    expected = bundle.tensors.get("advantages")
+    if expected is None:
+        result.message = "no expected advantages payload recorded"
+        return result
+
+    atol, rtol = tolerance_for(bundle.manifest, StageId.ADVANTAGE_ESTIMATE)
+    divergences, max_err, mismatches, non_finite = compare_tensors(
+        expected,
+        advantages,
+        field="advantages",
+        atol=atol,
+        rtol=rtol,
+        sample_ids=_sample_ids(bundle),
+        response_lengths=_response_lengths(bundle),
+    )
+    result.divergences = divergences
+    result.max_abs_error = max_err
+    result.mismatch_count = mismatches
+    result.non_finite_count = non_finite
+    if mismatches or non_finite:
+        result.status = StageStatus.FAIL
+        result.message = f"{mismatches} advantage token(s) diverged"
+    return result

--- a/relax/utils/replay/adapters/loss.py
+++ b/relax/utils/replay/adapters/loss.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Policy-loss replay adapter.
+
+Reuses ``compute_policy_loss`` from ``relax.utils.training.ppo_utils`` and
+restates only the CP=1 reduction semantics from
+``relax.backends.megatron.cp_utils.get_sum_of_sample_mean`` (per-sample masked
+mean, then summed — a plain-CPU computation with no collective). KL-loss, OPD
+and TIS paths are outside the frozen V1 scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.bundle import LoadedBundle
+from relax.utils.replay.compare import compare_scalar, scalar_error, tolerance_for
+from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
+from relax.utils.replay.schema import StageId
+from relax.utils.replay.stages import register_adapter
+from relax.utils.training.ppo_utils import compute_policy_loss
+
+
+logger = get_logger(__name__)
+
+
+def _sum_of_sample_mean(x: torch.Tensor, response_lengths: list[int], loss_masks: list[list[int]]) -> torch.Tensor:
+    """CP=1 ``sum_of_sample_mean``: per-sample masked mean, summed over
+    samples."""
+    total = 0.0
+    for chunk, mask in zip(torch.split(x, response_lengths), loss_masks, strict=False):
+        mask_t = torch.tensor(mask, dtype=x.dtype, device=x.device)
+        denominator = torch.clamp_min(mask_t.sum(), 1)
+        total = total + (chunk * mask_t).sum() / denominator
+    return total
+
+
+@register_adapter(StageId.LOSS_POLICY)
+def replay_loss_policy(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
+    """Recompute the GRPO policy loss and its reduction metrics."""
+    config = bundle.index.config
+    result = StageResult(stage=StageId.LOSS_POLICY.value, status=StageStatus.PASS)
+
+    advantages = ctx.get(StageId.ADVANTAGE_ESTIMATE.value)
+    if advantages is None:
+        # Partial capture (loss-only): fall back to the recorded advantages
+        # tensor, which is the loss stage's actual input. Full-chain replays
+        # still use ctx so upstream divergence propagates (see spec §5.9.2).
+        advantages = bundle.tensors.get("advantages")
+    if advantages is None:
+        result.status = StageStatus.FAIL
+        result.message = "upstream advantage.estimate output missing"
+        return result
+
+    old_log_probs = bundle.tensors["old_log_probs"]
+    log_probs = bundle.tensors["log_probs"]
+    entropy = bundle.tensors["entropy"]
+
+    response_lengths = [record.response_length for record in bundle.index.samples]
+    loss_masks = [record.loss_mask for record in bundle.index.samples]
+
+    ppo_kl = old_log_probs - log_probs
+    pg_loss, clipfrac = compute_policy_loss(ppo_kl, advantages, config.eps_clip, config.eps_clip_high)
+
+    pg_loss_scalar = _sum_of_sample_mean(pg_loss, response_lengths, loss_masks)
+    clipfrac_scalar = _sum_of_sample_mean(clipfrac, response_lengths, loss_masks)
+    ppo_kl_scalar = _sum_of_sample_mean(ppo_kl, response_lengths, loss_masks)
+    entropy_loss = _sum_of_sample_mean(entropy, response_lengths, loss_masks)
+    loss = pg_loss_scalar - config.entropy_coef * entropy_loss
+
+    recomputed = {
+        "loss": float(loss.item()),
+        "pg_loss": float(pg_loss_scalar.item()),
+        "entropy_loss": float(entropy_loss.item()),
+        "pg_clipfrac": float(clipfrac_scalar.item()),
+        "ppo_kl": float(ppo_kl_scalar.item()),
+    }
+
+    expected = bundle.expected.get(StageId.LOSS_POLICY.value)
+    if expected is None:
+        result.message = "no expected loss metrics recorded"
+        return result
+
+    atol, rtol = tolerance_for(bundle.manifest, StageId.LOSS_POLICY)
+    for field, actual_value in recomputed.items():
+        expected_value = expected.get(field)
+        if expected_value is None:
+            continue
+        if not compare_scalar(float(expected_value), float(actual_value), atol=atol, rtol=rtol):
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(
+                    field=field,
+                    expected=float(expected_value),
+                    actual=float(actual_value),
+                    abs_error=scalar_error(float(expected_value), float(actual_value)),
+                )
+            )
+    if result.status == StageStatus.FAIL:
+        result.message = f"loss divergence in fields {[d.field for d in result.divergences]}"
+    return result

--- a/relax/utils/replay/adapters/loss.py
+++ b/relax/utils/replay/adapters/loss.py
@@ -2,11 +2,8 @@
 
 """Policy-loss replay adapter.
 
-Reuses ``compute_policy_loss`` from ``relax.utils.training.ppo_utils`` and
-restates only the CP=1 reduction semantics from
-``relax.backends.megatron.cp_utils.get_sum_of_sample_mean`` (per-sample masked
-mean, then summed — a plain-CPU computation with no collective). KL-loss, OPD
-and TIS paths are outside the frozen V1 scope.
+Reuses compute_policy_loss and restates CP=1 sum_of_sample_mean (per-sample
+masked mean, then summed). KL-loss, OPD and TIS are out of V1.
 """
 
 from __future__ import annotations
@@ -15,21 +12,16 @@ from typing import Any
 
 import torch
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.bundle import LoadedBundle
-from relax.utils.replay.compare import compare_scalar, scalar_error, tolerance_for
-from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
+from relax.utils.replay.compare import report_scalar_fields, tolerance_for
+from relax.utils.replay.report import StageResult, StageStatus
 from relax.utils.replay.schema import StageId
 from relax.utils.replay.stages import register_adapter
 from relax.utils.training.ppo_utils import compute_policy_loss
 
 
-logger = get_logger(__name__)
-
-
 def _sum_of_sample_mean(x: torch.Tensor, response_lengths: list[int], loss_masks: list[list[int]]) -> torch.Tensor:
-    """CP=1 ``sum_of_sample_mean``: per-sample masked mean, summed over
-    samples."""
+    """CP=1 sum_of_sample_mean: per-sample masked mean, summed over samples."""
     total = 0.0
     for chunk, mask in zip(torch.split(x, response_lengths), loss_masks, strict=False):
         mask_t = torch.tensor(mask, dtype=x.dtype, device=x.device)
@@ -46,9 +38,8 @@ def replay_loss_policy(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult
 
     advantages = ctx.get(StageId.ADVANTAGE_ESTIMATE.value)
     if advantages is None:
-        # Partial capture (loss-only): fall back to the recorded advantages
-        # tensor, which is the loss stage's actual input. Full-chain replays
-        # still use ctx so upstream divergence propagates (see spec §5.9.2).
+        # Loss-only capture: recorded advantages are the stage input. Full-chain
+        # replays still prefer ctx so upstream divergence propagates.
         advantages = bundle.tensors.get("advantages")
     if advantages is None:
         result.status = StageStatus.FAIL
@@ -58,47 +49,29 @@ def replay_loss_policy(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult
     old_log_probs = bundle.tensors["old_log_probs"]
     log_probs = bundle.tensors["log_probs"]
     entropy = bundle.tensors["entropy"]
-
-    response_lengths = [record.response_length for record in bundle.index.samples]
     loss_masks = [record.loss_mask for record in bundle.index.samples]
 
     ppo_kl = old_log_probs - log_probs
     pg_loss, clipfrac = compute_policy_loss(ppo_kl, advantages, config.eps_clip, config.eps_clip_high)
 
-    pg_loss_scalar = _sum_of_sample_mean(pg_loss, response_lengths, loss_masks)
-    clipfrac_scalar = _sum_of_sample_mean(clipfrac, response_lengths, loss_masks)
-    ppo_kl_scalar = _sum_of_sample_mean(ppo_kl, response_lengths, loss_masks)
-    entropy_loss = _sum_of_sample_mean(entropy, response_lengths, loss_masks)
-    loss = pg_loss_scalar - config.entropy_coef * entropy_loss
-
-    recomputed = {
-        "loss": float(loss.item()),
-        "pg_loss": float(pg_loss_scalar.item()),
-        "entropy_loss": float(entropy_loss.item()),
-        "pg_clipfrac": float(clipfrac_scalar.item()),
-        "ppo_kl": float(ppo_kl_scalar.item()),
-    }
-
-    expected = bundle.expected.get(StageId.LOSS_POLICY.value)
-    if expected is None:
-        result.message = "no expected loss metrics recorded"
-        return result
+    pg_loss_scalar = _sum_of_sample_mean(pg_loss, bundle.response_lengths, loss_masks)
+    clipfrac_scalar = _sum_of_sample_mean(clipfrac, bundle.response_lengths, loss_masks)
+    ppo_kl_scalar = _sum_of_sample_mean(ppo_kl, bundle.response_lengths, loss_masks)
+    entropy_loss = _sum_of_sample_mean(entropy, bundle.response_lengths, loss_masks)
 
     atol, rtol = tolerance_for(bundle.manifest, StageId.LOSS_POLICY)
-    for field, actual_value in recomputed.items():
-        expected_value = expected.get(field)
-        if expected_value is None:
-            continue
-        if not compare_scalar(float(expected_value), float(actual_value), atol=atol, rtol=rtol):
-            result.status = StageStatus.FAIL
-            result.divergences.append(
-                FieldDivergence(
-                    field=field,
-                    expected=float(expected_value),
-                    actual=float(actual_value),
-                    abs_error=scalar_error(float(expected_value), float(actual_value)),
-                )
-            )
-    if result.status == StageStatus.FAIL:
-        result.message = f"loss divergence in fields {[d.field for d in result.divergences]}"
-    return result
+    return report_scalar_fields(
+        result,
+        expected=bundle.expected.get(StageId.LOSS_POLICY.value),
+        actual={
+            "loss": float((pg_loss_scalar - config.entropy_coef * entropy_loss).item()),
+            "pg_loss": float(pg_loss_scalar.item()),
+            "entropy_loss": float(entropy_loss.item()),
+            "pg_clipfrac": float(clipfrac_scalar.item()),
+            "ppo_kl": float(ppo_kl_scalar.item()),
+        },
+        atol=atol,
+        rtol=rtol,
+        missing="no expected loss metrics recorded",
+        mismatch="loss divergence in fields {fields}",
+    )

--- a/relax/utils/replay/adapters/reward.py
+++ b/relax/utils/replay/adapters/reward.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Reward-stage replay adapters.
+
+``reward.post_process`` restates the group normalization from
+``relax.utils.utils.post_process_rewards``. That production function lives in a
+module that imports Ray at module scope, so the offline runner cannot reuse it
+directly without pulling Ray into the CPU path; instead we restate the (small,
+stable) group-norm here and pin its semantics with the PR #65 parity fixture.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.bundle import LoadedBundle
+from relax.utils.replay.compare import compare_scalar, scalar_error, tolerance_for
+from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
+from relax.utils.replay.schema import StageId
+from relax.utils.replay.stages import register_adapter
+
+
+logger = get_logger(__name__)
+
+
+@register_adapter(StageId.REWARD_RAW)
+def replay_reward_raw(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
+    """Resolve the raw reward per sample.
+
+    V1 covers scalar rewards only (no ``reward_key``), so the resolved reward
+    is the sample's own scalar. Recompute equals the recorded value; divergence
+    here signals a record/identity integrity problem.
+    """
+    result = StageResult(stage=StageId.REWARD_RAW.value, status=StageStatus.PASS)
+    expected = bundle.expected.get(StageId.REWARD_RAW.value, {}).get("raw_rewards")
+    actual = [record.raw_reward for record in bundle.index.samples]
+
+    if expected is None:
+        result.message = "no expected raw_rewards recorded"
+        return result
+
+    atol, rtol = tolerance_for(bundle.manifest, StageId.REWARD_RAW)
+    for index, (exp, act) in enumerate(zip(expected, actual, strict=False)):
+        if not compare_scalar(float(exp), float(act), atol=atol, rtol=rtol):
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(
+                    field="raw_reward",
+                    sample_id=bundle.index.samples[index].sample_id,
+                    expected=float(exp),
+                    actual=float(act),
+                    abs_error=scalar_error(float(exp), float(act)),
+                )
+            )
+    if result.status == StageStatus.FAIL:
+        result.message = f"raw reward mismatch in {len(result.divergences)} sample(s)"
+    return result
+
+
+@register_adapter(StageId.REWARD_POST_PROCESS)
+def replay_reward_post_process(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
+    """Recompute group-normalized rewards (PR #65 semantics).
+
+    Mirrors ``relax.utils.utils.post_process_rewards``: group by
+    ``group_index`` (never by physical batch), subtract the group mean,
+    optionally divide by the group std (``+1e-6`` floor), and reject groups
+    whose size differs from ``n_samples_per_prompt``.
+    """
+    config = bundle.index.config
+    raw_rewards = [record.raw_reward for record in bundle.index.samples]
+    result = StageResult(stage=StageId.REWARD_POST_PROCESS.value, status=StageStatus.PASS)
+
+    rewards = torch.tensor(raw_rewards, dtype=torch.float)
+    positions_by_group: dict[int, list[int]] = {}
+    for position, record in enumerate(bundle.index.samples):
+        if record.group_index is None:
+            result.status = StageStatus.FAIL
+            result.message = f"sample {record.sample_id!r} has no group_index"
+            return result
+        positions_by_group.setdefault(record.group_index, []).append(position)
+
+    normalized = torch.empty_like(rewards)
+    for group_index, positions in positions_by_group.items():
+        if len(positions) != config.n_samples_per_prompt:
+            result.status = StageStatus.FAIL
+            result.message = (
+                f"reward group {group_index} has {len(positions)} samples, expected {config.n_samples_per_prompt}"
+            )
+            return result
+        group_rewards = rewards[positions]
+        group_rewards = group_rewards - group_rewards.mean()
+        if config.grpo_std_normalization:
+            group_rewards = group_rewards / (group_rewards.std() + 1e-6)
+        normalized[positions] = group_rewards
+
+    ctx[StageId.REWARD_POST_PROCESS.value] = normalized.tolist()
+
+    expected = bundle.expected.get(StageId.REWARD_POST_PROCESS.value, {}).get("rewards")
+    if expected is None:
+        result.message = "no expected normalized rewards recorded"
+        return result
+
+    atol, rtol = tolerance_for(bundle.manifest, StageId.REWARD_POST_PROCESS)
+    for index, (exp, act) in enumerate(zip(expected, normalized.tolist(), strict=False)):
+        if not compare_scalar(float(exp), float(act), atol=atol, rtol=rtol):
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(
+                    field="reward",
+                    sample_id=bundle.index.samples[index].sample_id,
+                    expected=float(exp),
+                    actual=float(act),
+                    abs_error=scalar_error(float(exp), float(act)),
+                )
+            )
+    if result.status == StageStatus.FAIL:
+        result.message = f"normalized reward mismatch in {len(result.divergences)} sample(s)"
+    return result

--- a/relax/utils/replay/adapters/reward.py
+++ b/relax/utils/replay/adapters/reward.py
@@ -2,11 +2,9 @@
 
 """Reward-stage replay adapters.
 
-``reward.post_process`` restates the group normalization from
-``relax.utils.utils.post_process_rewards``. That production function lives in a
-module that imports Ray at module scope, so the offline runner cannot reuse it
-directly without pulling Ray into the CPU path; instead we restate the (small,
-stable) group-norm here and pin its semantics with the PR #65 parity fixture.
+reward.post_process restates group normalization from
+relax.utils.utils.post_process_rewards (that module imports Ray at import
+time). Semantics are pinned by the PR #65 fixture.
 """
 
 from __future__ import annotations
@@ -15,65 +13,38 @@ from typing import Any
 
 import torch
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.bundle import LoadedBundle
-from relax.utils.replay.compare import compare_scalar, scalar_error, tolerance_for
-from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
+from relax.utils.replay.compare import report_scalar_list, tolerance_for
+from relax.utils.replay.report import StageResult, StageStatus
 from relax.utils.replay.schema import StageId
 from relax.utils.replay.stages import register_adapter
 
 
-logger = get_logger(__name__)
-
-
 @register_adapter(StageId.REWARD_RAW)
 def replay_reward_raw(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
-    """Resolve the raw reward per sample.
-
-    V1 covers scalar rewards only (no ``reward_key``), so the resolved reward
-    is the sample's own scalar. Recompute equals the recorded value; divergence
-    here signals a record/identity integrity problem.
-    """
+    """Resolve the raw reward per sample (V1: scalar rewards only)."""
     result = StageResult(stage=StageId.REWARD_RAW.value, status=StageStatus.PASS)
-    expected = bundle.expected.get(StageId.REWARD_RAW.value, {}).get("raw_rewards")
-    actual = [record.raw_reward for record in bundle.index.samples]
-
-    if expected is None:
-        result.message = "no expected raw_rewards recorded"
-        return result
-
     atol, rtol = tolerance_for(bundle.manifest, StageId.REWARD_RAW)
-    for index, (exp, act) in enumerate(zip(expected, actual, strict=False)):
-        if not compare_scalar(float(exp), float(act), atol=atol, rtol=rtol):
-            result.status = StageStatus.FAIL
-            result.divergences.append(
-                FieldDivergence(
-                    field="raw_reward",
-                    sample_id=bundle.index.samples[index].sample_id,
-                    expected=float(exp),
-                    actual=float(act),
-                    abs_error=scalar_error(float(exp), float(act)),
-                )
-            )
-    if result.status == StageStatus.FAIL:
-        result.message = f"raw reward mismatch in {len(result.divergences)} sample(s)"
-    return result
+    return report_scalar_list(
+        result,
+        expected=bundle.expected.get(StageId.REWARD_RAW.value, {}).get("raw_rewards"),
+        actual=[record.raw_reward for record in bundle.index.samples],
+        sample_ids=bundle.sample_ids,
+        field="raw_reward",
+        atol=atol,
+        rtol=rtol,
+        missing="no expected raw_rewards recorded",
+        mismatch="raw reward mismatch in {n} sample(s)",
+    )
 
 
 @register_adapter(StageId.REWARD_POST_PROCESS)
 def replay_reward_post_process(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
-    """Recompute group-normalized rewards (PR #65 semantics).
-
-    Mirrors ``relax.utils.utils.post_process_rewards``: group by
-    ``group_index`` (never by physical batch), subtract the group mean,
-    optionally divide by the group std (``+1e-6`` floor), and reject groups
-    whose size differs from ``n_samples_per_prompt``.
-    """
+    """Recompute group-normalized rewards (PR #65: group by group_index)."""
     config = bundle.index.config
-    raw_rewards = [record.raw_reward for record in bundle.index.samples]
     result = StageResult(stage=StageId.REWARD_POST_PROCESS.value, status=StageStatus.PASS)
 
-    rewards = torch.tensor(raw_rewards, dtype=torch.float)
+    rewards = torch.tensor([record.raw_reward for record in bundle.index.samples], dtype=torch.float)
     positions_by_group: dict[int, list[int]] = {}
     for position, record in enumerate(bundle.index.samples):
         if record.group_index is None:
@@ -97,25 +68,15 @@ def replay_reward_post_process(bundle: LoadedBundle, ctx: dict[str, Any]) -> Sta
         normalized[positions] = group_rewards
 
     ctx[StageId.REWARD_POST_PROCESS.value] = normalized.tolist()
-
-    expected = bundle.expected.get(StageId.REWARD_POST_PROCESS.value, {}).get("rewards")
-    if expected is None:
-        result.message = "no expected normalized rewards recorded"
-        return result
-
     atol, rtol = tolerance_for(bundle.manifest, StageId.REWARD_POST_PROCESS)
-    for index, (exp, act) in enumerate(zip(expected, normalized.tolist(), strict=False)):
-        if not compare_scalar(float(exp), float(act), atol=atol, rtol=rtol):
-            result.status = StageStatus.FAIL
-            result.divergences.append(
-                FieldDivergence(
-                    field="reward",
-                    sample_id=bundle.index.samples[index].sample_id,
-                    expected=float(exp),
-                    actual=float(act),
-                    abs_error=scalar_error(float(exp), float(act)),
-                )
-            )
-    if result.status == StageStatus.FAIL:
-        result.message = f"normalized reward mismatch in {len(result.divergences)} sample(s)"
-    return result
+    return report_scalar_list(
+        result,
+        expected=bundle.expected.get(StageId.REWARD_POST_PROCESS.value, {}).get("rewards"),
+        actual=normalized.tolist(),
+        sample_ids=bundle.sample_ids,
+        field="reward",
+        atol=atol,
+        rtol=rtol,
+        missing="no expected normalized rewards recorded",
+        mismatch="normalized reward mismatch in {n} sample(s)",
+    )

--- a/relax/utils/replay/adapters/sample.py
+++ b/relax/utils/replay/adapters/sample.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Sample-stage adapter (data-layer integrity)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from relax.utils.replay.bundle import LoadedBundle
+from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
+from relax.utils.replay.schema import StageId
+from relax.utils.replay.stages import register_adapter
+
+
+@register_adapter(StageId.SAMPLE)
+def replay_sample(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
+    """Verify sample records are internally consistent.
+
+    This is the data-layer ``recompute``: it does not produce a number but
+    checks that every record is complete and well-formed, mirroring what the
+    validator enforces at load time.
+    """
+    result = StageResult(stage=StageId.SAMPLE.value, status=StageStatus.PASS)
+    for record in bundle.index.samples:
+        if record.response_length < 0 or record.total_length < record.response_length:
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(field="length", sample_id=record.sample_id, expected=None, actual=None)
+            )
+        if len(record.loss_mask) != record.response_length:
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(field="loss_mask_length", sample_id=record.sample_id, expected=None, actual=None)
+            )
+    if result.status == StageStatus.FAIL:
+        result.message = f"{len(result.divergences)} sample record(s) are inconsistent"
+    return result

--- a/relax/utils/replay/adapters/sample.py
+++ b/relax/utils/replay/adapters/sample.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from relax.utils.replay.bundle import LoadedBundle
+from relax.utils.replay.identity import sample_integrity_problems
 from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
 from relax.utils.replay.schema import StageId
 from relax.utils.replay.stages import register_adapter
@@ -14,24 +15,12 @@ from relax.utils.replay.stages import register_adapter
 
 @register_adapter(StageId.SAMPLE)
 def replay_sample(bundle: LoadedBundle, ctx: dict[str, Any]) -> StageResult:
-    """Verify sample records are internally consistent.
-
-    This is the data-layer ``recompute``: it does not produce a number but
-    checks that every record is complete and well-formed, mirroring what the
-    validator enforces at load time.
-    """
+    """Check each sample record is well-formed (same rules as validate)."""
     result = StageResult(stage=StageId.SAMPLE.value, status=StageStatus.PASS)
     for record in bundle.index.samples:
-        if record.response_length < 0 or record.total_length < record.response_length:
+        for field, _message in sample_integrity_problems(record):
             result.status = StageStatus.FAIL
-            result.divergences.append(
-                FieldDivergence(field="length", sample_id=record.sample_id, expected=None, actual=None)
-            )
-        if len(record.loss_mask) != record.response_length:
-            result.status = StageStatus.FAIL
-            result.divergences.append(
-                FieldDivergence(field="loss_mask_length", sample_id=record.sample_id, expected=None, actual=None)
-            )
+            result.divergences.append(FieldDivergence(field=field, sample_id=record.sample_id))
     if result.status == StageStatus.FAIL:
         result.message = f"{len(result.divergences)} sample record(s) are inconsistent"
     return result

--- a/relax/utils/replay/bundle.py
+++ b/relax/utils/replay/bundle.py
@@ -88,9 +88,7 @@ def _identity_anchor(identity: Identity) -> dict[str, Any]:
     """COMPLETE.<rank> identity fields that must match index.identity."""
     step = identity.actor_step_id
     return {
-        "actor_step_id": (
-            {"rollout_id": step.rollout_id, "step_id": step.step_id} if step is not None else None
-        ),
+        "actor_step_id": ({"rollout_id": step.rollout_id, "step_id": step.step_id} if step is not None else None),
         "rollout_id": identity.rollout_id,
     }
 

--- a/relax/utils/replay/bundle.py
+++ b/relax/utils/replay/bundle.py
@@ -174,12 +174,19 @@ class BundleWriter:
             sha256=sha256_file(path),
         )
 
-    def finalize(self, ranks: list[int]) -> dict[str, Any]:
+    def finalize(self, ranks: list[int], *, expected_ranks: list[int] | None = None) -> dict[str, Any]:
         """Flush metadata, write COMPLETE sentinels and atomically publish.
 
-        Returns the rank-local COMPLETE.<rank> payload so a multi-rank caller
-        can publish the cohort shard without reading the bundle back.
+        ranks is the shard set stored in this rank-local bundle.
+        expected_ranks is the full producer set and defaults to ranks. A
+        multi-rank capture persists expected_ranks so the reader can require
+        the parent cohort COMPLETE.
+
+        Returns the rank-local COMPLETE.<rank> payload so a multi-rank
+        caller can publish the cohort shard without reading the bundle
+        back.
         """
+        expected = list(expected_ranks) if expected_ranks is not None else list(ranks)
         self._manifest.payloads = dict(self._payloads)
         _write_json(self._tmp_path / _MANIFEST, manifest_to_dict(self._manifest))
         _write_json(self._tmp_path / _INDEX, index_to_dict(self._index))
@@ -190,9 +197,13 @@ class BundleWriter:
             **_identity_anchor(self._index.identity),
             "payloads": {name: spec.sha256 for name, spec in self._payloads.items()},
             "metadata": metadata,
+            "expected_ranks": expected,
         }
         _write_json(self._tmp_path / f"{_COMPLETE}.{self._rank}", rank_complete)
-        _write_json(self._tmp_path / _COMPLETE, {"ranks": ranks, "metadata": metadata})
+        _write_json(
+            self._tmp_path / _COMPLETE,
+            {"ranks": list(ranks), "metadata": metadata, "expected_ranks": expected},
+        )
 
         if self._final_path.exists():
             raise FileExistsError(f"bundle already exists at {self._final_path}")
@@ -238,8 +249,9 @@ def try_finalize_cohort(path: str | Path, ranks: list[int]) -> bool:
     writer thread; concurrent finalizers atomically replace COMPLETE.
 
     The cohort COMPLETE is a coordinator sentinel (ranks + per-rank shards),
-    not a BundleReader target. Replay still loads rank-<n>/ which keeps the
-    rank-local COMPLETE of {ranks, metadata checksums}.
+    not a BundleReader target. Replay still loads rank-<n>/; that rank-local
+    COMPLETE records expected_ranks so the reader can require this parent
+    sentinel before treating a multi-rank capture as complete.
     """
     cohort_dir = Path(path)
     complete_path = cohort_dir / _COMPLETE
@@ -271,6 +283,39 @@ def try_finalize_cohort(path: str | Path, ranks: list[int]) -> bool:
     return True
 
 
+def parse_expected_ranks(complete_raw: dict[str, Any]) -> list[int] | None:
+    """Return expected_ranks from a COMPLETE payload, or None if unset."""
+    recorded = complete_raw.get("expected_ranks")
+    if recorded is None:
+        return None
+    if not isinstance(recorded, list) or not recorded or not all(isinstance(rank, int) for rank in recorded):
+        raise IncompleteBundleError(f"malformed {_COMPLETE}: 'expected_ranks' must be a non-empty integer list")
+    return [int(rank) for rank in recorded]
+
+
+def cohort_expected_ranks(cohort_dir: str | Path) -> list[int] | None:
+    """Read a multi-rank expected_ranks list from any COMPLETE.<rank> shard.
+
+    Returns None when the directory has no shard, or every shard is single-
+    rank. Used by the CLI selector and as a fallback for legacy rank-local
+    bundles that did not persist expected_ranks on COMPLETE.
+    """
+    cohort_dir = Path(cohort_dir)
+    if not cohort_dir.is_dir():
+        return None
+    for path in sorted(cohort_dir.iterdir()):
+        if not path.name.startswith(f"{_COMPLETE}.") or not path.is_file():
+            continue
+        try:
+            shard = _read_json(path)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        recorded = shard.get("expected_ranks")
+        if isinstance(recorded, list) and len(recorded) > 1 and all(isinstance(rank, int) for rank in recorded):
+            return [int(rank) for rank in recorded]
+    return None
+
+
 class IncompleteBundleError(ValueError):
     """Raised when a bundle is missing a sentinel, shard or payload."""
 
@@ -285,7 +330,8 @@ class BundleReader:
         """Load manifest, index, expected outputs and tensor payloads.
 
         allow_partial_read is for inspection of incomplete bundles; replay and
-        validate always require a complete bundle.
+        validate always require a complete bundle, including the parent cohort
+        COMPLETE when expected_ranks has more than one producer.
         """
         if not self._path.is_dir():
             raise IncompleteBundleError(f"bundle directory not found: {self._path}")
@@ -297,6 +343,7 @@ class BundleReader:
         complete_raw = _read_json(complete)
         ranks = self._parse_ranks(complete_raw)
         if not allow_partial_read:
+            self._require_parent_cohort_complete(complete_raw)
             self._validate_metadata_checksums(complete_raw.get("metadata"), required=True)
 
         manifest = manifest_from_dict(_read_json(self._path / _MANIFEST))
@@ -322,6 +369,23 @@ class BundleReader:
         if not isinstance(ranks, list) or not all(isinstance(rank, int) for rank in ranks):
             raise IncompleteBundleError(f"malformed {_COMPLETE}: missing integer 'ranks' list")
         return ranks
+
+    def _require_parent_cohort_complete(self, complete_raw: dict[str, Any]) -> None:
+        """Fail closed when a multi-rank rank-local bundle's cohort is open."""
+        expected = parse_expected_ranks(complete_raw)
+        if expected is None and self._path.name.startswith("rank-"):
+            expected = cohort_expected_ranks(self._path.parent)
+        if expected is None or len(expected) <= 1:
+            return
+        parent = self._path.parent
+        complete_path = parent / _COMPLETE
+        if not complete_path.is_file():
+            raise IncompleteBundleError(
+                f"cohort {parent} is incomplete (missing {_COMPLETE}) for multi-rank bundle {self._path}"
+            )
+        parent_ranks = _read_json(complete_path).get("ranks")
+        if not isinstance(parent_ranks, list) or list(parent_ranks) != list(expected):
+            raise IncompleteBundleError(f"cohort {parent} ranks {parent_ranks!r} != expected_ranks {list(expected)!r}")
 
     def _validate_metadata_checksums(self, recorded: object, *, required: bool) -> None:
         if not isinstance(recorded, dict):

--- a/relax/utils/replay/bundle.py
+++ b/relax/utils/replay/bundle.py
@@ -73,7 +73,8 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 
 def metadata_checksums(directory: str | Path) -> dict[str, str]:
-    """SHA-256 of manifest.json, index.json and expected.json under directory."""
+    """SHA-256 of manifest.json, index.json and expected.json under
+    directory."""
     directory = Path(directory)
     checksums: dict[str, str] = {}
     for name in _METADATA_FILES:
@@ -229,7 +230,8 @@ def write_cohort_shard(
 
 
 def try_finalize_cohort(path: str | Path, ranks: list[int]) -> bool:
-    """If every expected COMPLETE.<rank> is present and consistent, write COMPLETE.
+    """If every expected COMPLETE.<rank> is present and consistent, write
+    COMPLETE.
 
     Returns True when the cohort is finalized (including already-complete).
     Missing ranks return False without waiting. Safe to call from each rank's

--- a/relax/utils/replay/bundle.py
+++ b/relax/utils/replay/bundle.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Replay bundle writer and reader.
+
+The writer is crash-safe: payloads and metadata land in a sibling temp
+directory, then the directory is atomically renamed into place only after the
+completion sentinel is written. The reader refuses to open a bundle that is
+missing ``COMPLETE``, a payload, a rank shard, or whose checksums do not match
+the manifest — and it loads tensors with ``weights_only=True`` only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.schema import (
+    BundleIndex,
+    Manifest,
+    PayloadSpec,
+    index_from_dict,
+    index_to_dict,
+    manifest_from_dict,
+    manifest_to_dict,
+)
+
+
+logger = get_logger(__name__)
+
+_COMPLETE = "COMPLETE"
+_PAYLOAD_DIR = "payloads"
+_MANIFEST = "manifest.json"
+_INDEX = "index.json"
+_EXPECTED = "expected.json"
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True, ensure_ascii=False)
+        handle.write("\n")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@dataclass
+class LoadedBundle:
+    """A fully validated bundle ready for replay."""
+
+    manifest: Manifest
+    index: BundleIndex
+    expected: dict[str, Any]
+    tensors: dict[str, torch.Tensor]
+
+
+class BundleWriter:
+    """Writes a single-rank (or coordinator) replay bundle atomically."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        manifest: Manifest,
+        index: BundleIndex,
+        expected: dict[str, Any],
+        *,
+        rank: int = 0,
+    ) -> None:
+        self._final_path = Path(path)
+        self._tmp_path = self._final_path.with_name(f".{self._final_path.name}.tmp-{os.getpid()}")
+        self._manifest = manifest
+        self._index = index
+        self._expected = expected
+        self._rank = rank
+        self._payloads: dict[str, PayloadSpec] = {}
+
+    def _payload_dir(self) -> Path:
+        return self._tmp_path / _PAYLOAD_DIR
+
+    def write_payload(self, name: str, tensor: torch.Tensor) -> None:
+        """Store one detached CPU tensor payload under ``name``."""
+        tensor = tensor.detach().cpu().contiguous()
+        path = self._payload_dir() / f"{name}.pt"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(tensor, path)
+        self._payloads[name] = PayloadSpec(
+            name=name,
+            dtype=str(tensor.dtype),
+            shape=list(tensor.shape),
+            bytes=path.stat().st_size,
+            sha256=sha256_file(path),
+        )
+
+    def finalize(self, ranks: list[int]) -> None:
+        """Flush metadata, write COMPLETE sentinels and atomically publish."""
+        self._manifest.payloads = dict(self._payloads)
+        _write_json(self._tmp_path / _MANIFEST, manifest_to_dict(self._manifest))
+        _write_json(self._tmp_path / _INDEX, index_to_dict(self._index))
+        _write_json(self._tmp_path / _EXPECTED, self._expected)
+
+        step = self._index.identity.actor_step_id
+        rank_complete = {
+            "actor_step_id": ({"rollout_id": step.rollout_id, "step_id": step.step_id} if step is not None else None),
+            "rollout_id": self._index.identity.rollout_id,
+            "payloads": {name: spec.sha256 for name, spec in self._payloads.items()},
+        }
+        _write_json(self._tmp_path / f"{_COMPLETE}.{self._rank}", rank_complete)
+        _write_json(self._tmp_path / _COMPLETE, {"ranks": ranks})
+
+        if self._final_path.exists():
+            raise FileExistsError(f"bundle already exists at {self._final_path}")
+        os.replace(self._tmp_path, self._final_path)
+
+
+def write_rank_shard(
+    path: str | Path,
+    *,
+    rank: int,
+    actor_step_id: tuple[int, int],
+    payloads: dict[str, torch.Tensor],
+) -> None:
+    """Write one rank's payload shard and ``COMPLETE.<rank>`` into an existing
+    bundle dir.
+
+    Used by multi-rank producers; the coordinator calls :func:`finalize_bundle`
+    once every rank has flushed.
+    """
+    bundle_dir = Path(path)
+    payload_dir = bundle_dir / _PAYLOAD_DIR
+    payload_dir.mkdir(parents=True, exist_ok=True)
+
+    checksums: dict[str, str] = {}
+    for name, tensor in payloads.items():
+        tensor = tensor.detach().cpu().contiguous()
+        payload_path = payload_dir / f"{name}.pt"
+        torch.save(tensor, payload_path)
+        checksums[name] = sha256_file(payload_path)
+
+    _write_json(
+        bundle_dir / f"{_COMPLETE}.{rank}",
+        {
+            "actor_step_id": {"rollout_id": actor_step_id[0], "step_id": actor_step_id[1]},
+            "payloads": checksums,
+        },
+    )
+
+
+def finalize_bundle(path: str | Path, ranks: list[int]) -> None:
+    """Write the final COMPLETE sentinel after every rank shard is present."""
+    bundle_dir = Path(path)
+    for rank in ranks:
+        if not (bundle_dir / f"{_COMPLETE}.{rank}").is_file():
+            raise FileNotFoundError(f"missing COMPLETE.{rank} in {bundle_dir}")
+    _write_json(bundle_dir / _COMPLETE, {"ranks": ranks})
+
+
+class IncompleteBundleError(ValueError):
+    """Raised when a bundle is missing a sentinel, shard or payload."""
+
+
+class BundleReader:
+    """Reads and validates a replay bundle."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    def load(self, *, allow_partial_read: bool = False) -> LoadedBundle:
+        """Load manifest, index, expected outputs and tensor payloads.
+
+        ``allow_partial_read`` is for inspection of incomplete bundles; replay
+        and validate always require a complete bundle.
+        """
+        if not self._path.is_dir():
+            raise IncompleteBundleError(f"bundle directory not found: {self._path}")
+
+        complete = self._path / _COMPLETE
+        if not complete.is_file():
+            raise IncompleteBundleError(f"missing {_COMPLETE} sentinel in {self._path}")
+
+        manifest = manifest_from_dict(_read_json(self._path / _MANIFEST))
+        index = index_from_dict(_read_json(self._path / _INDEX))
+        expected = _read_json(self._path / _EXPECTED)
+
+        if manifest.bundle_id != index.bundle_id:
+            raise IncompleteBundleError(
+                f"manifest bundle_id {manifest.bundle_id!r} != index bundle_id {index.bundle_id!r}"
+            )
+
+        ranks = self._read_ranks()
+        self._validate_rank_shards(manifest, ranks)
+        self._validate_payloads(manifest)
+
+        if not allow_partial_read:
+            tensors = {name: self._read_payload(spec) for name, spec in manifest.payloads.items()}
+        else:
+            tensors = {}
+        return LoadedBundle(manifest=manifest, index=index, expected=expected, tensors=tensors)
+
+    def _read_ranks(self) -> list[int]:
+        complete_raw = _read_json(self._path / _COMPLETE)
+        ranks = complete_raw.get("ranks")
+        if not isinstance(ranks, list) or not all(isinstance(rank, int) for rank in ranks):
+            raise IncompleteBundleError(f"malformed {_COMPLETE}: missing integer 'ranks' list")
+        return ranks
+
+    def _validate_rank_shards(self, manifest: Manifest, ranks: list[int]) -> None:
+        accounted: dict[str, str] = {}
+        for rank in ranks:
+            shard_path = self._path / f"{_COMPLETE}.{rank}"
+            if not shard_path.is_file():
+                raise IncompleteBundleError(f"missing COMPLETE.{rank} in {self._path}")
+            shard = _read_json(shard_path)
+            for name, checksum in shard.get("payloads", {}).items():
+                if name in accounted:
+                    raise IncompleteBundleError(f"payload {name!r} written by more than one rank")
+                accounted[name] = checksum
+
+        manifest_names = set(manifest.payloads)
+        if set(accounted) != manifest_names:
+            missing = sorted(manifest_names - set(accounted))
+            extra = sorted(set(accounted) - manifest_names)
+            raise IncompleteBundleError(f"rank shards do not match manifest (missing={missing}, extra={extra})")
+
+        for name, checksum in accounted.items():
+            if checksum != manifest.payloads[name].sha256:
+                raise IncompleteBundleError(f"payload {name!r} checksum mismatch between shard and manifest")
+
+    def _validate_payloads(self, manifest: Manifest) -> None:
+        for name, spec in manifest.payloads.items():
+            path = self._path / _PAYLOAD_DIR / f"{name}.pt"
+            if not path.is_file():
+                raise IncompleteBundleError(f"missing payload file {path}")
+            if path.stat().st_size != spec.bytes:
+                raise IncompleteBundleError(f"payload {name!r} byte size mismatch")
+            if sha256_file(path) != spec.sha256:
+                raise IncompleteBundleError(f"payload {name!r} checksum mismatch")
+
+    def _read_payload(self, spec: PayloadSpec) -> torch.Tensor:
+        path = self._path / _PAYLOAD_DIR / f"{spec.name}.pt"
+        try:
+            tensor = torch.load(path, weights_only=True)
+        except Exception as exc:  # noqa: BLE001 — reject any unsafe/unpicklable payload as incomplete
+            raise IncompleteBundleError(f"payload {spec.name!r} could not be loaded safely: {exc}") from exc
+        if not isinstance(tensor, torch.Tensor):
+            raise IncompleteBundleError(f"payload {spec.name!r} is not a tensor (weights_only loader rejected it)")
+        if str(tensor.dtype) != spec.dtype:
+            raise IncompleteBundleError(f"payload {spec.name!r} dtype {tensor.dtype} != manifest {spec.dtype}")
+        if list(tensor.shape) != spec.shape:
+            raise IncompleteBundleError(f"payload {spec.name!r} shape {tuple(tensor.shape)} != manifest {spec.shape}")
+        return tensor

--- a/relax/utils/replay/bundle.py
+++ b/relax/utils/replay/bundle.py
@@ -22,6 +22,7 @@ import torch
 
 from relax.utils.replay.schema import (
     BundleIndex,
+    Identity,
     Manifest,
     PayloadSpec,
     index_from_dict,
@@ -36,6 +37,7 @@ _PAYLOAD_DIR = "payloads"
 _MANIFEST = "manifest.json"
 _INDEX = "index.json"
 _EXPECTED = "expected.json"
+_METADATA_FILES = (_MANIFEST, _INDEX, _EXPECTED)
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -57,9 +59,65 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
         handle.write("\n")
 
 
+def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON via a sibling temp file, then os.replace (POSIX-atomic)."""
+    path = Path(path)
+    tmp_path = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    _write_json(tmp_path, data)
+    os.replace(tmp_path, path)
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     with open(path, encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def metadata_checksums(directory: str | Path) -> dict[str, str]:
+    """SHA-256 of manifest.json, index.json and expected.json under directory."""
+    directory = Path(directory)
+    checksums: dict[str, str] = {}
+    for name in _METADATA_FILES:
+        path = directory / name
+        if not path.is_file():
+            raise IncompleteBundleError(f"missing {name} in {directory}")
+        checksums[name] = sha256_file(path)
+    return checksums
+
+
+def _identity_anchor(identity: Identity) -> dict[str, Any]:
+    """COMPLETE.<rank> identity fields that must match index.identity."""
+    step = identity.actor_step_id
+    return {
+        "actor_step_id": (
+            {"rollout_id": step.rollout_id, "step_id": step.step_id} if step is not None else None
+        ),
+        "rollout_id": identity.rollout_id,
+    }
+
+
+def _validate_shard_anchor(shard: dict[str, Any], identity: Identity, *, rank: int) -> None:
+    """Require actor_step_id + owned payloads, and match index.identity."""
+    if "actor_step_id" not in shard:
+        raise IncompleteBundleError(f"COMPLETE.{rank} missing required field 'actor_step_id'")
+    if not isinstance(shard.get("payloads"), dict):
+        raise IncompleteBundleError(f"COMPLETE.{rank} missing owned-record 'payloads' map")
+
+    expected = _identity_anchor(identity)
+    if shard["actor_step_id"] != expected["actor_step_id"]:
+        raise IncompleteBundleError(
+            f"COMPLETE.{rank} actor_step_id {shard['actor_step_id']!r} != index {expected['actor_step_id']!r}"
+        )
+    if expected["actor_step_id"] is None:
+        if "rollout_id" not in shard:
+            raise IncompleteBundleError(f"COMPLETE.{rank} missing rollout_id for a rollout-level bundle")
+        if shard["rollout_id"] != expected["rollout_id"]:
+            raise IncompleteBundleError(
+                f"COMPLETE.{rank} rollout_id {shard['rollout_id']!r} != index {expected['rollout_id']!r}"
+            )
+    elif "rollout_id" in shard and shard["rollout_id"] != expected["rollout_id"]:
+        raise IncompleteBundleError(
+            f"COMPLETE.{rank} rollout_id {shard['rollout_id']!r} != index {expected['rollout_id']!r}"
+        )
 
 
 @dataclass
@@ -81,7 +139,7 @@ class LoadedBundle:
 
 
 class BundleWriter:
-    """Writes a single-rank (or coordinator) replay bundle atomically."""
+    """Writes one rank-local replay bundle atomically."""
 
     def __init__(
         self,
@@ -117,67 +175,100 @@ class BundleWriter:
             sha256=sha256_file(path),
         )
 
-    def finalize(self, ranks: list[int]) -> None:
-        """Flush metadata, write COMPLETE sentinels and atomically publish."""
+    def finalize(self, ranks: list[int]) -> dict[str, Any]:
+        """Flush metadata, write COMPLETE sentinels and atomically publish.
+
+        Returns the rank-local COMPLETE.<rank> payload so a multi-rank caller
+        can publish the cohort shard without reading the bundle back.
+        """
         self._manifest.payloads = dict(self._payloads)
         _write_json(self._tmp_path / _MANIFEST, manifest_to_dict(self._manifest))
         _write_json(self._tmp_path / _INDEX, index_to_dict(self._index))
         _write_json(self._tmp_path / _EXPECTED, self._expected)
 
-        step = self._index.identity.actor_step_id
+        metadata = metadata_checksums(self._tmp_path)
         rank_complete = {
-            "actor_step_id": ({"rollout_id": step.rollout_id, "step_id": step.step_id} if step is not None else None),
-            "rollout_id": self._index.identity.rollout_id,
+            **_identity_anchor(self._index.identity),
             "payloads": {name: spec.sha256 for name, spec in self._payloads.items()},
+            "metadata": metadata,
         }
         _write_json(self._tmp_path / f"{_COMPLETE}.{self._rank}", rank_complete)
-        _write_json(self._tmp_path / _COMPLETE, {"ranks": ranks})
+        _write_json(self._tmp_path / _COMPLETE, {"ranks": ranks, "metadata": metadata})
 
         if self._final_path.exists():
             raise FileExistsError(f"bundle already exists at {self._final_path}")
         os.replace(self._tmp_path, self._final_path)
+        return rank_complete
 
 
-def write_rank_shard(
+def write_cohort_shard(
     path: str | Path,
     *,
     rank: int,
-    actor_step_id: tuple[int, int],
-    payloads: dict[str, torch.Tensor],
+    identity: Identity,
+    expected_ranks: list[int],
+    payloads: dict[str, str] | None = None,
+    metadata: dict[str, str] | None = None,
+    relpath: str | None = None,
 ) -> None:
-    """Write one rank's payload shard and COMPLETE.<rank> into an existing
-    bundle dir.
+    """Publish one rank's COMPLETE.<rank> into a shared cohort directory.
 
-    Used by multi-rank producers; the coordinator calls finalize_bundle once
-    every rank has flushed.
+    Does not block; other ranks may still be missing. try_finalize_cohort
+    writes the final COMPLETE once every expected rank has published.
     """
-    bundle_dir = Path(path)
-    payload_dir = bundle_dir / _PAYLOAD_DIR
-    payload_dir.mkdir(parents=True, exist_ok=True)
-
-    checksums: dict[str, str] = {}
-    for name, tensor in payloads.items():
-        tensor = tensor.detach().cpu().contiguous()
-        payload_path = payload_dir / f"{name}.pt"
-        torch.save(tensor, payload_path)
-        checksums[name] = sha256_file(payload_path)
-
-    _write_json(
-        bundle_dir / f"{_COMPLETE}.{rank}",
-        {
-            "actor_step_id": {"rollout_id": actor_step_id[0], "step_id": actor_step_id[1]},
-            "payloads": checksums,
-        },
-    )
+    cohort_dir = Path(path)
+    cohort_dir.mkdir(parents=True, exist_ok=True)
+    shard = {
+        **_identity_anchor(identity),
+        "payloads": dict(payloads) if payloads is not None else {},
+        "expected_ranks": list(expected_ranks),
+    }
+    if metadata is not None:
+        shard["metadata"] = dict(metadata)
+    if relpath is not None:
+        shard["relpath"] = relpath
+    _write_json_atomic(cohort_dir / f"{_COMPLETE}.{rank}", shard)
 
 
-def finalize_bundle(path: str | Path, ranks: list[int]) -> None:
-    """Write the final COMPLETE sentinel after every rank shard is present."""
-    bundle_dir = Path(path)
+def try_finalize_cohort(path: str | Path, ranks: list[int]) -> bool:
+    """If every expected COMPLETE.<rank> is present and consistent, write COMPLETE.
+
+    Returns True when the cohort is finalized (including already-complete).
+    Missing ranks return False without waiting. Safe to call from each rank's
+    writer thread; concurrent finalizers atomically replace COMPLETE.
+
+    The cohort COMPLETE is a coordinator sentinel (ranks + per-rank shards),
+    not a BundleReader target. Replay still loads rank-<n>/ which keeps the
+    rank-local COMPLETE of {ranks, metadata checksums}.
+    """
+    cohort_dir = Path(path)
+    complete_path = cohort_dir / _COMPLETE
+    if complete_path.is_file():
+        return True
+
+    shards: dict[str, dict[str, Any]] = {}
     for rank in ranks:
-        if not (bundle_dir / f"{_COMPLETE}.{rank}").is_file():
-            raise FileNotFoundError(f"missing COMPLETE.{rank} in {bundle_dir}")
-    _write_json(bundle_dir / _COMPLETE, {"ranks": ranks})
+        shard_path = cohort_dir / f"{_COMPLETE}.{rank}"
+        if not shard_path.is_file():
+            return False
+        shard = _read_json(shard_path)
+        if "actor_step_id" not in shard or not isinstance(shard.get("payloads"), dict):
+            raise IncompleteBundleError(f"COMPLETE.{rank} missing actor_step_id or owned-record payloads")
+        recorded_expected = shard.get("expected_ranks")
+        if recorded_expected is not None and list(recorded_expected) != list(ranks):
+            raise IncompleteBundleError(
+                f"COMPLETE.{rank} expected_ranks {recorded_expected!r} != coordinator {list(ranks)!r}"
+            )
+        shards[str(rank)] = shard
+
+    anchors = {
+        (json.dumps(shard.get("actor_step_id"), sort_keys=True), shard.get("rollout_id")) for shard in shards.values()
+    }
+    if len(anchors) != 1:
+        raise IncompleteBundleError("COMPLETE.<rank> identity anchors do not match across ranks")
+
+    _write_json_atomic(complete_path, {"ranks": list(ranks), "shards": shards})
+    return True
 
 
 class IncompleteBundleError(ValueError):
@@ -203,6 +294,11 @@ class BundleReader:
         if not complete.is_file():
             raise IncompleteBundleError(f"missing {_COMPLETE} sentinel in {self._path}")
 
+        complete_raw = _read_json(complete)
+        ranks = self._parse_ranks(complete_raw)
+        if not allow_partial_read:
+            self._validate_metadata_checksums(complete_raw.get("metadata"), required=True)
+
         manifest = manifest_from_dict(_read_json(self._path / _MANIFEST))
         index = index_from_dict(_read_json(self._path / _INDEX))
         expected = _read_json(self._path / _EXPECTED)
@@ -212,8 +308,7 @@ class BundleReader:
                 f"manifest bundle_id {manifest.bundle_id!r} != index bundle_id {index.bundle_id!r}"
             )
 
-        ranks = self._read_ranks()
-        self._validate_rank_shards(manifest, ranks)
+        self._validate_rank_shards(manifest, index.identity, ranks)
         self._validate_payloads(manifest)
 
         if not allow_partial_read:
@@ -222,21 +317,33 @@ class BundleReader:
             tensors = {}
         return LoadedBundle(manifest=manifest, index=index, expected=expected, tensors=tensors)
 
-    def _read_ranks(self) -> list[int]:
-        complete_raw = _read_json(self._path / _COMPLETE)
+    def _parse_ranks(self, complete_raw: dict[str, Any]) -> list[int]:
         ranks = complete_raw.get("ranks")
         if not isinstance(ranks, list) or not all(isinstance(rank, int) for rank in ranks):
             raise IncompleteBundleError(f"malformed {_COMPLETE}: missing integer 'ranks' list")
         return ranks
 
-    def _validate_rank_shards(self, manifest: Manifest, ranks: list[int]) -> None:
+    def _validate_metadata_checksums(self, recorded: object, *, required: bool) -> None:
+        if not isinstance(recorded, dict):
+            if required:
+                raise IncompleteBundleError(f"{_COMPLETE} missing metadata checksums")
+            return
+        actual = metadata_checksums(self._path)
+        if recorded != actual:
+            raise IncompleteBundleError("metadata checksum mismatch between COMPLETE and metadata files")
+
+    def _validate_rank_shards(self, manifest: Manifest, identity: Identity, ranks: list[int]) -> None:
         accounted: dict[str, str] = {}
         for rank in ranks:
             shard_path = self._path / f"{_COMPLETE}.{rank}"
             if not shard_path.is_file():
                 raise IncompleteBundleError(f"missing COMPLETE.{rank} in {self._path}")
             shard = _read_json(shard_path)
-            for name, checksum in shard.get("payloads", {}).items():
+            _validate_shard_anchor(shard, identity, rank=rank)
+            recorded_metadata = shard.get("metadata")
+            if recorded_metadata is not None:
+                self._validate_metadata_checksums(recorded_metadata, required=True)
+            for name, checksum in shard["payloads"].items():
                 if name in accounted:
                     raise IncompleteBundleError(f"payload {name!r} written by more than one rank")
                 accounted[name] = checksum

--- a/relax/utils/replay/bundle.py
+++ b/relax/utils/replay/bundle.py
@@ -5,8 +5,8 @@
 The writer is crash-safe: payloads and metadata land in a sibling temp
 directory, then the directory is atomically renamed into place only after the
 completion sentinel is written. The reader refuses to open a bundle that is
-missing ``COMPLETE``, a payload, a rank shard, or whose checksums do not match
-the manifest — and it loads tensors with ``weights_only=True`` only.
+missing COMPLETE, a payload, a rank shard, or whose checksums do not match the
+manifest — and it loads tensors with weights_only=True only.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from typing import Any
 
 import torch
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.schema import (
     BundleIndex,
     Manifest,
@@ -31,8 +30,6 @@ from relax.utils.replay.schema import (
     manifest_to_dict,
 )
 
-
-logger = get_logger(__name__)
 
 _COMPLETE = "COMPLETE"
 _PAYLOAD_DIR = "payloads"
@@ -74,6 +71,14 @@ class LoadedBundle:
     expected: dict[str, Any]
     tensors: dict[str, torch.Tensor]
 
+    @property
+    def sample_ids(self) -> list[str]:
+        return [record.sample_id for record in self.index.samples]
+
+    @property
+    def response_lengths(self) -> list[int]:
+        return [record.response_length for record in self.index.samples]
+
 
 class BundleWriter:
     """Writes a single-rank (or coordinator) replay bundle atomically."""
@@ -99,7 +104,7 @@ class BundleWriter:
         return self._tmp_path / _PAYLOAD_DIR
 
     def write_payload(self, name: str, tensor: torch.Tensor) -> None:
-        """Store one detached CPU tensor payload under ``name``."""
+        """Store one detached CPU tensor payload under name."""
         tensor = tensor.detach().cpu().contiguous()
         path = self._payload_dir() / f"{name}.pt"
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -140,11 +145,11 @@ def write_rank_shard(
     actor_step_id: tuple[int, int],
     payloads: dict[str, torch.Tensor],
 ) -> None:
-    """Write one rank's payload shard and ``COMPLETE.<rank>`` into an existing
+    """Write one rank's payload shard and COMPLETE.<rank> into an existing
     bundle dir.
 
-    Used by multi-rank producers; the coordinator calls :func:`finalize_bundle`
-    once every rank has flushed.
+    Used by multi-rank producers; the coordinator calls finalize_bundle once
+    every rank has flushed.
     """
     bundle_dir = Path(path)
     payload_dir = bundle_dir / _PAYLOAD_DIR
@@ -188,8 +193,8 @@ class BundleReader:
     def load(self, *, allow_partial_read: bool = False) -> LoadedBundle:
         """Load manifest, index, expected outputs and tensor payloads.
 
-        ``allow_partial_read`` is for inspection of incomplete bundles; replay
-        and validate always require a complete bundle.
+        allow_partial_read is for inspection of incomplete bundles; replay and
+        validate always require a complete bundle.
         """
         if not self._path.is_dir():
             raise IncompleteBundleError(f"bundle directory not found: {self._path}")

--- a/relax/utils/replay/capture.py
+++ b/relax/utils/replay/capture.py
@@ -364,7 +364,7 @@ def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> P
     writer = BundleWriter(rank_path, manifest, index, expected_outputs, rank=rank)
     for name, tensor in record.tensors.items():
         writer.write_payload(name, tensor.detach().cpu().contiguous())
-    rank_complete = writer.finalize(ranks=[rank])
+    rank_complete = writer.finalize(ranks=[rank], expected_ranks=expected)
     if multi:
         _publish_cohort_and_finalize(
             cohort_dir,

--- a/relax/utils/replay/capture.py
+++ b/relax/utils/replay/capture.py
@@ -88,6 +88,11 @@ class CaptureRecord:
     group_indices_tensor: torch.Tensor | None = None
     raw_rewards_tensor: torch.Tensor | None = None
     rewards_tensor: torch.Tensor | None = None
+    # Per-sample DataIterator micro-batch ids (mb-0000, ...). Parallel to
+    # response_lengths. captured_micro_batch_ids is the first-writer-wins set
+    # used to ignore activation-checkpoint recomputes of the same micro-batch.
+    sample_micro_batch_ids: list[str] | None = None
+    captured_micro_batch_ids: set[str] = field(default_factory=set)
 
     @property
     def anchor(self) -> str:
@@ -120,6 +125,10 @@ def _detach_record(record: CaptureRecord) -> CaptureRecord:
         group_indices_tensor=_detach_value(record.group_indices_tensor),
         raw_rewards_tensor=_detach_value(record.raw_rewards_tensor),
         rewards_tensor=_detach_value(record.rewards_tensor),
+        sample_micro_batch_ids=(
+            list(record.sample_micro_batch_ids) if record.sample_micro_batch_ids is not None else None
+        ),
+        captured_micro_batch_ids=set(record.captured_micro_batch_ids),
     )
 
 
@@ -216,8 +225,6 @@ def _build_samples_from_raw(record: CaptureRecord) -> list[SampleRecord]:
         if record.rewards_tensor is not None
         else raw_rewards
     )
-    micro_batch_id = _micro_batch_id_for(record)
-
     return [
         SampleRecord(
             sample_id=f"s-{index}",
@@ -228,21 +235,48 @@ def _build_samples_from_raw(record: CaptureRecord) -> list[SampleRecord]:
             raw_reward=raw_rewards[index],
             reward=rewards[index],
             label_hash="",
-            micro_batch_id=micro_batch_id,
+            micro_batch_id=_sample_micro_batch_id(record, index),
         )
         for index in range(count)
     ]
 
 
-def _micro_batch_id_for(record: CaptureRecord) -> str | None:
-    """Stable micro-batch id for a per-step capture (mb-<step_id>).
+def format_micro_batch_id(index: int) -> str:
+    """Stable DataIterator micro-batch id (mb-0000, mb-0001, ...)."""
+    return f"mb-{index:04d}"
 
-    Rollout-level records have no actor step, so batch selection stays fail-
-    closed.
+
+def _sample_micro_batch_id(record: CaptureRecord, index: int) -> str | None:
+    """Per-sample micro-batch id, or a single-mb fallback for loss-only
+    records."""
+    if record.sample_micro_batch_ids is not None and index < len(record.sample_micro_batch_ids):
+        return record.sample_micro_batch_ids[index]
+    return _micro_batch_id_for(record)
+
+
+def _micro_batch_id_for(record: CaptureRecord) -> str | None:
+    """Fallback id when the hook did not stamp per-sample membership.
+
+    Step-level records default to mb-0000 (a single captured micro-batch).
+    Rollout-level records leave it unset so --batch stays fail-closed.
     """
     if record.actor_step_id is None:
         return None
-    return f"mb-{record.actor_step_id[1]:04d}"
+    if record.captured_micro_batch_ids:
+        return sorted(record.captured_micro_batch_ids)[0]
+    return format_micro_batch_id(0)
+
+
+def _identity_micro_batch_ids(record: CaptureRecord, samples: list[SampleRecord]) -> list[str]:
+    """Unique micro-batch ids in first-seen order, matching SampleRecord."""
+    seen: list[str] = []
+    for sample in samples:
+        if sample.micro_batch_id and sample.micro_batch_id not in seen:
+            seen.append(sample.micro_batch_id)
+    if seen:
+        return seen
+    fallback = _micro_batch_id_for(record)
+    return [fallback] if fallback is not None else []
 
 
 def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> Path:
@@ -257,11 +291,11 @@ def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> P
     manifest = build_manifest_for_record(record)
     samples = record.samples if record.samples else _build_samples_from_raw(record)
     identity = record.identity
-    micro_batch_id = _micro_batch_id_for(record)
-    # When samples are reconstructed from raw step metadata, stamp a matching
+    micro_batch_ids = _identity_micro_batch_ids(record, samples)
+    # When samples are reconstructed from raw step metadata, stamp matching
     # identity.micro_batch_ids so --batch selection agrees with SampleRecord.
-    if not record.samples and micro_batch_id is not None:
-        identity = replace(identity, micro_batch_ids=[micro_batch_id])
+    if not record.samples and micro_batch_ids:
+        identity = replace(identity, micro_batch_ids=micro_batch_ids)
     index = BundleIndex(bundle_id=record.bundle_id, identity=identity, samples=samples, config=record.config)
 
     expected = _normalize_expected(record.expected)

--- a/relax/utils/replay/capture.py
+++ b/relax/utils/replay/capture.py
@@ -4,8 +4,8 @@
 
 Enabled via maybe_enable_from_env. Hooks live in capture_hooks.
 CaptureManager.submit detaches and clones tensors (GPU→GPU copy, no CPU sync);
-GPU→CPU copy and serialization run on a bounded writer thread that never
-back-pressures training.
+GPU→CPU copy and serialization run on a bounded writer thread that never back-
+pressures training.
 """
 
 from __future__ import annotations
@@ -580,7 +580,8 @@ def maybe_enable_from_env(
 
     rank is this process. expected_ranks is the last-PP producer set that must
     publish COMPLETE.<rank>; None means this rank only. Output stays under
-    RELAX_REPLAY_CAPTURE_DIR; multi-rank writers coordinate via try_finalize_cohort.
+    RELAX_REPLAY_CAPTURE_DIR; multi-rank writers coordinate via
+    try_finalize_cohort.
     """
     config = config_from_env()
     if config is None:

--- a/relax/utils/replay/capture.py
+++ b/relax/utils/replay/capture.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Production capture (PR B, data plane).
+
+This module owns the capture half of the trajectory replay system: turning a
+handful of post-forward tensors, identity and stage outputs from one training
+step into a replay bundle that :mod:`relax.utils.replay.runner` can replay.
+
+It contains no production math and touches no hot path itself. Training enables
+it via :func:`maybe_enable_from_env` (``RELAX_REPLAY_CAPTURE``). The hot-path
+hooks live in :mod:`relax.utils.replay.capture_hooks` and are called from:
+
+- rollout-level reward / advantage: ``MegatronTrainRayActor.train_actor``;
+- policy loss terms: ``relax.backends.megatron.loss.policy_loss_function``;
+- actor-step identity: the ``train_one_step`` loop in
+  ``relax.backends.megatron.model``.
+
+The hot-path contract is strict:
+
+- ``CaptureManager.submit`` only *detaches* tensors and enqueues them; it never
+  calls ``.cpu()`` / ``.item()`` / ``.tolist()`` and never touches ``torch.distributed``.
+- The GPU→CPU copy and serialization happen on a dedicated writer thread.
+- The queue is bounded: when full, a step is dropped and a diagnostic is logged
+  (never back-pressure into training).
+- The writer thread isolates all bundle-build failures so a crash there cannot
+  propagate into the training loop.
+"""
+
+from __future__ import annotations
+
+import atexit
+import queue
+import threading
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from relax.utils.env import Envs
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.bundle import BundleWriter
+from relax.utils.replay.schema import (
+    FORMAT_VERSION,
+    STAGE_ORDER,
+    BundleIndex,
+    ComparisonPolicy,
+    Identity,
+    Manifest,
+    ProducerInfo,
+    RecomputeConfig,
+    SampleRecord,
+    StageContract,
+    StageId,
+)
+from relax.utils.replay.stages import REIMPLEMENTED_STAGES, V1_STAGE_VERSIONS, capability_for
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class CaptureConfig:
+    """Runtime configuration for production capture."""
+
+    enabled: bool = False
+    output_dir: str | Path = ""
+    bundle_id_prefix: str = "replay"
+    queue_capacity: int = 16
+    # Actor steps (rollout_id, step_id) to capture; None captures every step.
+    selected_steps: set[tuple[int, int]] | None = None
+    # Rollouts to capture at rollout level (reward/advantage); None captures every rollout.
+    selected_rollouts: set[int] | None = None
+    redaction: dict[str, str] = field(default_factory=dict)
+    commit: str = ""
+
+
+@dataclass
+class CaptureRecord:
+    """Everything one capture cohort needs to be replayed.
+
+    A record is anchored by exactly one of ``actor_step_id`` (per-step, loss)
+    or ``rollout_id`` (per-rollout, reward/advantage). ``tensors`` holds the
+    post-forward tensor payloads (inputs and expected outputs); ``expected``
+    holds the JSON-serializable expected outputs.
+    """
+
+    identity: Identity
+    samples: list[SampleRecord]
+    config: RecomputeConfig
+    tensors: dict[str, torch.Tensor]
+    expected: dict[str, Any]
+    bundle_id: str
+    actor_step_id: tuple[int, int] | None = None
+    rollout_id: int | None = None
+    producer: ProducerInfo = field(default_factory=ProducerInfo)
+    redaction: dict[str, str] = field(default_factory=dict)
+    # Stages actually captured by this record; None means "derive from the
+    # frozen matrix" (declare every matrix stage). A partial capture (e.g. loss
+    # only) sets this explicitly so the manifest does not promise stages whose
+    # payloads are absent.
+    stages: set[StageId] | None = None
+    # Raw per-sample metadata used to build ``SampleRecord`` on the writer
+    # thread. The mask/reward/group tensors stay detached through the hot path;
+    # their GPU→CPU conversion happens only in ``build_bundle_from_record``.
+    response_lengths: list[int] | None = None
+    total_lengths: list[int] | None = None
+    loss_masks_tensor: torch.Tensor | None = None
+    group_indices_tensor: torch.Tensor | None = None
+    raw_rewards_tensor: torch.Tensor | None = None
+    rewards_tensor: torch.Tensor | None = None
+
+    @property
+    def anchor(self) -> str:
+        """Human-readable cohort anchor for logging."""
+        if self.actor_step_id is not None:
+            return f"step{self.actor_step_id}"
+        if self.rollout_id is not None:
+            return f"rollout-{self.rollout_id}"
+        return "<unset>"
+
+
+def build_manifest_for_record(record: CaptureRecord) -> Manifest:
+    """Derive the manifest from the frozen V1 capability matrix.
+
+    Each stage in ``STAGE_ORDER`` is declared with the capability the matrix
+    grants for the bundle's topology (``record.config.advantage_estimator`` and
+    ``record.identity.rank["cp"]``). Stages outside the matrix are
+    ``unsupported`` and will be skipped — never silently recomputed. When
+    ``record.stages`` is set, only those stages are declared (the rest get no
+    contract and are skipped), so a partial capture never promises absent
+    payloads.
+    """
+    context_parallel = record.identity.rank.get("cp", 1)
+    declared = record.stages if record.stages is not None else set(STAGE_ORDER)
+    stage_contracts: dict[StageId, StageContract] = {}
+    for stage in STAGE_ORDER:
+        if stage not in declared:
+            continue
+        capability = capability_for(
+            stage,
+            advantage_estimator=record.config.advantage_estimator,
+            context_parallel=context_parallel,
+        )
+        stage_contracts[stage] = StageContract(
+            stage=stage,
+            version=V1_STAGE_VERSIONS[stage],
+            capability=capability,
+            implementation="reimplemented" if stage in REIMPLEMENTED_STAGES else "reuse",
+        )
+    return Manifest(
+        format_version=FORMAT_VERSION,
+        bundle_id=record.bundle_id,
+        producer=record.producer,
+        stage_contracts=stage_contracts,
+        payloads={},
+        comparison_policy=ComparisonPolicy(),
+        redaction=dict(record.redaction),
+    )
+
+
+def _normalize_expected(expected: dict[str, Any]) -> dict[str, Any]:
+    """Convert detached scalar tensors in ``expected`` to plain floats.
+
+    Runs on the writer thread so the GPU→CPU sync (``.item()``) never happens
+    in the training hot path. Handles nested dicts/lists (e.g. ``loss.policy``
+    metric maps).
+    """
+
+    def _convert(value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return value.detach().cpu().item()
+        if isinstance(value, dict):
+            return {key: _convert(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [_convert(item) for item in value]
+        return value
+
+    return {key: _convert(value) for key, value in expected.items()}
+
+
+def _build_samples_from_raw(record: CaptureRecord) -> list[SampleRecord]:
+    """Build the ``SampleRecord`` list from raw per-sample metadata.
+
+    Runs on the writer thread; the flat ``loss_masks_tensor`` is split back per
+    sample using ``response_lengths``, and the optional group/reward tensors
+    are converted here so their GPU→CPU sync never happens in the hot path.
+    When the group/reward tensors are absent (loss-only capture) placeholders
+    are used.
+    """
+    if record.response_lengths is None or record.total_lengths is None or record.loss_masks_tensor is None:
+        raise ValueError("capture record has no samples and incomplete raw sample metadata")
+
+    count = len(record.response_lengths)
+    flat_masks = record.loss_masks_tensor.detach().cpu().tolist()
+    masks: list[list[int]] = []
+    offset = 0
+    for response_length in record.response_lengths:
+        masks.append([int(value) for value in flat_masks[offset : offset + response_length]])
+        offset += response_length
+
+    group_indices = (
+        [int(value) for value in record.group_indices_tensor.detach().cpu().tolist()]
+        if record.group_indices_tensor is not None
+        else [0] * count
+    )
+    raw_rewards = (
+        [float(value) for value in record.raw_rewards_tensor.detach().cpu().tolist()]
+        if record.raw_rewards_tensor is not None
+        else [0.0] * count
+    )
+    rewards = (
+        [float(value) for value in record.rewards_tensor.detach().cpu().tolist()]
+        if record.rewards_tensor is not None
+        else raw_rewards
+    )
+    micro_batch_id = _micro_batch_id_for(record)
+
+    return [
+        SampleRecord(
+            sample_id=f"s-{index}",
+            group_index=group_indices[index],
+            response_length=int(record.response_lengths[index]),
+            total_length=int(record.total_lengths[index]),
+            loss_mask=masks[index],
+            raw_reward=raw_rewards[index],
+            reward=rewards[index],
+            label_hash="",
+            micro_batch_id=micro_batch_id,
+        )
+        for index in range(count)
+    ]
+
+
+def _micro_batch_id_for(record: CaptureRecord) -> str | None:
+    """Stable micro-batch id for a per-step capture (``mb-<step_id>``).
+
+    Rollout-level records have no actor step, so batch selection stays fail-
+    closed.
+    """
+    if record.actor_step_id is None:
+        return None
+    return f"mb-{record.actor_step_id[1]:04d}"
+
+
+def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> Path:
+    """Serialize one :class:`CaptureRecord` into a replay bundle.
+
+    Pure and synchronous; used directly by tests and by the async writer
+    thread.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = build_manifest_for_record(record)
+    samples = record.samples if record.samples else _build_samples_from_raw(record)
+    identity = record.identity
+    micro_batch_id = _micro_batch_id_for(record)
+    # When samples are reconstructed from raw step metadata, stamp a matching
+    # identity.micro_batch_ids so --batch selection agrees with SampleRecord.
+    if not record.samples and micro_batch_id is not None:
+        identity = replace(identity, micro_batch_ids=[micro_batch_id])
+    index = BundleIndex(bundle_id=record.bundle_id, identity=identity, samples=samples, config=record.config)
+
+    expected = _normalize_expected(record.expected)
+    # Derive per-sample reward expectations from the deferred tensors (writer
+    # thread), so the reward adapters have JSON-serializable lists to compare.
+    if record.raw_rewards_tensor is not None:
+        expected.setdefault(StageId.REWARD_RAW.value, {})["raw_rewards"] = [
+            float(value) for value in record.raw_rewards_tensor.detach().cpu().tolist()
+        ]
+    if record.rewards_tensor is not None:
+        expected.setdefault(StageId.REWARD_POST_PROCESS.value, {})["rewards"] = [
+            float(value) for value in record.rewards_tensor.detach().cpu().tolist()
+        ]
+
+    writer = BundleWriter(output_dir / record.bundle_id, manifest, index, expected)
+    for name, tensor in record.tensors.items():
+        writer.write_payload(name, tensor.detach().cpu().contiguous())
+    writer.finalize(ranks=[0])
+    return output_dir / record.bundle_id
+
+
+class CaptureManager:
+    """Bounded, asynchronous capture sink.
+
+    Owns the writer thread and the bounded queue. Disabled by default: when
+    ``config.enabled`` is False, :meth:`submit` is a no-op that never inspects
+    tensors, so the disabled path is a single branch.
+    """
+
+    def __init__(self, config: CaptureConfig) -> None:
+        self._config = config
+        self._dropped_count = 0
+        self._error_count = 0
+        self._queue: queue.Queue[CaptureRecord | None] | None = None
+        self._thread: threading.Thread | None = None
+        if config.enabled:
+            self._queue = queue.Queue(maxsize=config.queue_capacity)
+            self._thread = threading.Thread(target=self._writer_loop, name="replay-capture-writer", daemon=True)
+            self._thread.start()
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    @property
+    def output_dir(self) -> str:
+        return str(self._config.output_dir)
+
+    @property
+    def dropped_count(self) -> int:
+        return self._dropped_count
+
+    @property
+    def error_count(self) -> int:
+        return self._error_count
+
+    def is_selected(self, actor_step_id: tuple[int, int]) -> bool:
+        if self._config.selected_steps is None:
+            return True
+        return actor_step_id in self._config.selected_steps
+
+    def is_rollout_selected(self, rollout_id: int) -> bool:
+        if self._config.selected_rollouts is None:
+            return True
+        return rollout_id in self._config.selected_rollouts
+
+    def _record_selected(self, record: CaptureRecord) -> bool:
+        if record.actor_step_id is not None:
+            return self.is_selected(record.actor_step_id)
+        if record.rollout_id is not None:
+            return self.is_rollout_selected(record.rollout_id)
+        return False
+
+    def submit(self, record: CaptureRecord) -> bool:
+        """Enqueue a detached snapshot of ``record``; returns True if queued.
+
+        Only ``detach()`` happens on the caller thread (no GPU→CPU sync, no
+        collective). On queue overflow the record is dropped and False
+        returned.
+        """
+        if not self.enabled or not self._record_selected(record):
+            return False
+
+        snapshot = CaptureRecord(
+            identity=record.identity,
+            samples=record.samples,
+            config=record.config,
+            tensors={name: tensor.detach() for name, tensor in record.tensors.items()},
+            expected={
+                key: value.detach() if isinstance(value, torch.Tensor) else value
+                for key, value in record.expected.items()
+            },
+            bundle_id=record.bundle_id,
+            actor_step_id=record.actor_step_id,
+            rollout_id=record.rollout_id,
+            producer=record.producer,
+            redaction=record.redaction,
+            stages=record.stages,
+            response_lengths=record.response_lengths,
+            total_lengths=record.total_lengths,
+            loss_masks_tensor=record.loss_masks_tensor.detach() if record.loss_masks_tensor is not None else None,
+            group_indices_tensor=record.group_indices_tensor.detach()
+            if record.group_indices_tensor is not None
+            else None,
+            raw_rewards_tensor=record.raw_rewards_tensor.detach() if record.raw_rewards_tensor is not None else None,
+            rewards_tensor=record.rewards_tensor.detach() if record.rewards_tensor is not None else None,
+        )
+        try:
+            self._queue.put_nowait(snapshot)
+            return True
+        except queue.Full:
+            self._dropped_count += 1
+            logger.warning(
+                "replay capture queue full (capacity=%d); dropping %s (dropped=%d)",
+                self._config.queue_capacity,
+                record.anchor,
+                self._dropped_count,
+            )
+            return False
+
+    def _writer_loop(self) -> None:
+        assert self._queue is not None
+        while True:
+            record = self._queue.get()
+            try:
+                if record is None:  # shutdown sentinel
+                    return
+                build_bundle_from_record(record, self._config.output_dir)
+            except Exception as exc:  # noqa: BLE001 — writer failure must never crash training
+                self._error_count += 1
+                logger.error("replay capture failed for %s: %s", record.anchor, exc)
+            finally:
+                self._queue.task_done()
+
+    def flush(self, wait: bool = False) -> None:
+        """Wait for all currently queued records to be written, if
+        requested."""
+        if self._queue is not None and wait:
+            self._queue.join()
+
+    def close(self, timeout: float | None = 10.0) -> None:
+        """Signal the writer thread to stop and join it.
+
+        The shutdown sentinel is enqueued with the same timeout as the join, so
+        a stuck writer cannot hang process exit (atexit / actor teardown).
+        """
+        if self._thread is None or self._queue is None:
+            return
+        try:
+            self._queue.put(None, timeout=timeout)
+        except queue.Full:
+            logger.warning("replay capture writer did not accept shutdown sentinel")
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            logger.warning("replay capture writer still running after shutdown timeout; abandoning remaining records")
+        self._thread = None
+
+
+# ---------------------------------------------------------------------------
+# Process-global capture state (the thin, hot-path-safe hook surface).
+#
+# Training files call the tiny functions below; everything heavier lives on the
+# ``CaptureManager`` / writer thread. ``active()`` is a single global read and
+# ``current_step()`` a single global read — no GPU→CPU sync, no collective.
+# ---------------------------------------------------------------------------
+
+_active: CaptureManager | None = None
+_current_step: StepCapture | None = None
+_atexit_registered: bool = False
+
+
+def _parse_selected_steps(raw: str | None) -> set[tuple[int, int]] | None:
+    """Parse ``RELAX_REPLAY_CAPTURE_STEPS`` (``ROLLOUT_ID:STEP_ID,...``)."""
+    if raw is None or not raw.strip():
+        return None
+    steps: set[tuple[int, int]] = set()
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        try:
+            rollout_id, step_id = token.split(":")
+            steps.add((int(rollout_id), int(step_id)))
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid RELAX_REPLAY_CAPTURE_STEPS item {token!r} (expected ROLLOUT_ID:STEP_ID)"
+            ) from exc
+    return steps or None
+
+
+def _parse_selected_rollouts(raw: str | None) -> set[int] | None:
+    """Parse ``RELAX_REPLAY_CAPTURE_ROLLOUTS`` (``ID,ID,...``)."""
+    if raw is None or not raw.strip():
+        return None
+    rollouts: set[int] = set()
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        try:
+            rollouts.add(int(token))
+        except ValueError as exc:
+            raise ValueError(f"invalid RELAX_REPLAY_CAPTURE_ROLLOUTS item {token!r} (expected int)") from exc
+    return rollouts or None
+
+
+def config_from_env() -> CaptureConfig | None:
+    """Build a :class:`CaptureConfig` from ``RELAX_REPLAY_CAPTURE*`` env vars.
+
+    Returns ``None`` when capture is unset/false, so the caller can no-op.
+    ``RELAX_REPLAY_CAPTURE=1`` without ``RELAX_REPLAY_CAPTURE_DIR`` logs a
+    warning and also returns ``None`` — never write to an implicit path.
+    """
+    if not Envs.RELAX_REPLAY_CAPTURE:
+        return None
+    output_dir = Envs.RELAX_REPLAY_CAPTURE_DIR
+    if not output_dir:
+        logger.warning("RELAX_REPLAY_CAPTURE is set but RELAX_REPLAY_CAPTURE_DIR is empty; capture stays disabled")
+        return None
+    return CaptureConfig(
+        enabled=True,
+        output_dir=output_dir,
+        selected_steps=_parse_selected_steps(Envs.RELAX_REPLAY_CAPTURE_STEPS),
+        selected_rollouts=_parse_selected_rollouts(Envs.RELAX_REPLAY_CAPTURE_ROLLOUTS),
+    )
+
+
+def maybe_enable_from_env(*, rank: int | None = None) -> CaptureManager | None:
+    """Enable capture from env vars. No-op when capture is not requested.
+
+    ``rank`` scopes the output directory to ``<dir>/rank-<rank>`` so concurrent
+    DP/TP writers do not clobber each other on a shared filesystem.
+    """
+    config = config_from_env()
+    if config is None:
+        return None
+    if rank is not None:
+        config = replace(config, output_dir=str(Path(config.output_dir) / f"rank-{rank}"))
+    logger.info("enabling trajectory-replay capture under %s", config.output_dir)
+    return enable(config)
+
+
+def enable(config: CaptureConfig) -> CaptureManager:
+    """Enable capture process-wide and return the active manager.
+
+    Replaces any previously active manager (flushing it first). This is the
+    Python-API injection point: the training actor calls it from
+    :func:`maybe_enable_from_env` — no argument-parsing changes required.
+    """
+    global _active, _atexit_registered
+    if _active is not None:
+        _active.close()
+    _active = CaptureManager(config)
+    if not _atexit_registered:
+        atexit.register(disable)
+        _atexit_registered = True
+    return _active
+
+
+def disable() -> None:
+    """Disable capture process-wide and flush the active manager."""
+    global _active
+    if _active is not None:
+        _active.close()
+        _active = None
+
+
+def active() -> CaptureManager | None:
+    """Return the active manager, or ``None`` when capture is disabled."""
+    return _active
+
+
+class StepCapture:
+    """Accumulates the data captured for one cohort across hooks.
+
+    Anchored by ``actor_step_id`` (per-step, loss) or ``rollout_id`` (per-
+    rollout, reward/advantage). The training-side hooks write tensors /
+    expected outputs into this object; ``end_step`` / ``end_rollout`` turn it
+    into a :class:`CaptureRecord` and hand it to the manager. All tensor
+    detaching happens in ``CaptureManager.submit``, so the hooks themselves
+    only hold live references.
+    """
+
+    def __init__(
+        self,
+        identity: Identity,
+        config: RecomputeConfig,
+        bundle_id: str,
+        *,
+        actor_step_id: tuple[int, int] | None = None,
+        rollout_id: int | None = None,
+        producer: ProducerInfo | None = None,
+    ) -> None:
+        self.actor_step_id = actor_step_id
+        self.rollout_id = rollout_id
+        self.identity = identity
+        self.config = config
+        self.bundle_id = bundle_id
+        self.producer = producer if producer is not None else ProducerInfo()
+        self.samples: list[SampleRecord] = []
+        self.tensors: dict[str, torch.Tensor] = {}
+        self.expected: dict[str, Any] = {}
+        self.stages: set[StageId] | None = None
+        self.response_lengths: list[int] | None = None
+        self.total_lengths: list[int] | None = None
+        self.loss_masks_tensor: torch.Tensor | None = None
+        self.group_indices_tensor: torch.Tensor | None = None
+        self.raw_rewards_tensor: torch.Tensor | None = None
+        self.rewards_tensor: torch.Tensor | None = None
+
+    def to_record(self) -> CaptureRecord:
+        return CaptureRecord(
+            identity=self.identity,
+            samples=self.samples,
+            config=self.config,
+            tensors=self.tensors,
+            expected=self.expected,
+            bundle_id=self.bundle_id,
+            actor_step_id=self.actor_step_id,
+            rollout_id=self.rollout_id,
+            producer=self.producer,
+            stages=self.stages,
+            response_lengths=self.response_lengths,
+            total_lengths=self.total_lengths,
+            loss_masks_tensor=self.loss_masks_tensor,
+            group_indices_tensor=self.group_indices_tensor,
+            raw_rewards_tensor=self.raw_rewards_tensor,
+            rewards_tensor=self.rewards_tensor,
+        )
+
+
+def begin_step(
+    actor_step_id: tuple[int, int],
+    *,
+    identity: Identity,
+    config: RecomputeConfig,
+    bundle_id: str,
+    producer: ProducerInfo | None = None,
+) -> None:
+    """Open a per-step capture accumulator (no-op when disabled/unselected)."""
+    global _current_step
+    if _active is None or not _active.is_selected(actor_step_id):
+        _current_step = None
+        return
+    _current_step = StepCapture(identity, config, bundle_id, actor_step_id=actor_step_id, producer=producer)
+
+
+def begin_rollout(
+    rollout_id: int,
+    *,
+    identity: Identity,
+    config: RecomputeConfig,
+    bundle_id: str,
+    producer: ProducerInfo | None = None,
+) -> None:
+    """Open a per-rollout capture accumulator (no-op when
+    disabled/unselected)."""
+    global _current_step
+    if _active is None or not _active.is_rollout_selected(rollout_id):
+        _current_step = None
+        return
+    _current_step = StepCapture(identity, config, bundle_id, rollout_id=rollout_id, producer=producer)
+
+
+def should_capture(actor_step_id: tuple[int, int]) -> bool:
+    """Cheap disabled/unselected guard (two global reads, no allocation).
+
+    Callers use this *before* building an :class:`Identity` /
+    :class:`RecomputeConfig` so the disabled hot path does no work at all.
+    """
+    return _active is not None and _active.is_selected(actor_step_id)
+
+
+def should_capture_rollout(rollout_id: int) -> bool:
+    """Cheap disabled/unselected guard for the rollout-level hot path."""
+    return _active is not None and _active.is_rollout_selected(rollout_id)
+
+
+def current_step() -> StepCapture | None:
+    """Return the current cohort's accumulator, or ``None`` when disabled."""
+    return _current_step
+
+
+def end_step() -> None:
+    """Finalize the current step's accumulator and submit it to the manager.
+
+    Accumulators that never received a payload (non-last PP ranks, unselected
+    hooks) are dropped instead of writing an incomplete bundle.
+    """
+    global _current_step
+    step = _current_step
+    _current_step = None
+    if step is None or _active is None:
+        return
+    if not step.stages:
+        return
+    _active.submit(step.to_record())
+
+
+def end_rollout() -> None:
+    """Finalize the current rollout's accumulator and submit it to the
+    manager."""
+    end_step()

--- a/relax/utils/replay/capture.py
+++ b/relax/utils/replay/capture.py
@@ -1,29 +1,10 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""Production capture (PR B, data plane).
+"""Production capture: post-forward tensors → replay bundle.
 
-This module owns the capture half of the trajectory replay system: turning a
-handful of post-forward tensors, identity and stage outputs from one training
-step into a replay bundle that :mod:`relax.utils.replay.runner` can replay.
-
-It contains no production math and touches no hot path itself. Training enables
-it via :func:`maybe_enable_from_env` (``RELAX_REPLAY_CAPTURE``). The hot-path
-hooks live in :mod:`relax.utils.replay.capture_hooks` and are called from:
-
-- rollout-level reward / advantage: ``MegatronTrainRayActor.train_actor``;
-- policy loss terms: ``relax.backends.megatron.loss.policy_loss_function``;
-- actor-step identity: the ``train_one_step`` loop in
-  ``relax.backends.megatron.model``.
-
-The hot-path contract is strict:
-
-- ``CaptureManager.submit`` only *detaches* tensors and enqueues them; it never
-  calls ``.cpu()`` / ``.item()`` / ``.tolist()`` and never touches ``torch.distributed``.
-- The GPU→CPU copy and serialization happen on a dedicated writer thread.
-- The queue is bounded: when full, a step is dropped and a diagnostic is logged
-  (never back-pressure into training).
-- The writer thread isolates all bundle-build failures so a crash there cannot
-  propagate into the training loop.
+Enabled via maybe_enable_from_env. Hooks live in capture_hooks.
+CaptureManager.submit only detaches tensors; GPU→CPU copy and serialization run
+on a bounded writer thread that never back-pressures training.
 """
 
 from __future__ import annotations
@@ -65,24 +46,22 @@ class CaptureConfig:
 
     enabled: bool = False
     output_dir: str | Path = ""
-    bundle_id_prefix: str = "replay"
     queue_capacity: int = 16
     # Actor steps (rollout_id, step_id) to capture; None captures every step.
     selected_steps: set[tuple[int, int]] | None = None
     # Rollouts to capture at rollout level (reward/advantage); None captures every rollout.
     selected_rollouts: set[int] | None = None
     redaction: dict[str, str] = field(default_factory=dict)
-    commit: str = ""
 
 
 @dataclass
 class CaptureRecord:
     """Everything one capture cohort needs to be replayed.
 
-    A record is anchored by exactly one of ``actor_step_id`` (per-step, loss)
-    or ``rollout_id`` (per-rollout, reward/advantage). ``tensors`` holds the
-    post-forward tensor payloads (inputs and expected outputs); ``expected``
-    holds the JSON-serializable expected outputs.
+    A record is anchored by exactly one of actor_step_id (per-step, loss) or
+    rollout_id (per-rollout, reward/advantage). tensors holds the post-forward
+    tensor payloads (inputs and expected outputs); expected holds the JSON-
+    serializable expected outputs.
     """
 
     identity: Identity
@@ -100,9 +79,9 @@ class CaptureRecord:
     # only) sets this explicitly so the manifest does not promise stages whose
     # payloads are absent.
     stages: set[StageId] | None = None
-    # Raw per-sample metadata used to build ``SampleRecord`` on the writer
+    # Raw per-sample metadata used to build SampleRecord on the writer
     # thread. The mask/reward/group tensors stay detached through the hot path;
-    # their GPU→CPU conversion happens only in ``build_bundle_from_record``.
+    # their GPU→CPU conversion happens only in build_bundle_from_record.
     response_lengths: list[int] | None = None
     total_lengths: list[int] | None = None
     loss_masks_tensor: torch.Tensor | None = None
@@ -120,16 +99,39 @@ class CaptureRecord:
         return "<unset>"
 
 
+def _detach_value(value: Any) -> Any:
+    """Detach tensors in a nested dict/list; leave other values unchanged."""
+    if isinstance(value, torch.Tensor):
+        return value.detach()
+    if isinstance(value, dict):
+        return {key: _detach_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_detach_value(item) for item in value]
+    return value
+
+
+def _detach_record(record: CaptureRecord) -> CaptureRecord:
+    """Snapshot record with tensors detached (no GPU→CPU sync)."""
+    return replace(
+        record,
+        tensors={name: tensor.detach() for name, tensor in record.tensors.items()},
+        expected=_detach_value(record.expected),
+        loss_masks_tensor=_detach_value(record.loss_masks_tensor),
+        group_indices_tensor=_detach_value(record.group_indices_tensor),
+        raw_rewards_tensor=_detach_value(record.raw_rewards_tensor),
+        rewards_tensor=_detach_value(record.rewards_tensor),
+    )
+
+
 def build_manifest_for_record(record: CaptureRecord) -> Manifest:
     """Derive the manifest from the frozen V1 capability matrix.
 
-    Each stage in ``STAGE_ORDER`` is declared with the capability the matrix
-    grants for the bundle's topology (``record.config.advantage_estimator`` and
-    ``record.identity.rank["cp"]``). Stages outside the matrix are
-    ``unsupported`` and will be skipped — never silently recomputed. When
-    ``record.stages`` is set, only those stages are declared (the rest get no
-    contract and are skipped), so a partial capture never promises absent
-    payloads.
+    Each stage in STAGE_ORDER is declared with the capability the matrix grants
+    for the bundle's topology (record.config.advantage_estimator and
+    record.identity.rank["cp"]). Stages outside the matrix are unsupported and
+    will be skipped — never silently recomputed. When record.stages is set,
+    only those stages are declared (the rest get no contract and are skipped),
+    so a partial capture never promises absent payloads.
     """
     context_parallel = record.identity.rank.get("cp", 1)
     declared = record.stages if record.stages is not None else set(STAGE_ORDER)
@@ -160,11 +162,11 @@ def build_manifest_for_record(record: CaptureRecord) -> Manifest:
 
 
 def _normalize_expected(expected: dict[str, Any]) -> dict[str, Any]:
-    """Convert detached scalar tensors in ``expected`` to plain floats.
+    """Convert detached scalar tensors in expected to plain floats.
 
-    Runs on the writer thread so the GPU→CPU sync (``.item()``) never happens
-    in the training hot path. Handles nested dicts/lists (e.g. ``loss.policy``
-    metric maps).
+    Runs on the writer thread so the GPU→CPU sync (.item()) never happens in
+    the training hot path. Handles nested dicts/lists (e.g. loss.policy metric
+    maps).
     """
 
     def _convert(value: Any) -> Any:
@@ -180,13 +182,13 @@ def _normalize_expected(expected: dict[str, Any]) -> dict[str, Any]:
 
 
 def _build_samples_from_raw(record: CaptureRecord) -> list[SampleRecord]:
-    """Build the ``SampleRecord`` list from raw per-sample metadata.
+    """Build the SampleRecord list from raw per-sample metadata.
 
-    Runs on the writer thread; the flat ``loss_masks_tensor`` is split back per
-    sample using ``response_lengths``, and the optional group/reward tensors
-    are converted here so their GPU→CPU sync never happens in the hot path.
-    When the group/reward tensors are absent (loss-only capture) placeholders
-    are used.
+    Runs on the writer thread; the flat loss_masks_tensor is split back per
+    sample using response_lengths, and the optional group/reward tensors are
+    converted here so their GPU→CPU sync never happens in the hot path. When
+    the group/reward tensors are absent (loss-only capture) placeholders are
+    used.
     """
     if record.response_lengths is None or record.total_lengths is None or record.loss_masks_tensor is None:
         raise ValueError("capture record has no samples and incomplete raw sample metadata")
@@ -233,7 +235,7 @@ def _build_samples_from_raw(record: CaptureRecord) -> list[SampleRecord]:
 
 
 def _micro_batch_id_for(record: CaptureRecord) -> str | None:
-    """Stable micro-batch id for a per-step capture (``mb-<step_id>``).
+    """Stable micro-batch id for a per-step capture (mb-<step_id>).
 
     Rollout-level records have no actor step, so batch selection stays fail-
     closed.
@@ -244,7 +246,7 @@ def _micro_batch_id_for(record: CaptureRecord) -> str | None:
 
 
 def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> Path:
-    """Serialize one :class:`CaptureRecord` into a replay bundle.
+    """Serialize one CaptureRecord into a replay bundle.
 
     Pure and synchronous; used directly by tests and by the async writer
     thread.
@@ -285,8 +287,8 @@ class CaptureManager:
     """Bounded, asynchronous capture sink.
 
     Owns the writer thread and the bounded queue. Disabled by default: when
-    ``config.enabled`` is False, :meth:`submit` is a no-op that never inspects
-    tensors, so the disabled path is a single branch.
+    config.enabled is False, submit is a no-op that never inspects tensors, so
+    the disabled path is a single branch.
     """
 
     def __init__(self, config: CaptureConfig) -> None:
@@ -334,41 +336,17 @@ class CaptureManager:
         return False
 
     def submit(self, record: CaptureRecord) -> bool:
-        """Enqueue a detached snapshot of ``record``; returns True if queued.
+        """Enqueue a detached snapshot of record; returns True if queued.
 
-        Only ``detach()`` happens on the caller thread (no GPU→CPU sync, no
+        Only detach() happens on the caller thread (no GPU→CPU sync, no
         collective). On queue overflow the record is dropped and False
         returned.
         """
         if not self.enabled or not self._record_selected(record):
             return False
 
-        snapshot = CaptureRecord(
-            identity=record.identity,
-            samples=record.samples,
-            config=record.config,
-            tensors={name: tensor.detach() for name, tensor in record.tensors.items()},
-            expected={
-                key: value.detach() if isinstance(value, torch.Tensor) else value
-                for key, value in record.expected.items()
-            },
-            bundle_id=record.bundle_id,
-            actor_step_id=record.actor_step_id,
-            rollout_id=record.rollout_id,
-            producer=record.producer,
-            redaction=record.redaction,
-            stages=record.stages,
-            response_lengths=record.response_lengths,
-            total_lengths=record.total_lengths,
-            loss_masks_tensor=record.loss_masks_tensor.detach() if record.loss_masks_tensor is not None else None,
-            group_indices_tensor=record.group_indices_tensor.detach()
-            if record.group_indices_tensor is not None
-            else None,
-            raw_rewards_tensor=record.raw_rewards_tensor.detach() if record.raw_rewards_tensor is not None else None,
-            rewards_tensor=record.rewards_tensor.detach() if record.rewards_tensor is not None else None,
-        )
         try:
-            self._queue.put_nowait(snapshot)
+            self._queue.put_nowait(_detach_record(record))
             return True
         except queue.Full:
             self._dropped_count += 1
@@ -394,10 +372,9 @@ class CaptureManager:
             finally:
                 self._queue.task_done()
 
-    def flush(self, wait: bool = False) -> None:
-        """Wait for all currently queued records to be written, if
-        requested."""
-        if self._queue is not None and wait:
+    def flush(self) -> None:
+        """Block until queued records have been written."""
+        if self._queue is not None:
             self._queue.join()
 
     def close(self, timeout: float | None = 10.0) -> None:
@@ -422,17 +399,17 @@ class CaptureManager:
 # Process-global capture state (the thin, hot-path-safe hook surface).
 #
 # Training files call the tiny functions below; everything heavier lives on the
-# ``CaptureManager`` / writer thread. ``active()`` is a single global read and
-# ``current_step()`` a single global read — no GPU→CPU sync, no collective.
+# CaptureManager / writer thread. active() is a single global read and
+# current_step() a single global read — no GPU→CPU sync, no collective.
 # ---------------------------------------------------------------------------
 
 _active: CaptureManager | None = None
-_current_step: StepCapture | None = None
+_current_step: CaptureRecord | None = None
 _atexit_registered: bool = False
 
 
 def _parse_selected_steps(raw: str | None) -> set[tuple[int, int]] | None:
-    """Parse ``RELAX_REPLAY_CAPTURE_STEPS`` (``ROLLOUT_ID:STEP_ID,...``)."""
+    """Parse RELAX_REPLAY_CAPTURE_STEPS (ROLLOUT_ID:STEP_ID,...)."""
     if raw is None or not raw.strip():
         return None
     steps: set[tuple[int, int]] = set()
@@ -451,7 +428,7 @@ def _parse_selected_steps(raw: str | None) -> set[tuple[int, int]] | None:
 
 
 def _parse_selected_rollouts(raw: str | None) -> set[int] | None:
-    """Parse ``RELAX_REPLAY_CAPTURE_ROLLOUTS`` (``ID,ID,...``)."""
+    """Parse RELAX_REPLAY_CAPTURE_ROLLOUTS (ID,ID,...)."""
     if raw is None or not raw.strip():
         return None
     rollouts: set[int] = set()
@@ -467,11 +444,11 @@ def _parse_selected_rollouts(raw: str | None) -> set[int] | None:
 
 
 def config_from_env() -> CaptureConfig | None:
-    """Build a :class:`CaptureConfig` from ``RELAX_REPLAY_CAPTURE*`` env vars.
+    """Build a CaptureConfig from RELAX_REPLAY_CAPTURE* env vars.
 
-    Returns ``None`` when capture is unset/false, so the caller can no-op.
-    ``RELAX_REPLAY_CAPTURE=1`` without ``RELAX_REPLAY_CAPTURE_DIR`` logs a
-    warning and also returns ``None`` — never write to an implicit path.
+    Returns None when capture is unset/false, so the caller can no-op.
+    RELAX_REPLAY_CAPTURE=1 without RELAX_REPLAY_CAPTURE_DIR logs a warning and
+    also returns None — never write to an implicit path.
     """
     if not Envs.RELAX_REPLAY_CAPTURE:
         return None
@@ -490,8 +467,8 @@ def config_from_env() -> CaptureConfig | None:
 def maybe_enable_from_env(*, rank: int | None = None) -> CaptureManager | None:
     """Enable capture from env vars. No-op when capture is not requested.
 
-    ``rank`` scopes the output directory to ``<dir>/rank-<rank>`` so concurrent
-    DP/TP writers do not clobber each other on a shared filesystem.
+    rank scopes the output directory to <dir>/rank-<rank> so concurrent DP/TP
+    writers do not clobber each other on a shared filesystem.
     """
     config = config_from_env()
     if config is None:
@@ -507,7 +484,7 @@ def enable(config: CaptureConfig) -> CaptureManager:
 
     Replaces any previously active manager (flushing it first). This is the
     Python-API injection point: the training actor calls it from
-    :func:`maybe_enable_from_env` — no argument-parsing changes required.
+    maybe_enable_from_env — no argument-parsing changes required.
     """
     global _active, _atexit_registered
     if _active is not None:
@@ -528,67 +505,35 @@ def disable() -> None:
 
 
 def active() -> CaptureManager | None:
-    """Return the active manager, or ``None`` when capture is disabled."""
+    """Return the active manager, or None when capture is disabled."""
     return _active
 
 
-class StepCapture:
-    """Accumulates the data captured for one cohort across hooks.
-
-    Anchored by ``actor_step_id`` (per-step, loss) or ``rollout_id`` (per-
-    rollout, reward/advantage). The training-side hooks write tensors /
-    expected outputs into this object; ``end_step`` / ``end_rollout`` turn it
-    into a :class:`CaptureRecord` and hand it to the manager. All tensor
-    detaching happens in ``CaptureManager.submit``, so the hooks themselves
-    only hold live references.
-    """
-
-    def __init__(
-        self,
-        identity: Identity,
-        config: RecomputeConfig,
-        bundle_id: str,
-        *,
-        actor_step_id: tuple[int, int] | None = None,
-        rollout_id: int | None = None,
-        producer: ProducerInfo | None = None,
-    ) -> None:
-        self.actor_step_id = actor_step_id
-        self.rollout_id = rollout_id
-        self.identity = identity
-        self.config = config
-        self.bundle_id = bundle_id
-        self.producer = producer if producer is not None else ProducerInfo()
-        self.samples: list[SampleRecord] = []
-        self.tensors: dict[str, torch.Tensor] = {}
-        self.expected: dict[str, Any] = {}
-        self.stages: set[StageId] | None = None
-        self.response_lengths: list[int] | None = None
-        self.total_lengths: list[int] | None = None
-        self.loss_masks_tensor: torch.Tensor | None = None
-        self.group_indices_tensor: torch.Tensor | None = None
-        self.raw_rewards_tensor: torch.Tensor | None = None
-        self.rewards_tensor: torch.Tensor | None = None
-
-    def to_record(self) -> CaptureRecord:
-        return CaptureRecord(
-            identity=self.identity,
-            samples=self.samples,
-            config=self.config,
-            tensors=self.tensors,
-            expected=self.expected,
-            bundle_id=self.bundle_id,
-            actor_step_id=self.actor_step_id,
-            rollout_id=self.rollout_id,
-            producer=self.producer,
-            stages=self.stages,
-            response_lengths=self.response_lengths,
-            total_lengths=self.total_lengths,
-            loss_masks_tensor=self.loss_masks_tensor,
-            group_indices_tensor=self.group_indices_tensor,
-            raw_rewards_tensor=self.raw_rewards_tensor,
-            rewards_tensor=self.rewards_tensor,
-        )
+def _open_cohort(
+    *,
+    selected: bool,
+    identity: Identity,
+    config: RecomputeConfig,
+    bundle_id: str,
+    actor_step_id: tuple[int, int] | None = None,
+    rollout_id: int | None = None,
+    producer: ProducerInfo | None = None,
+) -> None:
+    global _current_step
+    if not selected:
+        _current_step = None
+        return
+    _current_step = CaptureRecord(
+        identity=identity,
+        samples=[],
+        config=config,
+        tensors={},
+        expected={},
+        bundle_id=bundle_id,
+        actor_step_id=actor_step_id,
+        rollout_id=rollout_id,
+        producer=producer if producer is not None else ProducerInfo(),
+    )
 
 
 def begin_step(
@@ -600,11 +545,14 @@ def begin_step(
     producer: ProducerInfo | None = None,
 ) -> None:
     """Open a per-step capture accumulator (no-op when disabled/unselected)."""
-    global _current_step
-    if _active is None or not _active.is_selected(actor_step_id):
-        _current_step = None
-        return
-    _current_step = StepCapture(identity, config, bundle_id, actor_step_id=actor_step_id, producer=producer)
+    _open_cohort(
+        selected=_active is not None and _active.is_selected(actor_step_id),
+        identity=identity,
+        config=config,
+        bundle_id=bundle_id,
+        actor_step_id=actor_step_id,
+        producer=producer,
+    )
 
 
 def begin_rollout(
@@ -617,19 +565,18 @@ def begin_rollout(
 ) -> None:
     """Open a per-rollout capture accumulator (no-op when
     disabled/unselected)."""
-    global _current_step
-    if _active is None or not _active.is_rollout_selected(rollout_id):
-        _current_step = None
-        return
-    _current_step = StepCapture(identity, config, bundle_id, rollout_id=rollout_id, producer=producer)
+    _open_cohort(
+        selected=_active is not None and _active.is_rollout_selected(rollout_id),
+        identity=identity,
+        config=config,
+        bundle_id=bundle_id,
+        rollout_id=rollout_id,
+        producer=producer,
+    )
 
 
 def should_capture(actor_step_id: tuple[int, int]) -> bool:
-    """Cheap disabled/unselected guard (two global reads, no allocation).
-
-    Callers use this *before* building an :class:`Identity` /
-    :class:`RecomputeConfig` so the disabled hot path does no work at all.
-    """
+    """Cheap disabled/unselected guard (two global reads, no allocation)."""
     return _active is not None and _active.is_selected(actor_step_id)
 
 
@@ -638,28 +585,20 @@ def should_capture_rollout(rollout_id: int) -> bool:
     return _active is not None and _active.is_rollout_selected(rollout_id)
 
 
-def current_step() -> StepCapture | None:
-    """Return the current cohort's accumulator, or ``None`` when disabled."""
+def current_step() -> CaptureRecord | None:
+    """Return the current cohort's accumulator, or None when disabled."""
     return _current_step
 
 
 def end_step() -> None:
-    """Finalize the current step's accumulator and submit it to the manager.
-
-    Accumulators that never received a payload (non-last PP ranks, unselected
-    hooks) are dropped instead of writing an incomplete bundle.
-    """
+    """Submit the current accumulator, or drop it if no hook filled stages."""
     global _current_step
     step = _current_step
     _current_step = None
-    if step is None or _active is None:
+    if step is None or _active is None or not step.stages:
         return
-    if not step.stages:
-        return
-    _active.submit(step.to_record())
+    _active.submit(step)
 
 
 def end_rollout() -> None:
-    """Finalize the current rollout's accumulator and submit it to the
-    manager."""
     end_step()

--- a/relax/utils/replay/capture.py
+++ b/relax/utils/replay/capture.py
@@ -3,8 +3,9 @@
 """Production capture: post-forward tensors → replay bundle.
 
 Enabled via maybe_enable_from_env. Hooks live in capture_hooks.
-CaptureManager.submit only detaches tensors; GPU→CPU copy and serialization run
-on a bounded writer thread that never back-pressures training.
+CaptureManager.submit detaches and clones tensors (GPU→GPU copy, no CPU sync);
+GPU→CPU copy and serialization run on a bounded writer thread that never
+back-pressures training.
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ import torch
 
 from relax.utils.env import Envs
 from relax.utils.logging_utils import get_logger
-from relax.utils.replay.bundle import BundleWriter
+from relax.utils.replay.bundle import BundleWriter, try_finalize_cohort, write_cohort_shard
 from relax.utils.replay.schema import (
     FORMAT_VERSION,
     STAGE_ORDER,
@@ -52,6 +53,11 @@ class CaptureConfig:
     # Rollouts to capture at rollout level (reward/advantage); None captures every rollout.
     selected_rollouts: set[int] | None = None
     redaction: dict[str, str] = field(default_factory=dict)
+    # Capturing process rank and the last-PP ranks that must publish
+    # COMPLETE.<rank> before the shared cohort is finalized. None means this
+    # rank only (single-rank bundle, no cross-rank coordinator).
+    rank: int = 0
+    expected_ranks: list[int] | None = None
 
 
 @dataclass
@@ -93,6 +99,8 @@ class CaptureRecord:
     # used to ignore activation-checkpoint recomputes of the same micro-batch.
     sample_micro_batch_ids: list[str] | None = None
     captured_micro_batch_ids: set[str] = field(default_factory=set)
+    capture_rank: int = 0
+    expected_ranks: list[int] | None = None
 
     @property
     def anchor(self) -> str:
@@ -104,31 +112,41 @@ class CaptureRecord:
         return "<unset>"
 
 
-def _detach_value(value: Any) -> Any:
-    """Detach tensors in a nested dict/list; leave other values unchanged."""
+def _snapshot_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Detach and clone so later in-place writes cannot mutate the snapshot.
+
+    clone() is a device-local copy (GPU→GPU when the tensor is CUDA) and does
+    not synchronize to CPU. GPU→CPU transfer stays on the writer thread.
+    """
+    return tensor.detach().clone()
+
+
+def _snapshot_value(value: Any) -> Any:
+    """Snapshot tensors in a nested dict/list; leave other values unchanged."""
     if isinstance(value, torch.Tensor):
-        return value.detach()
+        return _snapshot_tensor(value)
     if isinstance(value, dict):
-        return {key: _detach_value(item) for key, item in value.items()}
+        return {key: _snapshot_value(item) for key, item in value.items()}
     if isinstance(value, list):
-        return [_detach_value(item) for item in value]
+        return [_snapshot_value(item) for item in value]
     return value
 
 
-def _detach_record(record: CaptureRecord) -> CaptureRecord:
-    """Snapshot record with tensors detached (no GPU→CPU sync)."""
+def _snapshot_record(record: CaptureRecord) -> CaptureRecord:
+    """Immutable snapshot of record tensors (no GPU→CPU sync)."""
     return replace(
         record,
-        tensors={name: tensor.detach() for name, tensor in record.tensors.items()},
-        expected=_detach_value(record.expected),
-        loss_masks_tensor=_detach_value(record.loss_masks_tensor),
-        group_indices_tensor=_detach_value(record.group_indices_tensor),
-        raw_rewards_tensor=_detach_value(record.raw_rewards_tensor),
-        rewards_tensor=_detach_value(record.rewards_tensor),
+        tensors={name: _snapshot_tensor(tensor) for name, tensor in record.tensors.items()},
+        expected=_snapshot_value(record.expected),
+        loss_masks_tensor=_snapshot_value(record.loss_masks_tensor),
+        group_indices_tensor=_snapshot_value(record.group_indices_tensor),
+        raw_rewards_tensor=_snapshot_value(record.raw_rewards_tensor),
+        rewards_tensor=_snapshot_value(record.rewards_tensor),
         sample_micro_batch_ids=(
             list(record.sample_micro_batch_ids) if record.sample_micro_batch_ids is not None else None
         ),
         captured_micro_batch_ids=set(record.captured_micro_batch_ids),
+        expected_ranks=list(record.expected_ranks) if record.expected_ranks is not None else None,
     )
 
 
@@ -279,14 +297,46 @@ def _identity_micro_batch_ids(record: CaptureRecord, samples: list[SampleRecord]
     return [fallback] if fallback is not None else []
 
 
+def _resolved_ranks(record: CaptureRecord) -> tuple[int, list[int]]:
+    rank = record.capture_rank
+    expected = list(record.expected_ranks) if record.expected_ranks is not None else [rank]
+    return rank, expected
+
+
+def _publish_cohort_and_finalize(
+    cohort_dir: Path,
+    record: CaptureRecord,
+    *,
+    relpath: str | None,
+    payloads: dict[str, str] | None = None,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    rank, expected = _resolved_ranks(record)
+    write_cohort_shard(
+        cohort_dir,
+        rank=rank,
+        identity=record.identity,
+        expected_ranks=expected,
+        payloads=payloads or {},
+        metadata=metadata,
+        relpath=relpath,
+    )
+    try_finalize_cohort(cohort_dir, expected)
+
+
 def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> Path:
     """Serialize one CaptureRecord into a replay bundle.
 
     Pure and synchronous; used directly by tests and by the async writer
-    thread.
+    thread. A multi-rank capture writes rank-local bundles under
+    <dir>/<bundle_id>/rank-<rank>/ and try-finalizes a shared COMPLETE without
+    waiting for other ranks.
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    rank, expected = _resolved_ranks(record)
+    multi = len(expected) > 1
+    cohort_dir = output_dir / record.bundle_id
 
     manifest = build_manifest_for_record(record)
     samples = record.samples if record.samples else _build_samples_from_raw(record)
@@ -298,23 +348,32 @@ def build_bundle_from_record(record: CaptureRecord, output_dir: str | Path) -> P
         identity = replace(identity, micro_batch_ids=micro_batch_ids)
     index = BundleIndex(bundle_id=record.bundle_id, identity=identity, samples=samples, config=record.config)
 
-    expected = _normalize_expected(record.expected)
+    expected_outputs = _normalize_expected(record.expected)
     # Derive per-sample reward expectations from the deferred tensors (writer
     # thread), so the reward adapters have JSON-serializable lists to compare.
     if record.raw_rewards_tensor is not None:
-        expected.setdefault(StageId.REWARD_RAW.value, {})["raw_rewards"] = [
+        expected_outputs.setdefault(StageId.REWARD_RAW.value, {})["raw_rewards"] = [
             float(value) for value in record.raw_rewards_tensor.detach().cpu().tolist()
         ]
     if record.rewards_tensor is not None:
-        expected.setdefault(StageId.REWARD_POST_PROCESS.value, {})["rewards"] = [
+        expected_outputs.setdefault(StageId.REWARD_POST_PROCESS.value, {})["rewards"] = [
             float(value) for value in record.rewards_tensor.detach().cpu().tolist()
         ]
 
-    writer = BundleWriter(output_dir / record.bundle_id, manifest, index, expected)
+    rank_path = (cohort_dir / f"rank-{rank}") if multi else cohort_dir
+    writer = BundleWriter(rank_path, manifest, index, expected_outputs, rank=rank)
     for name, tensor in record.tensors.items():
         writer.write_payload(name, tensor.detach().cpu().contiguous())
-    writer.finalize(ranks=[0])
-    return output_dir / record.bundle_id
+    rank_complete = writer.finalize(ranks=[rank])
+    if multi:
+        _publish_cohort_and_finalize(
+            cohort_dir,
+            record,
+            relpath=f"rank-{rank}",
+            payloads=dict(rank_complete["payloads"]),
+            metadata=dict(rank_complete["metadata"]) if rank_complete.get("metadata") else None,
+        )
+    return rank_path
 
 
 class CaptureManager:
@@ -352,6 +411,14 @@ class CaptureManager:
     def error_count(self) -> int:
         return self._error_count
 
+    @property
+    def rank(self) -> int:
+        return self._config.rank
+
+    @property
+    def expected_ranks(self) -> list[int] | None:
+        return self._config.expected_ranks
+
     def is_selected(self, actor_step_id: tuple[int, int]) -> bool:
         if self._config.selected_steps is None:
             return True
@@ -369,28 +436,36 @@ class CaptureManager:
             return self.is_rollout_selected(record.rollout_id)
         return False
 
-    def submit(self, record: CaptureRecord) -> bool:
-        """Enqueue a detached snapshot of record; returns True if queued.
-
-        Only detach() happens on the caller thread (no GPU→CPU sync, no
-        collective). On queue overflow the record is dropped and False
-        returned.
-        """
-        if not self.enabled or not self._record_selected(record):
-            return False
-
+    def _enqueue(self, record: CaptureRecord, *, drop_label: str) -> bool:
+        assert self._queue is not None
         try:
-            self._queue.put_nowait(_detach_record(record))
+            self._queue.put_nowait(record)
             return True
         except queue.Full:
             self._dropped_count += 1
             logger.warning(
                 "replay capture queue full (capacity=%d); dropping %s (dropped=%d)",
                 self._config.queue_capacity,
-                record.anchor,
+                drop_label,
                 self._dropped_count,
             )
             return False
+
+    def submit(self, record: CaptureRecord) -> bool:
+        """Enqueue a cloned snapshot of record; returns True if queued.
+
+        detach()+clone() happens on the caller thread (no GPU→CPU sync, no
+        collective). On queue overflow the record is dropped and False
+        returned.
+        """
+        if not self.enabled or not self._record_selected(record):
+            return False
+        snapshot = _snapshot_record(record)
+        snapshot.capture_rank = self._config.rank
+        snapshot.expected_ranks = (
+            list(self._config.expected_ranks) if self._config.expected_ranks is not None else None
+        )
+        return self._enqueue(snapshot, drop_label=record.anchor)
 
     def _writer_loop(self) -> None:
         assert self._queue is not None
@@ -498,17 +573,24 @@ def config_from_env() -> CaptureConfig | None:
     )
 
 
-def maybe_enable_from_env(*, rank: int | None = None) -> CaptureManager | None:
+def maybe_enable_from_env(
+    *, rank: int | None = None, expected_ranks: list[int] | None = None
+) -> CaptureManager | None:
     """Enable capture from env vars. No-op when capture is not requested.
 
-    rank scopes the output directory to <dir>/rank-<rank> so concurrent DP/TP
-    writers do not clobber each other on a shared filesystem.
+    rank is this process. expected_ranks is the last-PP producer set that must
+    publish COMPLETE.<rank>; None means this rank only. Output stays under
+    RELAX_REPLAY_CAPTURE_DIR; multi-rank writers coordinate via try_finalize_cohort.
     """
     config = config_from_env()
     if config is None:
         return None
     if rank is not None:
-        config = replace(config, output_dir=str(Path(config.output_dir) / f"rank-{rank}"))
+        config = replace(
+            config,
+            rank=rank,
+            expected_ranks=list(expected_ranks) if expected_ranks is not None else None,
+        )
     logger.info("enabling trajectory-replay capture under %s", config.output_dir)
     return enable(config)
 
@@ -518,7 +600,7 @@ def enable(config: CaptureConfig) -> CaptureManager:
 
     Replaces any previously active manager (flushing it first). This is the
     Python-API injection point: the training actor calls it from
-    maybe_enable_from_env — no argument-parsing changes required.
+    maybe_enable_for_actor — no argument-parsing changes required.
     """
     global _active, _atexit_registered
     if _active is not None:

--- a/relax/utils/replay/capture_hooks.py
+++ b/relax/utils/replay/capture_hooks.py
@@ -1,16 +1,9 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""Train-side hook glue for production capture.
+"""Train-side capture hooks. Import only from loss.py / model.py / actor.py.
 
-Import this module **only** from the hot-path files (``loss.py``, ``model.py``,
-``actor.py``) — it lazily imports ``megatron.core.mpu`` to resolve the parallel
-topology and is therefore *not* part of the offline replay path. The offline
-modules (``runner``, ``adapters``, ``bundle``, ``schema``, ``layout``) never
-import this file.
-
-Each function is a thin, hot-path-safe wrapper: it short-circuits through
-``capture.begin_step`` / ``capture.current_step`` / ``capture.end_step`` when
-capture is disabled or the step is unselected.
+Lazily imports megatron.core.mpu. Offline replay modules must not import this
+file. Disabled path: two global reads, then return.
 """
 
 from __future__ import annotations
@@ -19,16 +12,12 @@ from typing import Any
 
 import torch
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay import capture
 from relax.utils.replay.schema import ActorStepId, Identity, RecomputeConfig, StageId
 
 
-logger = get_logger(__name__)
-
-
 def build_config_from_args(args: Any) -> RecomputeConfig:
-    """Build a :class:`RecomputeConfig` from the runtime ``args`` namespace."""
+    """Build a RecomputeConfig from the runtime args namespace."""
     return RecomputeConfig(
         advantage_estimator=str(getattr(args, "advantage_estimator", "grpo")),
         n_samples_per_prompt=int(getattr(args, "n_samples_per_prompt", 1)),
@@ -41,121 +30,80 @@ def build_config_from_args(args: Any) -> RecomputeConfig:
     )
 
 
-def build_identity(args: Any, rollout_id: int, step_id: int) -> Identity:
-    """Resolve the parallel topology for the captured step via ``mpu``."""
+def _parallel_sizes() -> dict[str, int]:
+    """Megatron parallel world sizes (not the capturing process rank)."""
     from megatron.core import mpu  # lazy: hot-path / megatron only
 
-    return Identity(
-        actor_step_id=ActorStepId(rollout_id=int(rollout_id), step_id=int(step_id)),
-        rank={
-            "dp": int(mpu.get_data_parallel_world_size()),
-            "tp": int(mpu.get_tensor_model_parallel_world_size()),
-            "pp": int(mpu.get_pipeline_model_parallel_world_size()),
-            "cp": int(mpu.get_context_parallel_world_size()),
-        },
-    )
+    return {
+        "dp": int(mpu.get_data_parallel_world_size()),
+        "tp": int(mpu.get_tensor_model_parallel_world_size()),
+        "pp": int(mpu.get_pipeline_model_parallel_world_size()),
+        "cp": int(mpu.get_context_parallel_world_size()),
+    }
 
 
-def build_rollout_identity(args: Any, rollout_id: int) -> Identity:
-    """Resolve the parallel topology for a rollout-level cohort via ``mpu``."""
-    from megatron.core import mpu  # lazy: hot-path / megatron only
-
-    return Identity(
-        rollout_id=int(rollout_id),
-        rank={
-            "dp": int(mpu.get_data_parallel_world_size()),
-            "tp": int(mpu.get_tensor_model_parallel_world_size()),
-            "pp": int(mpu.get_pipeline_model_parallel_world_size()),
-            "cp": int(mpu.get_context_parallel_world_size()),
-        },
-    )
+def build_identity(rollout_id: int, step_id: int | None = None) -> Identity:
+    """Identity for a step (step_id set) or a rollout (step_id omitted)."""
+    rank = _parallel_sizes()
+    if step_id is None:
+        return Identity(rollout_id=int(rollout_id), rank=rank)
+    return Identity(actor_step_id=ActorStepId(rollout_id=int(rollout_id), step_id=int(step_id)), rank=rank)
 
 
 def begin_step_for(args: Any, rollout_id: int, step_id: int, bundle_id: str | None = None) -> None:
-    """Open a per-step accumulator from the ``train_one_step`` loop.
-
-    Short-circuits on the disabled/unselected guard *before* building the
-    identity/config, so the disabled hot path pays only two global reads.
-    """
+    """Open a per-step accumulator from train_one_step."""
     actor_step_id = (int(rollout_id), int(step_id))
     if not capture.should_capture(actor_step_id):
         return
     capture.begin_step(
         actor_step_id,
-        identity=build_identity(args, rollout_id, step_id),
+        identity=build_identity(rollout_id, step_id),
         config=build_config_from_args(args),
         bundle_id=bundle_id if bundle_id is not None else f"replay-{rollout_id}-{step_id}",
     )
 
 
 def end_step_for() -> None:
-    """Finalize and submit the current step's accumulator."""
     capture.end_step()
 
 
 def begin_rollout_for(args: Any, rollout_id: int, bundle_id: str | None = None) -> None:
-    """Open a per-rollout accumulator from the ``train_actor`` loop.
-
-    Captures the reward → advantage chain (a rollout-level cohort). Short-
-    circuits on the disabled/unselected guard before building the
-    identity/config.
-    """
+    """Open a per-rollout accumulator from train_actor."""
     if not capture.should_capture_rollout(int(rollout_id)):
         return
     capture.begin_rollout(
         int(rollout_id),
-        identity=build_rollout_identity(args, rollout_id),
+        identity=build_identity(int(rollout_id)),
         config=build_config_from_args(args),
         bundle_id=bundle_id if bundle_id is not None else f"replay-rollout-{rollout_id}",
     )
 
 
 def end_rollout_for() -> None:
-    """Finalize and submit the current rollout's accumulator."""
     capture.end_rollout()
 
 
 def _cat(tensors: list[torch.Tensor]) -> torch.Tensor:
-    """Flatten a per-sample tensor list into one contiguous 1-D tensor
-    (detached)."""
     return torch.cat([tensor.detach().reshape(-1) for tensor in tensors])
 
 
-def _detach_1d_float(value: Any) -> torch.Tensor:
-    """Return ``value`` as a detached 1-D float tensor (no GPU→CPU sync).
+def _detach_1d(value: Any, dtype: torch.dtype) -> torch.Tensor:
+    """Detached 1-D tensor; no GPU→CPU sync.
 
-    A Python list is already CPU materialized, so ``torch.tensor(list)`` is
-    cheap; a tensor is only detached here, its ``.tolist()`` deferred to the
-    writer.
+    Lists are already on CPU.
     """
     if isinstance(value, torch.Tensor):
-        return value.detach().reshape(-1).float()
-    return torch.tensor(list(value), dtype=torch.float32)
-
-
-def _detach_1d_long(value: Any) -> torch.Tensor:
-    """Return ``value`` as a detached 1-D long tensor (no GPU→CPU sync)."""
-    if isinstance(value, torch.Tensor):
-        return value.detach().reshape(-1).long()
-    return torch.tensor(list(value), dtype=torch.long)
+        return value.detach().reshape(-1).to(dtype)
+    return torch.tensor(list(value), dtype=dtype)
 
 
 def capture_rollout_advantage(*, rollout_data: Any, args: Any) -> None:
-    """Record the reward → advantage chain from ``train_actor`` (rollout
-    level).
-
-    Called once per rollout after ``compute_advantages_and_returns`` has added
-    ``advantages``/``returns``. Every value is stored as a detached tensor
-    reference; per-sample metadata (group index / rewards / masks) is converted
-    on the writer thread. The expected KL is recomputed here from the rollout
-    vs reference log-probs because production keeps it a local variable.
-    """
+    """Record the reward → advantage chain from train_actor."""
     step = capture.current_step()
     if step is None:
         return
 
-    # Non-last pipeline stages return from compute_advantages_and_returns before
-    # "advantages" is written; skip them (the last-PP-stage rank records once).
+    # Non-last PP returns from compute_advantages_and_returns before advantages.
     if rollout_data.get("advantages") is None:
         return
 
@@ -176,9 +124,9 @@ def capture_rollout_advantage(*, rollout_data: Any, args: Any) -> None:
     step.total_lengths = [int(length) for length in rollout_data["total_lengths"]]
     if rollout_data.get("loss_masks"):
         step.loss_masks_tensor = _cat(list(rollout_data["loss_masks"]))
-    step.group_indices_tensor = _detach_1d_long(rollout_data["group_index"])
-    step.raw_rewards_tensor = _detach_1d_float(rollout_data["raw_reward"])
-    step.rewards_tensor = _detach_1d_float(rollout_data["rewards"])
+    step.group_indices_tensor = _detach_1d(rollout_data["group_index"], torch.long)
+    step.raw_rewards_tensor = _detach_1d(rollout_data["raw_reward"], torch.float32)
+    step.rewards_tensor = _detach_1d(rollout_data["rewards"], torch.float32)
 
     log_probs_key = "rollout_log_probs" if use_rollout else "log_probs"
     old_log_probs = list(rollout_data[log_probs_key])
@@ -210,12 +158,7 @@ def capture_policy_loss(
     total_lengths: list[int],
     reported_loss: dict[str, torch.Tensor],
 ) -> None:
-    """Record the ``loss.policy`` stage from inside ``policy_loss_function``.
-
-    Every value is stored as a detached tensor reference — no ``.cpu()`` /
-    ``.item()`` / ``.tolist()`` on the training thread. The loss-mask list is
-    concatenated into a single tensor and split back on the writer thread.
-    """
+    """Record loss.policy from policy_loss_function (detach only)."""
     step = capture.current_step()
     if step is None:
         return

--- a/relax/utils/replay/capture_hooks.py
+++ b/relax/utils/replay/capture_hooks.py
@@ -50,6 +50,44 @@ def build_identity(rollout_id: int, step_id: int | None = None) -> Identity:
     return Identity(actor_step_id=ActorStepId(rollout_id=int(rollout_id), step_id=int(step_id)), rank=rank)
 
 
+def capture_producer_ranks() -> list[int]:
+    """Global ranks on the last pipeline stage (they own post-forward payloads).
+
+    Init-time all-gather; not on the training hot path. Independent of rank order.
+    """
+    import torch.distributed as dist
+    from megatron.core import mpu
+
+    from relax.utils.distributed_utils import get_gloo_group
+
+    flag = bool(mpu.is_pipeline_last_stage(ignore_virtual=True))
+    world = dist.get_world_size()
+    # Last-PP flags are CPU metadata. NCCL all_gather_object copies onto CUDA
+    # and fails after offload_train (cudaErrorInvalidValue).
+    if world == 1:
+        return [0] if flag else []
+    gathered: list[object] = [None] * world
+    dist.all_gather_object(gathered, flag, group=get_gloo_group())
+    return [index for index, item in enumerate(gathered) if item]
+
+
+def maybe_enable_for_actor() -> capture.CaptureManager | None:
+    """Enable capture on last-PP producer ranks only.
+
+    Every actor rank must call this when capture env vars are set (all-gather is
+    collective). Non-producers return without starting a writer thread.
+    """
+    if capture.config_from_env() is None:
+        return None
+    import torch.distributed as dist
+
+    expected = capture_producer_ranks()
+    rank = dist.get_rank()
+    if rank not in expected:
+        return None
+    return capture.maybe_enable_from_env(rank=rank, expected_ranks=expected)
+
+
 def begin_step_for(args: Any, rollout_id: int, step_id: int, bundle_id: str | None = None) -> None:
     """Open a per-step accumulator from train_one_step."""
     actor_step_id = (int(rollout_id), int(step_id))
@@ -97,6 +135,15 @@ def _detach_1d(value: Any, dtype: torch.dtype) -> torch.Tensor:
     return torch.tensor(list(value), dtype=dtype)
 
 
+def _group_indices_from_rollout(rollout_data: Any, args: Any) -> Any:
+    """Prefer TransferQueue ``group_index``; else consecutive GRPO groups."""
+    if "group_index" in rollout_data:
+        return rollout_data["group_index"]
+    n_samples = len(rollout_data["response_lengths"])
+    n = int(getattr(args, "n_samples_per_prompt", 1) or 1)
+    return [index // n for index in range(n_samples)]
+
+
 def capture_rollout_advantage(*, rollout_data: Any, args: Any) -> None:
     """Record the reward → advantage chain from train_actor."""
     step = capture.current_step()
@@ -124,7 +171,7 @@ def capture_rollout_advantage(*, rollout_data: Any, args: Any) -> None:
     step.total_lengths = [int(length) for length in rollout_data["total_lengths"]]
     if rollout_data.get("loss_masks"):
         step.loss_masks_tensor = _cat(list(rollout_data["loss_masks"]))
-    step.group_indices_tensor = _detach_1d(rollout_data["group_index"], torch.long)
+    step.group_indices_tensor = _detach_1d(_group_indices_from_rollout(rollout_data, args), torch.long)
     step.raw_rewards_tensor = _detach_1d(rollout_data["raw_reward"], torch.float32)
     step.rewards_tensor = _detach_1d(rollout_data["rewards"], torch.float32)
 

--- a/relax/utils/replay/capture_hooks.py
+++ b/relax/utils/replay/capture_hooks.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Train-side hook glue for production capture.
+
+Import this module **only** from the hot-path files (``loss.py``, ``model.py``,
+``actor.py``) — it lazily imports ``megatron.core.mpu`` to resolve the parallel
+topology and is therefore *not* part of the offline replay path. The offline
+modules (``runner``, ``adapters``, ``bundle``, ``schema``, ``layout``) never
+import this file.
+
+Each function is a thin, hot-path-safe wrapper: it short-circuits through
+``capture.begin_step`` / ``capture.current_step`` / ``capture.end_step`` when
+capture is disabled or the step is unselected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay import capture
+from relax.utils.replay.schema import ActorStepId, Identity, RecomputeConfig, StageId
+
+
+logger = get_logger(__name__)
+
+
+def build_config_from_args(args: Any) -> RecomputeConfig:
+    """Build a :class:`RecomputeConfig` from the runtime ``args`` namespace."""
+    return RecomputeConfig(
+        advantage_estimator=str(getattr(args, "advantage_estimator", "grpo")),
+        n_samples_per_prompt=int(getattr(args, "n_samples_per_prompt", 1)),
+        grpo_std_normalization=bool(getattr(args, "grpo_std_normalization", False)),
+        kl_loss_type=str(getattr(args, "kl_loss_type", "k1")),
+        kl_coef=float(getattr(args, "kl_coef", 0.0)),
+        eps_clip=float(getattr(args, "eps_clip", 0.2)),
+        eps_clip_high=float(getattr(args, "eps_clip_high", 0.2)),
+        entropy_coef=float(getattr(args, "entropy_coef", 0.0)),
+    )
+
+
+def build_identity(args: Any, rollout_id: int, step_id: int) -> Identity:
+    """Resolve the parallel topology for the captured step via ``mpu``."""
+    from megatron.core import mpu  # lazy: hot-path / megatron only
+
+    return Identity(
+        actor_step_id=ActorStepId(rollout_id=int(rollout_id), step_id=int(step_id)),
+        rank={
+            "dp": int(mpu.get_data_parallel_world_size()),
+            "tp": int(mpu.get_tensor_model_parallel_world_size()),
+            "pp": int(mpu.get_pipeline_model_parallel_world_size()),
+            "cp": int(mpu.get_context_parallel_world_size()),
+        },
+    )
+
+
+def build_rollout_identity(args: Any, rollout_id: int) -> Identity:
+    """Resolve the parallel topology for a rollout-level cohort via ``mpu``."""
+    from megatron.core import mpu  # lazy: hot-path / megatron only
+
+    return Identity(
+        rollout_id=int(rollout_id),
+        rank={
+            "dp": int(mpu.get_data_parallel_world_size()),
+            "tp": int(mpu.get_tensor_model_parallel_world_size()),
+            "pp": int(mpu.get_pipeline_model_parallel_world_size()),
+            "cp": int(mpu.get_context_parallel_world_size()),
+        },
+    )
+
+
+def begin_step_for(args: Any, rollout_id: int, step_id: int, bundle_id: str | None = None) -> None:
+    """Open a per-step accumulator from the ``train_one_step`` loop.
+
+    Short-circuits on the disabled/unselected guard *before* building the
+    identity/config, so the disabled hot path pays only two global reads.
+    """
+    actor_step_id = (int(rollout_id), int(step_id))
+    if not capture.should_capture(actor_step_id):
+        return
+    capture.begin_step(
+        actor_step_id,
+        identity=build_identity(args, rollout_id, step_id),
+        config=build_config_from_args(args),
+        bundle_id=bundle_id if bundle_id is not None else f"replay-{rollout_id}-{step_id}",
+    )
+
+
+def end_step_for() -> None:
+    """Finalize and submit the current step's accumulator."""
+    capture.end_step()
+
+
+def begin_rollout_for(args: Any, rollout_id: int, bundle_id: str | None = None) -> None:
+    """Open a per-rollout accumulator from the ``train_actor`` loop.
+
+    Captures the reward → advantage chain (a rollout-level cohort). Short-
+    circuits on the disabled/unselected guard before building the
+    identity/config.
+    """
+    if not capture.should_capture_rollout(int(rollout_id)):
+        return
+    capture.begin_rollout(
+        int(rollout_id),
+        identity=build_rollout_identity(args, rollout_id),
+        config=build_config_from_args(args),
+        bundle_id=bundle_id if bundle_id is not None else f"replay-rollout-{rollout_id}",
+    )
+
+
+def end_rollout_for() -> None:
+    """Finalize and submit the current rollout's accumulator."""
+    capture.end_rollout()
+
+
+def _cat(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Flatten a per-sample tensor list into one contiguous 1-D tensor
+    (detached)."""
+    return torch.cat([tensor.detach().reshape(-1) for tensor in tensors])
+
+
+def _detach_1d_float(value: Any) -> torch.Tensor:
+    """Return ``value`` as a detached 1-D float tensor (no GPU→CPU sync).
+
+    A Python list is already CPU materialized, so ``torch.tensor(list)`` is
+    cheap; a tensor is only detached here, its ``.tolist()`` deferred to the
+    writer.
+    """
+    if isinstance(value, torch.Tensor):
+        return value.detach().reshape(-1).float()
+    return torch.tensor(list(value), dtype=torch.float32)
+
+
+def _detach_1d_long(value: Any) -> torch.Tensor:
+    """Return ``value`` as a detached 1-D long tensor (no GPU→CPU sync)."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().reshape(-1).long()
+    return torch.tensor(list(value), dtype=torch.long)
+
+
+def capture_rollout_advantage(*, rollout_data: Any, args: Any) -> None:
+    """Record the reward → advantage chain from ``train_actor`` (rollout
+    level).
+
+    Called once per rollout after ``compute_advantages_and_returns`` has added
+    ``advantages``/``returns``. Every value is stored as a detached tensor
+    reference; per-sample metadata (group index / rewards / masks) is converted
+    on the writer thread. The expected KL is recomputed here from the rollout
+    vs reference log-probs because production keeps it a local variable.
+    """
+    step = capture.current_step()
+    if step is None:
+        return
+
+    # Non-last pipeline stages return from compute_advantages_and_returns before
+    # "advantages" is written; skip them (the last-PP-stage rank records once).
+    if rollout_data.get("advantages") is None:
+        return
+
+    from relax.utils.training.ppo_utils import compute_approx_kl  # train-side only
+
+    use_rollout = bool(getattr(args, "use_rollout_logprobs", False))
+    kl_loss_type = str(getattr(args, "kl_loss_type", "k1"))
+    kl_coef = float(getattr(args, "kl_coef", 0.0))
+
+    step.stages = {
+        StageId.REWARD_RAW,
+        StageId.REWARD_POST_PROCESS,
+        StageId.ADVANTAGE_KL,
+        StageId.ADVANTAGE_ESTIMATE,
+    }
+
+    step.response_lengths = [int(length) for length in rollout_data["response_lengths"]]
+    step.total_lengths = [int(length) for length in rollout_data["total_lengths"]]
+    if rollout_data.get("loss_masks"):
+        step.loss_masks_tensor = _cat(list(rollout_data["loss_masks"]))
+    step.group_indices_tensor = _detach_1d_long(rollout_data["group_index"])
+    step.raw_rewards_tensor = _detach_1d_float(rollout_data["raw_reward"])
+    step.rewards_tensor = _detach_1d_float(rollout_data["rewards"])
+
+    log_probs_key = "rollout_log_probs" if use_rollout else "log_probs"
+    old_log_probs = list(rollout_data[log_probs_key])
+    ref_log_probs = list(rollout_data["ref_log_probs"]) if rollout_data.get("ref_log_probs") else None
+
+    step.tensors["old_log_probs"] = _cat(old_log_probs)
+    step.tensors["advantages"] = _cat(list(rollout_data["advantages"]))
+
+    if kl_coef == 0 or ref_log_probs is None:
+        ref_log_probs = [torch.zeros_like(probs, dtype=torch.float32) for probs in old_log_probs]
+        kl = [torch.zeros_like(probs, dtype=torch.float32) for probs in old_log_probs]
+    else:
+        kl = [
+            compute_approx_kl(old_log_probs[index], ref_log_probs[index], kl_loss_type=kl_loss_type)
+            for index in range(len(old_log_probs))
+        ]
+    step.tensors["ref_log_probs"] = _cat(ref_log_probs)
+    step.tensors["kl"] = _cat(kl)
+
+
+def capture_policy_loss(
+    *,
+    old_log_probs: torch.Tensor,
+    log_probs: torch.Tensor,
+    entropy: torch.Tensor,
+    advantages: torch.Tensor,
+    loss_masks: list[torch.Tensor],
+    response_lengths: list[int],
+    total_lengths: list[int],
+    reported_loss: dict[str, torch.Tensor],
+) -> None:
+    """Record the ``loss.policy`` stage from inside ``policy_loss_function``.
+
+    Every value is stored as a detached tensor reference — no ``.cpu()`` /
+    ``.item()`` / ``.tolist()`` on the training thread. The loss-mask list is
+    concatenated into a single tensor and split back on the writer thread.
+    """
+    step = capture.current_step()
+    if step is None:
+        return
+
+    step.stages = {StageId.LOSS_POLICY}
+    step.tensors["old_log_probs"] = old_log_probs.detach()
+    step.tensors["log_probs"] = log_probs.detach()
+    step.tensors["entropy"] = entropy.detach()
+    step.tensors["advantages"] = advantages.detach()
+    step.response_lengths = [int(length) for length in response_lengths]
+    step.total_lengths = [int(length) for length in total_lengths]
+    step.loss_masks_tensor = torch.cat([mask.detach().reshape(-1) for mask in loss_masks]) if loss_masks else None
+
+    policy_fields = ("loss", "pg_loss", "entropy_loss", "pg_clipfrac", "ppo_kl")
+    step.expected[StageId.LOSS_POLICY.value] = {
+        field: value.detach() for field, value in reported_loss.items() if field in policy_fields
+    }

--- a/relax/utils/replay/capture_hooks.py
+++ b/relax/utils/replay/capture_hooks.py
@@ -157,22 +157,49 @@ def capture_policy_loss(
     response_lengths: list[int],
     total_lengths: list[int],
     reported_loss: dict[str, torch.Tensor],
+    micro_batch_index: int | None = None,
 ) -> None:
-    """Record loss.policy from policy_loss_function (detach only)."""
+    """Record loss.policy from policy_loss_function (detach only).
+
+    Each DataIterator micro-batch is appended. A repeated micro_batch_index
+    (activation-checkpoint recompute) is ignored so the first writer wins.
+    """
     step = capture.current_step()
     if step is None:
         return
 
+    mb_id = capture.format_micro_batch_id(0 if micro_batch_index is None else int(micro_batch_index))
+    if mb_id in step.captured_micro_batch_ids:
+        return
+    step.captured_micro_batch_ids.add(mb_id)
+
     step.stages = {StageId.LOSS_POLICY}
-    step.tensors["old_log_probs"] = old_log_probs.detach()
-    step.tensors["log_probs"] = log_probs.detach()
-    step.tensors["entropy"] = entropy.detach()
-    step.tensors["advantages"] = advantages.detach()
-    step.response_lengths = [int(length) for length in response_lengths]
-    step.total_lengths = [int(length) for length in total_lengths]
-    step.loss_masks_tensor = torch.cat([mask.detach().reshape(-1) for mask in loss_masks]) if loss_masks else None
+    _append_flat(step, "old_log_probs", old_log_probs)
+    _append_flat(step, "log_probs", log_probs)
+    _append_flat(step, "entropy", entropy)
+    _append_flat(step, "advantages", advantages)
+
+    lengths = [int(length) for length in response_lengths]
+    step.response_lengths = (step.response_lengths or []) + lengths
+    step.total_lengths = (step.total_lengths or []) + [int(length) for length in total_lengths]
+    step.sample_micro_batch_ids = (step.sample_micro_batch_ids or []) + [mb_id] * len(lengths)
+
+    if loss_masks:
+        masks = torch.cat([mask.detach().reshape(-1) for mask in loss_masks])
+        step.loss_masks_tensor = (
+            masks if step.loss_masks_tensor is None else torch.cat([step.loss_masks_tensor, masks])
+        )
 
     policy_fields = ("loss", "pg_loss", "entropy_loss", "pg_clipfrac", "ppo_kl")
-    step.expected[StageId.LOSS_POLICY.value] = {
-        field: value.detach() for field, value in reported_loss.items() if field in policy_fields
-    }
+    expected = step.expected.setdefault(StageId.LOSS_POLICY.value, {})
+    for field, value in reported_loss.items():
+        if field not in policy_fields:
+            continue
+        detached = value.detach()
+        expected[field] = detached if field not in expected else expected[field] + detached
+
+
+def _append_flat(step: capture.CaptureRecord, name: str, tensor: torch.Tensor) -> None:
+    detached = tensor.detach().reshape(-1)
+    existing = step.tensors.get(name)
+    step.tensors[name] = detached if existing is None else torch.cat([existing, detached])

--- a/relax/utils/replay/capture_hooks.py
+++ b/relax/utils/replay/capture_hooks.py
@@ -51,9 +51,11 @@ def build_identity(rollout_id: int, step_id: int | None = None) -> Identity:
 
 
 def capture_producer_ranks() -> list[int]:
-    """Global ranks on the last pipeline stage (they own post-forward payloads).
+    """Global ranks on the last pipeline stage (they own post-forward
+    payloads).
 
-    Init-time all-gather; not on the training hot path. Independent of rank order.
+    Init-time all-gather; not on the training hot path. Independent of rank
+    order.
     """
     import torch.distributed as dist
     from megatron.core import mpu
@@ -74,8 +76,8 @@ def capture_producer_ranks() -> list[int]:
 def maybe_enable_for_actor() -> capture.CaptureManager | None:
     """Enable capture on last-PP producer ranks only.
 
-    Every actor rank must call this when capture env vars are set (all-gather is
-    collective). Non-producers return without starting a writer thread.
+    Every actor rank must call this when capture env vars are set (all-gather
+    is collective). Non-producers return without starting a writer thread.
     """
     if capture.config_from_env() is None:
         return None

--- a/relax/utils/replay/compare.py
+++ b/relax/utils/replay/compare.py
@@ -4,24 +4,25 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 
-from relax.utils.replay.report import FieldDivergence
+from relax.utils.replay.report import FieldDivergence, StageResult, StageStatus
 from relax.utils.replay.schema import Manifest, StageId
 
 
 def tolerance_for(
     manifest: Manifest, stage: StageId, *, default_atol: float = 1e-6, default_rtol: float = 1e-5
 ) -> tuple[float, float]:
-    """Return ``(atol, rtol)`` for ``stage`` from the manifest, with
-    defaults."""
+    """Return (atol, rtol) for stage from the manifest, with defaults."""
     entry = manifest.comparison_policy.tolerances.get(stage.value, {})
     return entry.get("atol", default_atol), entry.get("rtol", default_rtol)
 
 
 def compare_scalar(expected: float, actual: float, *, atol: float, rtol: float) -> bool:
-    """True when ``actual`` matches ``expected`` within tolerance."""
-    return bool(torch.isclose(torch.tensor(actual), torch.tensor(expected), atol=atol, rtol=rtol))
+    """True when |actual - expected| <= atol + rtol * |expected|."""
+    return abs(actual - expected) <= atol + rtol * abs(expected)
 
 
 def scalar_error(expected: float, actual: float) -> float:
@@ -40,9 +41,9 @@ def compare_tensors(
 ) -> tuple[list[FieldDivergence], float, int, int]:
     """Elementwise-compare two 1-D tensors and localize divergences.
 
-    Returns ``(divergences, max_abs_error, mismatch_count, non_finite_count)``.
-    Flat token index is mapped back to ``(sample_id, token_offset)`` when
-    ``sample_ids``/``response_lengths`` are provided.
+    Returns (divergences, max_abs_error, mismatch_count, non_finite_count).
+    Flat token index is mapped back to (sample_id, token_offset) when
+    sample_ids/response_lengths are provided.
     """
     expected = expected.float().reshape(-1)
     actual = actual.float().reshape(-1)
@@ -70,6 +71,117 @@ def compare_tensors(
             )
         )
     return divergences, max_abs_error, len(mismatched), non_finite
+
+
+def report_scalar_list(
+    result: StageResult,
+    *,
+    expected: list[Any] | None,
+    actual: list[float],
+    sample_ids: list[str],
+    field: str,
+    atol: float,
+    rtol: float,
+    missing: str,
+    mismatch: str,
+) -> StageResult:
+    """Compare per-sample scalars.
+
+    Missing expected values stay PASS.
+    """
+    if expected is None:
+        result.message = missing
+        return result
+    for index, (exp, act) in enumerate(zip(expected, actual, strict=False)):
+        if not compare_scalar(float(exp), float(act), atol=atol, rtol=rtol):
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(
+                    field=field,
+                    sample_id=sample_ids[index],
+                    expected=float(exp),
+                    actual=float(act),
+                    abs_error=scalar_error(float(exp), float(act)),
+                )
+            )
+    if result.status == StageStatus.FAIL:
+        result.message = mismatch.format(n=len(result.divergences))
+    return result
+
+
+def report_scalar_fields(
+    result: StageResult,
+    *,
+    expected: dict[str, Any] | None,
+    actual: dict[str, float],
+    atol: float,
+    rtol: float,
+    missing: str,
+    mismatch: str,
+) -> StageResult:
+    """Compare a map of named scalars.
+
+    Missing expected keys are skipped.
+    """
+    if expected is None:
+        result.message = missing
+        return result
+    for field, actual_value in actual.items():
+        expected_value = expected.get(field)
+        if expected_value is None:
+            continue
+        if not compare_scalar(float(expected_value), float(actual_value), atol=atol, rtol=rtol):
+            result.status = StageStatus.FAIL
+            result.divergences.append(
+                FieldDivergence(
+                    field=field,
+                    expected=float(expected_value),
+                    actual=float(actual_value),
+                    abs_error=scalar_error(float(expected_value), float(actual_value)),
+                )
+            )
+    if result.status == StageStatus.FAIL:
+        result.message = mismatch.format(fields=[item.field for item in result.divergences])
+    return result
+
+
+def report_tensor(
+    result: StageResult,
+    *,
+    expected: torch.Tensor | None,
+    actual: torch.Tensor,
+    field: str,
+    atol: float,
+    rtol: float,
+    sample_ids: list[str],
+    response_lengths: list[int],
+    missing: str,
+    mismatch: str,
+) -> StageResult:
+    """Compare a flat per-token tensor.
+
+    Missing expected payload stays PASS.
+    """
+    if expected is None:
+        result.message = missing
+        return result
+    divergences, max_err, mismatches, non_finite = compare_tensors(
+        expected,
+        actual,
+        field=field,
+        atol=atol,
+        rtol=rtol,
+        sample_ids=sample_ids,
+        response_lengths=response_lengths,
+    )
+    result.divergences = divergences
+    result.max_abs_error = max_err
+    result.mismatch_count = mismatches
+    result.non_finite_count = non_finite
+    if mismatches or non_finite:
+        result.status = StageStatus.FAIL
+        result.message = mismatch.format(n=mismatches)
+    return result
 
 
 def _locate(

--- a/relax/utils/replay/compare.py
+++ b/relax/utils/replay/compare.py
@@ -87,9 +87,11 @@ def report_scalar_list(
 ) -> StageResult:
     """Compare per-sample scalars.
 
-    Missing expected values stay PASS.
+    Missing expected values fail: a recompute stage without recorded outputs
+    is an incomplete bundle, not a silent pass.
     """
     if expected is None:
+        result.status = StageStatus.FAIL
         result.message = missing
         return result
     for index, (exp, act) in enumerate(zip(expected, actual, strict=False)):
@@ -121,14 +123,17 @@ def report_scalar_fields(
 ) -> StageResult:
     """Compare a map of named scalars.
 
-    Missing expected keys are skipped.
+    A missing expected map or key fails the stage.
     """
     if expected is None:
+        result.status = StageStatus.FAIL
         result.message = missing
         return result
     for field, actual_value in actual.items():
         expected_value = expected.get(field)
         if expected_value is None:
+            result.status = StageStatus.FAIL
+            result.divergences.append(FieldDivergence(field=field, actual=float(actual_value)))
             continue
         if not compare_scalar(float(expected_value), float(actual_value), atol=atol, rtol=rtol):
             result.status = StageStatus.FAIL
@@ -160,9 +165,10 @@ def report_tensor(
 ) -> StageResult:
     """Compare a flat per-token tensor.
 
-    Missing expected payload stays PASS.
+    Missing expected payload fails the stage.
     """
     if expected is None:
+        result.status = StageStatus.FAIL
         result.message = missing
         return result
     divergences, max_err, mismatches, non_finite = compare_tensors(

--- a/relax/utils/replay/compare.py
+++ b/relax/utils/replay/compare.py
@@ -87,8 +87,8 @@ def report_scalar_list(
 ) -> StageResult:
     """Compare per-sample scalars.
 
-    Missing expected values fail: a recompute stage without recorded outputs
-    is an incomplete bundle, not a silent pass.
+    Missing expected values fail: a recompute stage without recorded outputs is
+    an incomplete bundle, not a silent pass.
     """
     if expected is None:
         result.status = StageStatus.FAIL

--- a/relax/utils/replay/compare.py
+++ b/relax/utils/replay/compare.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Numerical comparison helpers for replay adapters."""
+
+from __future__ import annotations
+
+import torch
+
+from relax.utils.replay.report import FieldDivergence
+from relax.utils.replay.schema import Manifest, StageId
+
+
+def tolerance_for(
+    manifest: Manifest, stage: StageId, *, default_atol: float = 1e-6, default_rtol: float = 1e-5
+) -> tuple[float, float]:
+    """Return ``(atol, rtol)`` for ``stage`` from the manifest, with
+    defaults."""
+    entry = manifest.comparison_policy.tolerances.get(stage.value, {})
+    return entry.get("atol", default_atol), entry.get("rtol", default_rtol)
+
+
+def compare_scalar(expected: float, actual: float, *, atol: float, rtol: float) -> bool:
+    """True when ``actual`` matches ``expected`` within tolerance."""
+    return bool(torch.isclose(torch.tensor(actual), torch.tensor(expected), atol=atol, rtol=rtol))
+
+
+def scalar_error(expected: float, actual: float) -> float:
+    return abs(actual - expected)
+
+
+def compare_tensors(
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    field: str,
+    atol: float,
+    rtol: float,
+    sample_ids: list[str] | None = None,
+    response_lengths: list[int] | None = None,
+) -> tuple[list[FieldDivergence], float, int, int]:
+    """Elementwise-compare two 1-D tensors and localize divergences.
+
+    Returns ``(divergences, max_abs_error, mismatch_count, non_finite_count)``.
+    Flat token index is mapped back to ``(sample_id, token_offset)`` when
+    ``sample_ids``/``response_lengths`` are provided.
+    """
+    expected = expected.float().reshape(-1)
+    actual = actual.float().reshape(-1)
+    if expected.numel() != actual.numel():
+        raise ValueError(f"shape mismatch for {field!r}: {tuple(expected.shape)} vs {tuple(actual.shape)}")
+
+    diff = (actual - expected).abs()
+    threshold = atol + rtol * expected.abs()
+    mismatched = (diff > threshold).nonzero(as_tuple=False).flatten().tolist()
+
+    non_finite = int((~torch.isfinite(actual)).sum().item())
+    max_abs_error = float(diff.max().item()) if diff.numel() else 0.0
+
+    divergences: list[FieldDivergence] = []
+    for token_index in mismatched[:10]:  # cap the report at 10 concrete examples
+        sample_id, token_offset = _locate(token_index, sample_ids, response_lengths)
+        divergences.append(
+            FieldDivergence(
+                field=field,
+                sample_id=sample_id,
+                token_offset=token_offset,
+                expected=float(expected[token_index].item()),
+                actual=float(actual[token_index].item()),
+                abs_error=float(diff[token_index].item()),
+            )
+        )
+    return divergences, max_abs_error, len(mismatched), non_finite
+
+
+def _locate(
+    token_index: int,
+    sample_ids: list[str] | None,
+    response_lengths: list[int] | None,
+) -> tuple[str | None, int | None]:
+    if not sample_ids or not response_lengths:
+        return None, None
+    offset = token_index
+    for sample_id, length in zip(sample_ids, response_lengths, strict=False):
+        if offset < length:
+            return sample_id, offset
+        offset -= length
+    return None, None

--- a/relax/utils/replay/identity.py
+++ b/relax/utils/replay/identity.py
@@ -2,27 +2,35 @@
 
 """Identity model and dependency closure.
 
-Replay identity is two-layered: *logical* identity (sample, semantic group,
-normalization cohort, actor step) and *physical provenance* (rollout partition,
-consumer batch, micro-batch, rank shard, weight lineage). The dependency
-closure in this module expands a selection to every record it must include
-before a stage may run — and refuses to guess when a mapping is missing,
-mirroring the PR #65 lesson that a physical batch is not a semantic group.
+Expands a sample/group/batch selection to its semantic-group closure and
+refuses to guess when membership is missing (PR #65: physical batch ≠ group).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.schema import BundleIndex, SampleRecord
-
-
-logger = get_logger(__name__)
 
 
 class ClosureError(ValueError):
     """Raised when a selection cannot be expanded to a complete cohort."""
+
+
+def sample_integrity_problems(record: SampleRecord) -> list[tuple[str, str]]:
+    """Return (field, message) pairs for a malformed sample record."""
+    problems: list[tuple[str, str]] = []
+    if record.response_length < 0 or record.total_length < record.response_length:
+        problems.append(("length", f"sample {record.sample_id!r} has invalid lengths"))
+    if len(record.loss_mask) != record.response_length:
+        problems.append(
+            (
+                "loss_mask_length",
+                f"sample {record.sample_id!r} loss_mask length {len(record.loss_mask)} != "
+                f"response_length {record.response_length}",
+            )
+        )
+    return problems
 
 
 @dataclass
@@ -42,7 +50,7 @@ def _sample_to_group(record: SampleRecord) -> str:
 
 
 def group_members(index: BundleIndex, group_id: str) -> list[SampleRecord]:
-    """Return every sample record belonging to semantic group ``group_id``."""
+    """Return every sample record belonging to semantic group group_id."""
     members = [record for record in index.samples if _sample_to_group(record) == group_id]
     if not members:
         raise ClosureError(f"semantic group {group_id!r} has no members in bundle {index.bundle_id!r}")
@@ -50,10 +58,10 @@ def group_members(index: BundleIndex, group_id: str) -> list[SampleRecord]:
 
 
 def batch_members(index: BundleIndex, batch_id: str) -> list[SampleRecord]:
-    """Return every sample record belonging to micro-batch ``batch_id``.
+    """Return every sample record belonging to micro-batch batch_id.
 
     Fails closed when no sample records the batch (including the case where the
-    producer never recorded ``micro_batch_id``), so a selection never silently
+    producer never recorded micro_batch_id), so a selection never silently
     degrades into a physical-size guess.
     """
     members = [record for record in index.samples if record.micro_batch_id == batch_id]
@@ -75,7 +83,7 @@ def expand_selection(
     """Expand a selection into the full semantic-group dependency closure.
 
     Selecting any sample pulls in its entire semantic group, because reward and
-    advantage normalization are group-level. ``batch_ids`` select by physical
+    advantage normalization are group-level. batch_ids select by physical
     micro-batch membership, then pull each member's group the same way. Missing
     membership is a hard error, never an inference from physical batch size.
     """
@@ -118,9 +126,9 @@ def expand_selection(
 def validate_identity(index: BundleIndex) -> None:
     """Verify the index identity has exactly one valid cohort anchor.
 
-    The anchor is either an ``actor_step_id`` ``(rollout_id, step_id)`` tuple
-    (per-step) or a ``rollout_id`` (per-rollout). A scalar
-    ``accumulated_step_id`` is never a valid anchor (see :class:`ActorStepId`).
+    The anchor is either an actor_step_id (rollout_id, step_id) tuple (per-
+    step) or a rollout_id (per-rollout). A scalar accumulated_step_id is never
+    a valid anchor (see ActorStepId).
     """
     identity = index.identity
     if (identity.actor_step_id is None) == (identity.rollout_id is None):

--- a/relax/utils/replay/identity.py
+++ b/relax/utils/replay/identity.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Identity model and dependency closure.
+
+Replay identity is two-layered: *logical* identity (sample, semantic group,
+normalization cohort, actor step) and *physical provenance* (rollout partition,
+consumer batch, micro-batch, rank shard, weight lineage). The dependency
+closure in this module expands a selection to every record it must include
+before a stage may run — and refuses to guess when a mapping is missing,
+mirroring the PR #65 lesson that a physical batch is not a semantic group.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.schema import BundleIndex, SampleRecord
+
+
+logger = get_logger(__name__)
+
+
+class ClosureError(ValueError):
+    """Raised when a selection cannot be expanded to a complete cohort."""
+
+
+@dataclass
+class Closure:
+    """The result of expanding a selection to a replayable cohort."""
+
+    sample_ids: list[str] = field(default_factory=list)
+    group_ids: set[str] = field(default_factory=set)
+    cohort_ids: set[str] = field(default_factory=set)
+
+
+def _sample_to_group(record: SampleRecord) -> str:
+    """Map a sample record to its semantic group id (or fail closed)."""
+    if record.group_index is None:
+        raise ClosureError(f"sample {record.sample_id!r} has no group_index; cannot resolve semantic group")
+    return f"g-{record.group_index}"
+
+
+def group_members(index: BundleIndex, group_id: str) -> list[SampleRecord]:
+    """Return every sample record belonging to semantic group ``group_id``."""
+    members = [record for record in index.samples if _sample_to_group(record) == group_id]
+    if not members:
+        raise ClosureError(f"semantic group {group_id!r} has no members in bundle {index.bundle_id!r}")
+    return members
+
+
+def batch_members(index: BundleIndex, batch_id: str) -> list[SampleRecord]:
+    """Return every sample record belonging to micro-batch ``batch_id``.
+
+    Fails closed when no sample records the batch (including the case where the
+    producer never recorded ``micro_batch_id``), so a selection never silently
+    degrades into a physical-size guess.
+    """
+    members = [record for record in index.samples if record.micro_batch_id == batch_id]
+    if not members:
+        raise ClosureError(
+            f"micro-batch {batch_id!r} has no members in bundle {index.bundle_id!r} "
+            "(or micro_batch_id was not recorded)"
+        )
+    return members
+
+
+def expand_selection(
+    index: BundleIndex,
+    *,
+    sample_ids: list[str] | None = None,
+    group_ids: list[str] | None = None,
+    batch_ids: list[str] | None = None,
+) -> Closure:
+    """Expand a selection into the full semantic-group dependency closure.
+
+    Selecting any sample pulls in its entire semantic group, because reward and
+    advantage normalization are group-level. ``batch_ids`` select by physical
+    micro-batch membership, then pull each member's group the same way. Missing
+    membership is a hard error, never an inference from physical batch size.
+    """
+    records_by_id = {record.sample_id: record for record in index.samples}
+
+    selected_ids: set[str] = set()
+    for sample_id in sample_ids or []:
+        if sample_id not in records_by_id:
+            raise ClosureError(f"sample {sample_id!r} not found in bundle {index.bundle_id!r}")
+        selected_ids.add(sample_id)
+
+    closure_group_ids: set[str] = set(group_ids or [])
+    closure_group_ids.update(_sample_to_group(records_by_id[sample_id]) for sample_id in selected_ids)
+    for batch_id in batch_ids or []:
+        closure_group_ids.update(_sample_to_group(record) for record in batch_members(index, batch_id))
+
+    # An empty selection expands to every group in the bundle, so validation of
+    # the whole bundle never reports a spurious "partial cohort".
+    if not closure_group_ids:
+        closure_group_ids = {_sample_to_group(record) for record in index.samples}
+
+    expanded_ids: list[str] = []
+    for group_id in sorted(closure_group_ids):
+        for record in group_members(index, group_id):
+            if record.sample_id not in expanded_ids:
+                expanded_ids.append(record.sample_id)
+
+    # Preserve original order for the explicitly selected samples, then append
+    # the remaining closure members in stable group order.
+    ordered = [sample_id for sample_id in (sample_ids or []) if sample_id in expanded_ids]
+    ordered.extend(sample_id for sample_id in expanded_ids if sample_id not in ordered)
+
+    return Closure(
+        sample_ids=ordered,
+        group_ids=closure_group_ids,
+        cohort_ids=closure_group_ids,  # GRPO CP=1: semantic group == normalization cohort
+    )
+
+
+def validate_identity(index: BundleIndex) -> None:
+    """Verify the index identity has exactly one valid cohort anchor.
+
+    The anchor is either an ``actor_step_id`` ``(rollout_id, step_id)`` tuple
+    (per-step) or a ``rollout_id`` (per-rollout). A scalar
+    ``accumulated_step_id`` is never a valid anchor (see :class:`ActorStepId`).
+    """
+    identity = index.identity
+    if (identity.actor_step_id is None) == (identity.rollout_id is None):
+        raise ClosureError("identity must set exactly one of actor_step_id or rollout_id")
+    if identity.actor_step_id is not None:
+        step = identity.actor_step_id
+        if step.rollout_id < 0 or step.step_id < 0:
+            raise ClosureError(f"invalid actor step coordinate {step}")
+    elif identity.rollout_id < 0:
+        raise ClosureError(f"invalid rollout id {identity.rollout_id}")

--- a/relax/utils/replay/layout.py
+++ b/relax/utils/replay/layout.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Distributed layout primitives for replay (PR C, pure CPU).
+
+This module owns the *layout metadata* half of distributed replay: resolving a
+``(dp, tp, pp, cp)`` topology, computing token shard offsets, ordering shards
+deterministically, validating that a DP-normalized stage has a complete rank
+set, and reconstructing a canonical logical tensor from rank-local shards (or
+rejecting the capability explicitly).
+
+It is pure: no Ray, no Megatron, no ``torch.distributed``. Reconstruction is a
+sequence of local concats driven entirely by the recorded offsets.
+
+Layout metadata is meant to be persisted alongside the bundle; the JSON
+round-trips here are the on-disk form. The full reduction denominator is *not*
+modeled here — that lives with the loss stage, which records numerator and
+denominator explicitly (see the implementation spec §5.8.3).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from relax.utils.replay.schema import StageCapability, StageId
+
+
+class LayoutError(ValueError):
+    """Raised when shard metadata is missing, incomplete, or inconsistent."""
+
+
+@dataclass(frozen=True)
+class RankTopology:
+    """The parallel topology of a captured bundle."""
+
+    dp: int = 1
+    tp: int = 1
+    pp: int = 1
+    cp: int = 1
+
+    @classmethod
+    def from_rank_dict(cls, rank: Mapping[str, int]) -> "RankTopology":
+        return cls(
+            dp=int(rank.get("dp", 1)),
+            tp=int(rank.get("tp", 1)),
+            pp=int(rank.get("pp", 1)),
+            cp=int(rank.get("cp", 1)),
+        )
+
+    @property
+    def world_size(self) -> int:
+        return self.dp * self.tp * self.pp * self.cp
+
+
+@dataclass(frozen=True)
+class ShardSpec:
+    """One rank-local shard of a logical tensor.
+
+    ``offsets`` are the *global* start coordinates of the shard (``None`` means
+    "not recorded", which reconstruction rejects). ``unpadded_length`` is the
+    number of real elements along the split dimension; the shard's ``shape``
+    may be larger when capture padded it.
+    """
+
+    rank: int
+    offsets: tuple[int, ...] | None
+    shape: tuple[int, ...]
+    unpadded_length: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rank": self.rank,
+            "offsets": list(self.offsets) if self.offsets is not None else None,
+            "shape": list(self.shape),
+            "unpadded_length": self.unpadded_length,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ShardSpec":
+        offsets = data.get("offsets")
+        return cls(
+            rank=int(data["rank"]),
+            offsets=tuple(int(v) for v in offsets) if offsets is not None else None,
+            shape=tuple(int(v) for v in data["shape"]),
+            unpadded_length=data.get("unpadded_length"),
+        )
+
+
+@dataclass(frozen=True)
+class TensorLayout:
+    """Logical tensor shape plus its per-rank shard specs."""
+
+    name: str
+    dims: tuple[int, ...]
+    split_dim: int = 0
+    shards: dict[int, ShardSpec] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "dims": list(self.dims),
+            "split_dim": self.split_dim,
+            "shards": {str(rank): spec.to_dict() for rank, spec in self.shards.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "TensorLayout":
+        return cls(
+            name=str(data["name"]),
+            dims=tuple(int(v) for v in data["dims"]),
+            split_dim=int(data.get("split_dim", 0)),
+            shards={int(rank): ShardSpec.from_dict(spec) for rank, spec in data.get("shards", {}).items()},
+        )
+
+
+def shard_order(ranks: Iterable[int]) -> list[int]:
+    """Return ranks in a deterministic, sorted order."""
+    return sorted(ranks)
+
+
+def compute_offsets(
+    name: str,
+    lengths: Sequence[int],
+    dims: Sequence[int],
+    *,
+    split_dim: int = 0,
+    ranks: Sequence[int] | None = None,
+    pad_to: int | None = None,
+) -> TensorLayout:
+    """Build a :class:`TensorLayout` from per-shard unpadded lengths.
+
+    Shards are placed contiguously along ``split_dim``; every other dimension
+    is assumed full. When ``pad_to`` is set, each shard's split dimension is
+    padded up to a multiple of ``pad_to`` (the padding is recorded via
+    ``unpadded_length``).
+    """
+    dims = tuple(int(v) for v in dims)
+    ranks = shard_order(ranks) if ranks is not None else list(range(len(lengths)))
+    if len(ranks) != len(lengths):
+        raise LayoutError(f"{name!r}: {len(ranks)} ranks but {len(lengths)} lengths")
+
+    shards: dict[int, ShardSpec] = {}
+    offset = 0
+    for rank, length in zip(ranks, lengths, strict=False):
+        length = int(length)
+        shard_len = length
+        if pad_to is not None:
+            shard_len = ((length + pad_to - 1) // pad_to) * pad_to
+        shape = list(dims)
+        shape[split_dim] = shard_len
+        offsets = [0] * len(dims)
+        offsets[split_dim] = offset
+        shards[rank] = ShardSpec(
+            rank=rank,
+            offsets=tuple(offsets),
+            shape=tuple(shape),
+            unpadded_length=length,
+        )
+        # Offsets are canonical (unpadded) logical coordinates; padding is a
+        # storage detail carried by ``shape`` vs ``unpadded_length``.
+        offset += length
+    return TensorLayout(name=name, dims=dims, split_dim=split_dim, shards=shards)
+
+
+def validate_dp_completeness(stage: StageId, required_ranks: Iterable[int], present_ranks: Collection[int]) -> None:
+    """Reject a DP-normalized stage unless every required rank shard is
+    present.
+
+    A stage whose reduction spans the DP dimension (group reward normalization,
+    group advantages) cannot be recomputed from a partial rank set — replay
+    must fail closed rather than guess a denominator from the physical batch.
+    """
+    present = set(present_ranks)
+    missing = [rank for rank in shard_order(required_ranks) if rank not in present]
+    if missing:
+        raise LayoutError(
+            f"{stage.value}: missing DP rank shard(s) {missing}; a DP-normalized stage requires the full rank set"
+        )
+
+
+def reconstruct_shards(layout: TensorLayout, shards: Mapping[int, torch.Tensor]) -> torch.Tensor:
+    """Assemble the canonical logical tensor from rank-local shards.
+
+    Fails closed on any inconsistency: a missing shard, a shard without
+    recorded offsets, an overlap or gap along the split dimension, or a shape
+    mismatch on any non-split dimension.
+    """
+    present = set(shards)
+    missing = [rank for rank in layout.shards if rank not in present]
+    if missing:
+        raise LayoutError(f"{layout.name!r}: missing shard(s) for rank {missing}")
+
+    rank_order = shard_order(layout.shards)
+    pieces: list[torch.Tensor] = []
+    occupied: list[tuple[int, int]] = []  # (start, end) along split_dim, unpadded
+    for rank in rank_order:
+        spec = layout.shards[rank]
+        tensor = shards[rank]
+        if tuple(tensor.shape) != spec.shape:
+            raise LayoutError(f"{layout.name!r} rank {rank}: shard shape {tuple(tensor.shape)} != spec {spec.shape}")
+        if spec.offsets is None:
+            raise LayoutError(f"{layout.name!r} rank {rank}: offsets not recorded; cannot reconstruct")
+
+        for dim, offset in enumerate(spec.offsets):
+            if dim == layout.split_dim:
+                continue
+            if offset != 0:
+                raise LayoutError(f"{layout.name!r} rank {rank}: non-split dim {dim} offset {offset} != 0")
+            if spec.shape[dim] != layout.dims[dim]:
+                raise LayoutError(
+                    f"{layout.name!r} rank {rank}: non-split dim {dim} shape {spec.shape[dim]} != canonical {layout.dims[dim]}"
+                )
+
+        start = spec.offsets[layout.split_dim]
+        unpadded = spec.unpadded_length if spec.unpadded_length is not None else spec.shape[layout.split_dim]
+        if unpadded > spec.shape[layout.split_dim]:
+            raise LayoutError(
+                f"{layout.name!r} rank {rank}: unpadded_length {unpadded} > shard dim {spec.shape[layout.split_dim]}"
+            )
+        end = start + unpadded
+        occupied.append((start, end))
+
+        if unpadded == spec.shape[layout.split_dim]:
+            pieces.append(tensor)
+        else:
+            slices = [slice(None)] * tensor.dim()
+            slices[layout.split_dim] = slice(0, unpadded)
+            pieces.append(tensor[tuple(slices)])
+
+    occupied.sort()
+    expected = 0
+    for start, end in occupied:
+        if start != expected:
+            raise LayoutError(
+                f"{layout.name!r}: gap or overlap in split dim {layout.split_dim} (expected offset {expected}, got {start})"
+            )
+        expected = end
+    if expected != layout.dims[layout.split_dim]:
+        raise LayoutError(
+            f"{layout.name!r}: shards cover {expected} elements but canonical dim is {layout.dims[layout.split_dim]}"
+        )
+
+    return torch.cat(pieces, dim=layout.split_dim)
+
+
+def cp_capability(stage: StageId, cp: int, *, reconstructable: bool) -> StageCapability:
+    """Resolve the replay capability of ``stage`` for a context-parallel
+    topology.
+
+    ``CP=1`` is unsharded. ``CP>1`` requires reconstructable shard offsets; the
+    frozen V1 capability matrix does not yet endorse a ``recompute`` verdict
+    for ``CP>1``, so this returns ``unsupported`` even when the layout *is*
+    reconstructable — the mechanism exists, but the evidence does not.
+    """
+    if cp == 1:
+        return StageCapability.RECOMPUTE if reconstructable else StageCapability.UNSUPPORTED
+    return StageCapability.UNSUPPORTED  # TODO(agent): flip to RECOMPUTE once CP adapters land with parity evidence

--- a/relax/utils/replay/layout.py
+++ b/relax/utils/replay/layout.py
@@ -1,20 +1,10 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""Distributed layout primitives for replay (PR C, pure CPU).
+"""Distributed layout primitives for replay.
 
-This module owns the *layout metadata* half of distributed replay: resolving a
-``(dp, tp, pp, cp)`` topology, computing token shard offsets, ordering shards
-deterministically, validating that a DP-normalized stage has a complete rank
-set, and reconstructing a canonical logical tensor from rank-local shards (or
-rejecting the capability explicitly).
-
-It is pure: no Ray, no Megatron, no ``torch.distributed``. Reconstruction is a
-sequence of local concats driven entirely by the recorded offsets.
-
-Layout metadata is meant to be persisted alongside the bundle; the JSON
-round-trips here are the on-disk form. The full reduction denominator is *not*
-modeled here — that lives with the loss stage, which records numerator and
-denominator explicitly (see the implementation spec §5.8.3).
+Pure CPU: topology, shard offsets, DP completeness, and canonical-tensor
+reconstruction (or explicit rejection). No Ray/Megatron/torch.distributed. CP>1
+stays unsupported in the frozen V1 matrix until parity evidence exists.
 """
 
 from __future__ import annotations
@@ -59,10 +49,10 @@ class RankTopology:
 class ShardSpec:
     """One rank-local shard of a logical tensor.
 
-    ``offsets`` are the *global* start coordinates of the shard (``None`` means
-    "not recorded", which reconstruction rejects). ``unpadded_length`` is the
-    number of real elements along the split dimension; the shard's ``shape``
-    may be larger when capture padded it.
+    offsets are the global start coordinates of the shard (None means "not
+    recorded", which reconstruction rejects). unpadded_length is the number of
+    real elements along the split dimension; the shard's shape may be larger
+    when capture padded it.
     """
 
     rank: int
@@ -130,12 +120,11 @@ def compute_offsets(
     ranks: Sequence[int] | None = None,
     pad_to: int | None = None,
 ) -> TensorLayout:
-    """Build a :class:`TensorLayout` from per-shard unpadded lengths.
+    """Build a TensorLayout from per-shard unpadded lengths.
 
-    Shards are placed contiguously along ``split_dim``; every other dimension
-    is assumed full. When ``pad_to`` is set, each shard's split dimension is
-    padded up to a multiple of ``pad_to`` (the padding is recorded via
-    ``unpadded_length``).
+    Shards are placed contiguously along split_dim; every other dimension is
+    assumed full. When pad_to is set, each shard's split dimension is padded up
+    to a multiple of pad_to (the padding is recorded via unpadded_length).
     """
     dims = tuple(int(v) for v in dims)
     ranks = shard_order(ranks) if ranks is not None else list(range(len(lengths)))
@@ -160,7 +149,7 @@ def compute_offsets(
             unpadded_length=length,
         )
         # Offsets are canonical (unpadded) logical coordinates; padding is a
-        # storage detail carried by ``shape`` vs ``unpadded_length``.
+        # storage detail carried by shape vs unpadded_length.
         offset += length
     return TensorLayout(name=name, dims=dims, split_dim=split_dim, shards=shards)
 
@@ -247,13 +236,12 @@ def reconstruct_shards(layout: TensorLayout, shards: Mapping[int, torch.Tensor])
 
 
 def cp_capability(stage: StageId, cp: int, *, reconstructable: bool) -> StageCapability:
-    """Resolve the replay capability of ``stage`` for a context-parallel
-    topology.
+    """Resolve the replay capability of stage for a context-parallel topology.
 
-    ``CP=1`` is unsharded. ``CP>1`` requires reconstructable shard offsets; the
-    frozen V1 capability matrix does not yet endorse a ``recompute`` verdict
-    for ``CP>1``, so this returns ``unsupported`` even when the layout *is*
-    reconstructable — the mechanism exists, but the evidence does not.
+    CP=1 is unsharded. CP>1 requires reconstructable shard offsets; the frozen
+    V1 capability matrix does not yet endorse a recompute verdict for CP>1, so
+    this returns unsupported even when the layout is reconstructable — the
+    mechanism exists, but the evidence does not.
     """
     if cp == 1:
         return StageCapability.RECOMPUTE if reconstructable else StageCapability.UNSUPPORTED

--- a/relax/utils/replay/report.py
+++ b/relax/utils/replay/report.py
@@ -2,11 +2,10 @@
 
 """Divergence report model.
 
-A replay reports the *first* stage at which recomputed outputs diverge from
+A replay reports the first stage at which recomputed outputs diverge from
 captured expected outputs, plus the field, sample and token offset where
-possible. Stages that were skipped (``recorded-only`` / ``inspect-only`` /
-``unsupported``) are never counted as passing or failing — they are reported as
-``not_verified``.
+possible. Skipped stages (recorded-only / inspect-only / unsupported) never
+count as pass or fail.
 """
 
 from __future__ import annotations

--- a/relax/utils/replay/report.py
+++ b/relax/utils/replay/report.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Divergence report model.
+
+A replay reports the *first* stage at which recomputed outputs diverge from
+captured expected outputs, plus the field, sample and token offset where
+possible. Stages that were skipped (``recorded-only`` / ``inspect-only`` /
+``unsupported``) are never counted as passing or failing — they are reported as
+``not_verified``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class StageStatus(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class FieldDivergence:
+    """A single field/token mismatch within a failing stage."""
+
+    field: str
+    sample_id: str | None = None
+    token_offset: int | None = None
+    expected: float | None = None
+    actual: float | None = None
+    abs_error: float | None = None
+
+
+@dataclass
+class StageResult:
+    """Outcome of replaying one pipeline stage."""
+
+    stage: str
+    status: StageStatus
+    message: str = ""
+    divergences: list[FieldDivergence] = field(default_factory=list)
+    max_abs_error: float | None = None
+    mismatch_count: int = 0
+    non_finite_count: int = 0
+
+
+@dataclass
+class ReplayReport:
+    """Full replay report: per-stage results plus the first divergent stage."""
+
+    bundle_id: str
+    stages: list[StageResult] = field(default_factory=list)
+    first_divergent_stage: str | None = None
+
+    def add(self, result: StageResult) -> None:
+        self.stages.append(result)
+        if result.status == StageStatus.FAIL and self.first_divergent_stage is None:
+            self.first_divergent_stage = result.stage
+
+    @property
+    def passed(self) -> bool:
+        return self.first_divergent_stage is None

--- a/relax/utils/replay/runner.py
+++ b/relax/utils/replay/runner.py
@@ -4,8 +4,11 @@
 
 Executes the pipeline stages in DAG order. Only stages that (a) resolve to
 recompute under the frozen V1 matrix for the bundle's topology and (b) are
-declared recompute in the manifest are executed; everything else is reported as
-skipped and never counted toward the first-divergent-stage determination.
+declared recompute in the manifest are executed. An unsupported topology
+(non-GRPO or CP!=1) raises ValueError. Per-stage unsupported / recorded-only /
+inspect-only results are skipped unless the caller explicitly requested that
+stage, in which case unsupported fails. Skipped stages never count toward the
+first-divergent-stage determination.
 """
 
 from __future__ import annotations
@@ -18,7 +21,7 @@ from relax.utils.replay.bundle import BundleReader, LoadedBundle
 from relax.utils.replay.report import ReplayReport, StageResult, StageStatus
 from relax.utils.replay.schema import STAGE_ORDER, StageCapability, StageId
 from relax.utils.replay.selection import select_bundle
-from relax.utils.replay.stages import capability_for, get_adapter
+from relax.utils.replay.stages import capability_for, get_adapter, topology_supported
 
 
 logger = get_logger(__name__)
@@ -30,45 +33,85 @@ logger = get_logger(__name__)
 _COHORT_LEVEL_STAGES = frozenset({StageId.LOSS_POLICY, StageId.LOSS_VALUE})
 
 
-def replay_bundle(bundle: LoadedBundle, *, partial_selection: bool = False) -> ReplayReport:
+def _requested(stage: StageId, requested_stages: frozenset[str] | None) -> bool:
+    return requested_stages is not None and stage.value in requested_stages
+
+
+def _skip_or_fail(
+    report: ReplayReport,
+    stage: StageId,
+    *,
+    message: str,
+    requested_stages: frozenset[str] | None,
+    fail_if_requested: bool,
+) -> None:
+    """Skip a non-recompute stage, or fail when the caller asked for it."""
+    status = (
+        StageStatus.FAIL if fail_if_requested and _requested(stage, requested_stages) else StageStatus.SKIPPED
+    )
+    report.add(StageResult(stage=stage.value, status=status, message=message))
+
+
+def replay_bundle(
+    bundle: LoadedBundle,
+    *,
+    partial_selection: bool = False,
+    requested_stages: frozenset[str] | None = None,
+) -> ReplayReport:
     """Replay every declared stage and return the divergence report."""
     register_all()
     report = ReplayReport(bundle_id=bundle.index.bundle_id)
     config = bundle.index.config
     context_parallel = bundle.index.identity.rank.get("cp", 1)
+    if not topology_supported(advantage_estimator=config.advantage_estimator, context_parallel=context_parallel):
+        raise ValueError(
+            "unsupported replay topology "
+            f"advantage_estimator={config.advantage_estimator!r} cp={context_parallel} "
+            "(V1 supports GRPO with CP=1)"
+        )
     ctx: dict[str, object] = {}
 
     for stage in STAGE_ORDER:
         if partial_selection and stage in _COHORT_LEVEL_STAGES:
-            report.add(
-                StageResult(
-                    stage=stage.value,
-                    status=StageStatus.SKIPPED,
-                    message="cohort-level stage is not replayable under a partial selection",
-                )
+            _skip_or_fail(
+                report,
+                stage,
+                message="cohort-level stage is not replayable under a partial selection",
+                requested_stages=requested_stages,
+                fail_if_requested=False,
             )
             continue
 
         contract = bundle.manifest.stage_contracts.get(stage)
         if contract is None:
-            report.add(StageResult(stage=stage.value, status=StageStatus.SKIPPED, message="no stage contract"))
+            _skip_or_fail(
+                report,
+                stage,
+                message="no stage contract",
+                requested_stages=requested_stages,
+                fail_if_requested=True,
+            )
             continue
 
         capability = capability_for(
             stage, advantage_estimator=config.advantage_estimator, context_parallel=context_parallel
         )
         if capability != StageCapability.RECOMPUTE:
-            report.add(
-                StageResult(stage=stage.value, status=StageStatus.SKIPPED, message=f"capability={capability.value}")
+            _skip_or_fail(
+                report,
+                stage,
+                message=f"capability={capability.value}",
+                requested_stages=requested_stages,
+                fail_if_requested=capability == StageCapability.UNSUPPORTED,
             )
             continue
         if contract.capability != StageCapability.RECOMPUTE:
-            report.add(
-                StageResult(
-                    stage=stage.value,
-                    status=StageStatus.SKIPPED,
-                    message=f"manifest capability={contract.capability.value}",
-                )
+            _skip_or_fail(
+                report,
+                stage,
+                message=f"manifest capability={contract.capability.value}",
+                requested_stages=requested_stages,
+                fail_if_requested=contract.capability == StageCapability.UNSUPPORTED,
             )
             continue
 
@@ -84,6 +127,7 @@ def replay(
     sample_ids: list[str] | None = None,
     group_ids: list[str] | None = None,
     batch_ids: list[str] | None = None,
+    requested_stages: frozenset[str] | None = None,
 ) -> ReplayReport:
     """Load a bundle from path and replay it (optionally a selection)."""
     bundle = BundleReader(path).load()
@@ -96,4 +140,4 @@ def replay(
         partial_selection = len(bundle.index.samples) != full_count
 
     logger.info("replaying bundle %s (%d samples)", bundle.index.bundle_id, len(bundle.index.samples))
-    return replay_bundle(bundle, partial_selection=partial_selection)
+    return replay_bundle(bundle, partial_selection=partial_selection, requested_stages=requested_stages)

--- a/relax/utils/replay/runner.py
+++ b/relax/utils/replay/runner.py
@@ -3,10 +3,9 @@
 """Offline replay runner.
 
 Executes the pipeline stages in DAG order. Only stages that (a) resolve to
-``recompute`` under the frozen V1 matrix for the bundle's topology and (b) are
-declared ``recompute`` in the manifest are executed; everything else is
-reported as ``skipped`` and never counted toward the first-divergent-stage
-determination.
+recompute under the frozen V1 matrix for the bundle's topology and (b) are
+declared recompute in the manifest are executed; everything else is reported as
+skipped and never counted toward the first-divergent-stage determination.
 """
 
 from __future__ import annotations
@@ -24,7 +23,7 @@ from relax.utils.replay.stages import capability_for, get_adapter
 
 logger = get_logger(__name__)
 
-# Stages whose output is a reduction over the *entire* cohort. They cannot be
+# Stages whose output is a reduction over the entire cohort. They cannot be
 # faithfully recomputed for a partial selection (single sample/group/batch), so
 # a partial replay reports them as skipped rather than comparing a subset scalar
 # against a full-cohort expected value.
@@ -86,7 +85,7 @@ def replay(
     group_ids: list[str] | None = None,
     batch_ids: list[str] | None = None,
 ) -> ReplayReport:
-    """Load a bundle from ``path`` and replay it (optionally a selection)."""
+    """Load a bundle from path and replay it (optionally a selection)."""
     bundle = BundleReader(path).load()
 
     has_selection = any((sample_ids, group_ids, batch_ids))

--- a/relax/utils/replay/runner.py
+++ b/relax/utils/replay/runner.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Offline replay runner.
+
+Executes the pipeline stages in DAG order. Only stages that (a) resolve to
+``recompute`` under the frozen V1 matrix for the bundle's topology and (b) are
+declared ``recompute`` in the manifest are executed; everything else is
+reported as ``skipped`` and never counted toward the first-divergent-stage
+determination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.adapters import register_all
+from relax.utils.replay.bundle import BundleReader, LoadedBundle
+from relax.utils.replay.report import ReplayReport, StageResult, StageStatus
+from relax.utils.replay.schema import STAGE_ORDER, StageCapability, StageId
+from relax.utils.replay.selection import select_bundle
+from relax.utils.replay.stages import capability_for, get_adapter
+
+
+logger = get_logger(__name__)
+
+# Stages whose output is a reduction over the *entire* cohort. They cannot be
+# faithfully recomputed for a partial selection (single sample/group/batch), so
+# a partial replay reports them as skipped rather than comparing a subset scalar
+# against a full-cohort expected value.
+_COHORT_LEVEL_STAGES = frozenset({StageId.LOSS_POLICY, StageId.LOSS_VALUE})
+
+
+def replay_bundle(bundle: LoadedBundle, *, partial_selection: bool = False) -> ReplayReport:
+    """Replay every declared stage and return the divergence report."""
+    register_all()
+    report = ReplayReport(bundle_id=bundle.index.bundle_id)
+    config = bundle.index.config
+    context_parallel = bundle.index.identity.rank.get("cp", 1)
+    ctx: dict[str, object] = {}
+
+    for stage in STAGE_ORDER:
+        if partial_selection and stage in _COHORT_LEVEL_STAGES:
+            report.add(
+                StageResult(
+                    stage=stage.value,
+                    status=StageStatus.SKIPPED,
+                    message="cohort-level stage is not replayable under a partial selection",
+                )
+            )
+            continue
+
+        contract = bundle.manifest.stage_contracts.get(stage)
+        if contract is None:
+            report.add(StageResult(stage=stage.value, status=StageStatus.SKIPPED, message="no stage contract"))
+            continue
+
+        capability = capability_for(
+            stage, advantage_estimator=config.advantage_estimator, context_parallel=context_parallel
+        )
+        if capability != StageCapability.RECOMPUTE:
+            report.add(
+                StageResult(stage=stage.value, status=StageStatus.SKIPPED, message=f"capability={capability.value}")
+            )
+            continue
+        if contract.capability != StageCapability.RECOMPUTE:
+            report.add(
+                StageResult(
+                    stage=stage.value,
+                    status=StageStatus.SKIPPED,
+                    message=f"manifest capability={contract.capability.value}",
+                )
+            )
+            continue
+
+        adapter = get_adapter(stage)
+        report.add(adapter(bundle, ctx))
+
+    return report
+
+
+def replay(
+    path: str | Path,
+    *,
+    sample_ids: list[str] | None = None,
+    group_ids: list[str] | None = None,
+    batch_ids: list[str] | None = None,
+) -> ReplayReport:
+    """Load a bundle from ``path`` and replay it (optionally a selection)."""
+    bundle = BundleReader(path).load()
+
+    has_selection = any((sample_ids, group_ids, batch_ids))
+    partial_selection = False
+    if has_selection:
+        full_count = len(bundle.index.samples)
+        bundle = select_bundle(bundle, sample_ids=sample_ids, group_ids=group_ids, batch_ids=batch_ids)
+        partial_selection = len(bundle.index.samples) != full_count
+
+    logger.info("replaying bundle %s (%d samples)", bundle.index.bundle_id, len(bundle.index.samples))
+    return replay_bundle(bundle, partial_selection=partial_selection)

--- a/relax/utils/replay/runner.py
+++ b/relax/utils/replay/runner.py
@@ -4,8 +4,8 @@
 
 Executes the pipeline stages in DAG order. Only stages that (a) resolve to
 recompute under the frozen V1 matrix for the bundle's topology and (b) are
-declared recompute in the manifest are executed. An unsupported topology
-(non-GRPO or CP!=1) raises ValueError. Per-stage unsupported / recorded-only /
+declared recompute in the manifest are executed. An unsupported topology (non-
+GRPO or CP!=1) raises ValueError. Per-stage unsupported / recorded-only /
 inspect-only results are skipped unless the caller explicitly requested that
 stage, in which case unsupported fails. Skipped stages never count toward the
 first-divergent-stage determination.

--- a/relax/utils/replay/runner.py
+++ b/relax/utils/replay/runner.py
@@ -46,9 +46,7 @@ def _skip_or_fail(
     fail_if_requested: bool,
 ) -> None:
     """Skip a non-recompute stage, or fail when the caller asked for it."""
-    status = (
-        StageStatus.FAIL if fail_if_requested and _requested(stage, requested_stages) else StageStatus.SKIPPED
-    )
+    status = StageStatus.FAIL if fail_if_requested and _requested(stage, requested_stages) else StageStatus.SKIPPED
     report.add(StageResult(stage=stage.value, status=status, message=message))
 
 

--- a/relax/utils/replay/schema.py
+++ b/relax/utils/replay/schema.py
@@ -3,8 +3,8 @@
 """Replay bundle contract.
 
 The on-disk schema for an offline trajectory replay bundle. This module owns
-*data description* only — no production math, no tensors, no I/O beyond
-``dict`` round-trips. The bundle is a directory laid out as::
+data description only — no production math, no tensors, no I/O beyond
+dict round-trips. The bundle is a directory laid out as:
 
     <bundle>/
     ├── manifest.json    # versions, producer, stage contracts, payload specs
@@ -13,7 +13,7 @@ The on-disk schema for an offline trajectory replay bundle. This module owns
     ├── payloads/        # tensor payloads (inputs and expected tensors)
     └── COMPLETE         # completion sentinel (or COMPLETE.<rank> per rank)
 
-Only JSON-compatible metadata and ``weights_only=True`` tensor payloads are
+Only JSON-compatible metadata and weights_only=True tensor payloads are
 accepted, so a bundle can be exchanged without executing arbitrary Python.
 """
 
@@ -25,7 +25,7 @@ from typing import Any
 
 
 # Bundle format version. A reader refuses to open a bundle whose major version
-# differs. ``format_major`` is derived, never stored.
+# differs. format_major is derived, never stored.
 FORMAT_VERSION = "1.0.0"
 FORMAT_MAJOR = FORMAT_VERSION.split(".", maxsplit=1)[0]
 
@@ -76,12 +76,12 @@ STAGE_ORDER: tuple[StageId, ...] = (
 class ActorStepId:
     """Training-step coordinate (Task 34 identity anchor).
 
-    This is the ``(rollout_id, step_id)`` coordinate of one
-    ``train_one_step`` call — the stable identity within a run. The derived
-    ``accumulated_step_id`` scalar is intentionally *not* the identity: under
-    dynamic batching and streaming schedules ``num_steps_per_rollout`` can vary
-    per rollout, so ``rollout_id * num_steps_per_rollout + step_id`` is not a
-    monotonic global counter (see ``relax/backends/megatron/model.py``).
+    This is the (rollout_id, step_id) coordinate of one
+    train_one_step call — the stable identity within a run. The derived
+    accumulated_step_id scalar is intentionally not the identity: under
+    dynamic batching and streaming schedules num_steps_per_rollout can vary
+    per rollout, so rollout_id * num_steps_per_rollout + step_id is not a
+    monotonic global counter (see relax/backends/megatron/model.py).
     """
 
     rollout_id: int
@@ -100,8 +100,8 @@ class WeightLineage:
 class Identity:
     """Logical identity + physical provenance of a captured cohort.
 
-    Anchored by exactly one of ``actor_step_id`` (per-step, loss) or
-    ``rollout_id`` (per-rollout, reward/advantage).
+    Anchored by exactly one of actor_step_id (per-step, loss) or rollout_id
+    (per-rollout, reward/advantage).
     """
 
     actor_step_id: ActorStepId | None = None
@@ -112,15 +112,16 @@ class Identity:
     semantic_group_ids: list[str] = field(default_factory=list)
     normalization_cohort_ids: list[str] = field(default_factory=list)
     weight_lineage: WeightLineage = field(default_factory=WeightLineage)
+    # Parallel world sizes {dp, tp, pp, cp}, not the capturing process rank.
     rank: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
 class SampleRecord:
-    """Replay-relevant, JSON-safe slice of one :class:`Sample`.
+    """Replay-relevant, JSON-safe slice of one Sample.
 
     Text (prompt/response/label) is never stored raw; the caller substitutes a
-    redaction digest. Per-token tensors live in ``payloads/``, not here.
+    redaction digest. Per-token tensors live in payloads/, not here.
     """
 
     sample_id: str
@@ -157,7 +158,7 @@ class StageContract:
     stage: StageId
     version: str
     capability: StageCapability
-    # ``reuse`` — adapter calls the same production kernel; ``reimplemented``
+    # reuse — adapter calls the same production kernel; reimplemented
     # — adapter restates production math and must carry its own parity evidence.
     implementation: str = "reuse"
     inputs: list[str] = field(default_factory=list)

--- a/relax/utils/replay/schema.py
+++ b/relax/utils/replay/schema.py
@@ -1,0 +1,427 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Replay bundle contract.
+
+The on-disk schema for an offline trajectory replay bundle. This module owns
+*data description* only — no production math, no tensors, no I/O beyond
+``dict`` round-trips. The bundle is a directory laid out as::
+
+    <bundle>/
+    ├── manifest.json    # versions, producer, stage contracts, payload specs
+    ├── index.json       # identity + per-sample records + recompute config
+    ├── expected.json    # JSON-serializable expected outputs per stage
+    ├── payloads/        # tensor payloads (inputs and expected tensors)
+    └── COMPLETE         # completion sentinel (or COMPLETE.<rank> per rank)
+
+Only JSON-compatible metadata and ``weights_only=True`` tensor payloads are
+accepted, so a bundle can be exchanged without executing arbitrary Python.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+# Bundle format version. A reader refuses to open a bundle whose major version
+# differs. ``format_major`` is derived, never stored.
+FORMAT_VERSION = "1.0.0"
+FORMAT_MAJOR = FORMAT_VERSION.split(".", maxsplit=1)[0]
+
+# Top-level keys the V1 reader understands for each metadata file. Validation
+# uses these to flag unknown fields (which would otherwise be silently dropped)
+# instead of letting a newer-but-same-major schema degrade without a warning.
+MANIFEST_KEYS = frozenset(
+    {"format_version", "bundle_id", "producer", "stage_contracts", "payloads", "comparison_policy", "redaction"}
+)
+INDEX_KEYS = frozenset({"bundle_id", "identity", "samples", "config"})
+
+
+class StageCapability(str, Enum):
+    """How faithfully a stage can be reproduced offline."""
+
+    RECOMPUTE = "recompute"
+    RECORDED_ONLY = "recorded-only"
+    INSPECT_ONLY = "inspect-only"
+    UNSUPPORTED = "unsupported"
+
+
+class StageId(str, Enum):
+    """Pipeline stages along the reward -> advantage -> loss chain."""
+
+    SAMPLE = "sample"
+    REWARD_RAW = "reward.raw"
+    REWARD_POST_PROCESS = "reward.post_process"
+    ADVANTAGE_KL = "advantage.kl"
+    ADVANTAGE_ESTIMATE = "advantage.estimate"
+    LOSS_POLICY = "loss.policy"
+    LOSS_VALUE = "loss.value"
+
+
+# Stage DAG order used by the offline runner. A stage may only consume outputs
+# produced by stages listed before it.
+STAGE_ORDER: tuple[StageId, ...] = (
+    StageId.SAMPLE,
+    StageId.REWARD_RAW,
+    StageId.REWARD_POST_PROCESS,
+    StageId.ADVANTAGE_KL,
+    StageId.ADVANTAGE_ESTIMATE,
+    StageId.LOSS_POLICY,
+    StageId.LOSS_VALUE,
+)
+
+
+@dataclass(frozen=True)
+class ActorStepId:
+    """Training-step coordinate (Task 34 identity anchor).
+
+    This is the ``(rollout_id, step_id)`` coordinate of one
+    ``train_one_step`` call — the stable identity within a run. The derived
+    ``accumulated_step_id`` scalar is intentionally *not* the identity: under
+    dynamic batching and streaming schedules ``num_steps_per_rollout`` can vary
+    per rollout, so ``rollout_id * num_steps_per_rollout + step_id`` is not a
+    monotonic global counter (see ``relax/backends/megatron/model.py``).
+    """
+
+    rollout_id: int
+    step_id: int
+
+
+@dataclass(frozen=True)
+class WeightLineage:
+    """Weight versions of the producers that shaped a sample."""
+
+    rollout_weight: str | None = None
+    actor_weight: str | None = None
+
+
+@dataclass
+class Identity:
+    """Logical identity + physical provenance of a captured cohort.
+
+    Anchored by exactly one of ``actor_step_id`` (per-step, loss) or
+    ``rollout_id`` (per-rollout, reward/advantage).
+    """
+
+    actor_step_id: ActorStepId | None = None
+    rollout_id: int | None = None
+    rollout_partition_ids: list[str] = field(default_factory=list)
+    consumer_batch_ids: list[str] = field(default_factory=list)
+    micro_batch_ids: list[str] = field(default_factory=list)
+    semantic_group_ids: list[str] = field(default_factory=list)
+    normalization_cohort_ids: list[str] = field(default_factory=list)
+    weight_lineage: WeightLineage = field(default_factory=WeightLineage)
+    rank: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class SampleRecord:
+    """Replay-relevant, JSON-safe slice of one :class:`Sample`.
+
+    Text (prompt/response/label) is never stored raw; the caller substitutes a
+    redaction digest. Per-token tensors live in ``payloads/``, not here.
+    """
+
+    sample_id: str
+    group_index: int | None
+    response_length: int
+    total_length: int
+    loss_mask: list[int]
+    raw_reward: float
+    reward: float
+    label_hash: str | None = None
+    # Physical micro-batch membership (single-batch replay selection). None when
+    # the producer did not record it; batch selection then fails closed.
+    micro_batch_id: str | None = None
+
+
+@dataclass
+class RecomputeConfig:
+    """Numerical configuration required to recompute the frozen V1 path."""
+
+    advantage_estimator: str = "grpo"
+    n_samples_per_prompt: int = 1
+    grpo_std_normalization: bool = False
+    kl_loss_type: str = "k1"
+    kl_coef: float = 0.0
+    eps_clip: float = 0.2
+    eps_clip_high: float = 0.2
+    entropy_coef: float = 0.0
+
+
+@dataclass
+class StageContract:
+    """Versioned capability declaration for one pipeline stage."""
+
+    stage: StageId
+    version: str
+    capability: StageCapability
+    # ``reuse`` — adapter calls the same production kernel; ``reimplemented``
+    # — adapter restates production math and must carry its own parity evidence.
+    implementation: str = "reuse"
+    inputs: list[str] = field(default_factory=list)
+    expected_outputs: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PayloadSpec:
+    """Checksummed description of one tensor payload file."""
+
+    name: str
+    dtype: str
+    shape: list[int]
+    bytes: int
+    sha256: str
+
+
+@dataclass
+class ComparisonPolicy:
+    """Exact-field and floating-tolerance comparison rules."""
+
+    exact_fields: list[str] = field(default_factory=list)
+    tolerances: dict[str, dict[str, float]] = field(default_factory=dict)
+
+
+@dataclass
+class ProducerInfo:
+    """Producer identity used to gate replay on a matching build."""
+
+    commit: str = ""
+    dirty_patch_digest: str = ""
+    torch_version: str = ""
+
+
+@dataclass
+class Manifest:
+    """Top-level self-description of a replay bundle."""
+
+    format_version: str
+    bundle_id: str
+    producer: ProducerInfo
+    stage_contracts: dict[StageId, StageContract]
+    payloads: dict[str, PayloadSpec]
+    comparison_policy: ComparisonPolicy
+    redaction: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class BundleIndex:
+    """Index payload: identity, samples and recompute config."""
+
+    bundle_id: str
+    identity: Identity
+    samples: list[SampleRecord]
+    config: RecomputeConfig
+
+
+def _payload_spec_to_dict(spec: PayloadSpec) -> dict[str, Any]:
+    return {
+        "name": spec.name,
+        "dtype": spec.dtype,
+        "shape": spec.shape,
+        "bytes": spec.bytes,
+        "sha256": spec.sha256,
+    }
+
+
+def _stage_contract_to_dict(contract: StageContract) -> dict[str, Any]:
+    return {
+        "stage": contract.stage.value,
+        "version": contract.version,
+        "capability": contract.capability.value,
+        "implementation": contract.implementation,
+        "inputs": contract.inputs,
+        "expected_outputs": contract.expected_outputs,
+    }
+
+
+def _producer_to_dict(producer: ProducerInfo) -> dict[str, Any]:
+    return {
+        "commit": producer.commit,
+        "dirty_patch_digest": producer.dirty_patch_digest,
+        "torch_version": producer.torch_version,
+    }
+
+
+def manifest_to_dict(manifest: Manifest) -> dict[str, Any]:
+    """Serialize a manifest to a JSON-compatible dict."""
+    return {
+        "format_version": manifest.format_version,
+        "bundle_id": manifest.bundle_id,
+        "producer": _producer_to_dict(manifest.producer),
+        "stage_contracts": {
+            stage.value: _stage_contract_to_dict(contract) for stage, contract in manifest.stage_contracts.items()
+        },
+        "payloads": {name: _payload_spec_to_dict(spec) for name, spec in manifest.payloads.items()},
+        "comparison_policy": {
+            "exact_fields": manifest.comparison_policy.exact_fields,
+            "tolerances": manifest.comparison_policy.tolerances,
+        },
+        "redaction": manifest.redaction,
+    }
+
+
+def manifest_from_dict(data: dict[str, Any]) -> Manifest:
+    """Deserialize and validate a manifest dict."""
+    format_version = data["format_version"]
+    if format_version.split(".", maxsplit=1)[0] != FORMAT_MAJOR:
+        raise ValueError(f"Unsupported bundle format version {format_version!r} (major != {FORMAT_MAJOR})")
+
+    producer_raw = data.get("producer", {})
+    producer = ProducerInfo(
+        commit=producer_raw.get("commit", ""),
+        dirty_patch_digest=producer_raw.get("dirty_patch_digest", ""),
+        torch_version=producer_raw.get("torch_version", ""),
+    )
+
+    stage_contracts: dict[StageId, StageContract] = {}
+    for stage_name, raw in data.get("stage_contracts", {}).items():
+        stage = StageId(stage_name)
+        stage_contracts[stage] = StageContract(
+            stage=stage,
+            version=raw["version"],
+            capability=StageCapability(raw["capability"]),
+            implementation=raw.get("implementation", "reuse"),
+            inputs=raw.get("inputs", []),
+            expected_outputs=raw.get("expected_outputs", []),
+        )
+
+    payloads = {
+        name: PayloadSpec(
+            name=raw["name"],
+            dtype=raw["dtype"],
+            shape=raw["shape"],
+            bytes=raw["bytes"],
+            sha256=raw["sha256"],
+        )
+        for name, raw in data.get("payloads", {}).items()
+    }
+
+    comparison_raw = data.get("comparison_policy", {})
+    comparison = ComparisonPolicy(
+        exact_fields=comparison_raw.get("exact_fields", []),
+        tolerances=comparison_raw.get("tolerances", {}),
+    )
+
+    return Manifest(
+        format_version=format_version,
+        bundle_id=data["bundle_id"],
+        producer=producer,
+        stage_contracts=stage_contracts,
+        payloads=payloads,
+        comparison_policy=comparison,
+        redaction=data.get("redaction", {}),
+    )
+
+
+def _sample_record_to_dict(record: SampleRecord) -> dict[str, Any]:
+    return {
+        "sample_id": record.sample_id,
+        "group_index": record.group_index,
+        "response_length": record.response_length,
+        "total_length": record.total_length,
+        "loss_mask": record.loss_mask,
+        "raw_reward": record.raw_reward,
+        "reward": record.reward,
+        "label_hash": record.label_hash,
+        "micro_batch_id": record.micro_batch_id,
+    }
+
+
+def _sample_record_from_dict(data: dict[str, Any]) -> SampleRecord:
+    return SampleRecord(
+        sample_id=data["sample_id"],
+        group_index=data["group_index"],
+        response_length=data["response_length"],
+        total_length=data["total_length"],
+        loss_mask=data["loss_mask"],
+        raw_reward=data["raw_reward"],
+        reward=data["reward"],
+        label_hash=data.get("label_hash"),
+        micro_batch_id=data.get("micro_batch_id"),
+    )
+
+
+def _identity_to_dict(identity: Identity) -> dict[str, Any]:
+    actor_step_id = identity.actor_step_id
+    return {
+        "actor_step_id": (
+            {"rollout_id": actor_step_id.rollout_id, "step_id": actor_step_id.step_id}
+            if actor_step_id is not None
+            else None
+        ),
+        "rollout_id": identity.rollout_id,
+        "rollout_partition_ids": identity.rollout_partition_ids,
+        "consumer_batch_ids": identity.consumer_batch_ids,
+        "micro_batch_ids": identity.micro_batch_ids,
+        "semantic_group_ids": identity.semantic_group_ids,
+        "normalization_cohort_ids": identity.normalization_cohort_ids,
+        "weight_lineage": {
+            "rollout_weight": identity.weight_lineage.rollout_weight,
+            "actor_weight": identity.weight_lineage.actor_weight,
+        },
+        "rank": identity.rank,
+    }
+
+
+def _identity_from_dict(data: dict[str, Any]) -> Identity:
+    step_raw = data.get("actor_step_id")
+    lineage_raw = data.get("weight_lineage", {})
+    return Identity(
+        actor_step_id=(
+            ActorStepId(rollout_id=step_raw["rollout_id"], step_id=step_raw["step_id"])
+            if step_raw is not None
+            else None
+        ),
+        rollout_id=data.get("rollout_id"),
+        rollout_partition_ids=data.get("rollout_partition_ids", []),
+        consumer_batch_ids=data.get("consumer_batch_ids", []),
+        micro_batch_ids=data.get("micro_batch_ids", []),
+        semantic_group_ids=data.get("semantic_group_ids", []),
+        normalization_cohort_ids=data.get("normalization_cohort_ids", []),
+        weight_lineage=WeightLineage(
+            rollout_weight=lineage_raw.get("rollout_weight"),
+            actor_weight=lineage_raw.get("actor_weight"),
+        ),
+        rank=data.get("rank", {}),
+    )
+
+
+def index_to_dict(index: BundleIndex) -> dict[str, Any]:
+    """Serialize a bundle index to a JSON-compatible dict."""
+    return {
+        "bundle_id": index.bundle_id,
+        "identity": _identity_to_dict(index.identity),
+        "samples": [_sample_record_to_dict(sample) for sample in index.samples],
+        "config": {
+            "advantage_estimator": index.config.advantage_estimator,
+            "n_samples_per_prompt": index.config.n_samples_per_prompt,
+            "grpo_std_normalization": index.config.grpo_std_normalization,
+            "kl_loss_type": index.config.kl_loss_type,
+            "kl_coef": index.config.kl_coef,
+            "eps_clip": index.config.eps_clip,
+            "eps_clip_high": index.config.eps_clip_high,
+            "entropy_coef": index.config.entropy_coef,
+        },
+    }
+
+
+def index_from_dict(data: dict[str, Any]) -> BundleIndex:
+    """Deserialize and validate a bundle index dict."""
+    config_raw = data.get("config", {})
+    return BundleIndex(
+        bundle_id=data["bundle_id"],
+        identity=_identity_from_dict(data["identity"]),
+        samples=[_sample_record_from_dict(sample) for sample in data["samples"]],
+        config=RecomputeConfig(
+            advantage_estimator=config_raw.get("advantage_estimator", "grpo"),
+            n_samples_per_prompt=config_raw.get("n_samples_per_prompt", 1),
+            grpo_std_normalization=config_raw.get("grpo_std_normalization", False),
+            kl_loss_type=config_raw.get("kl_loss_type", "k1"),
+            kl_coef=config_raw.get("kl_coef", 0.0),
+            eps_clip=config_raw.get("eps_clip", 0.2),
+            eps_clip_high=config_raw.get("eps_clip_high", 0.2),
+            entropy_coef=config_raw.get("entropy_coef", 0.0),
+        ),
+    )

--- a/relax/utils/replay/selection.py
+++ b/relax/utils/replay/selection.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Bundle subsetting for replay selection.
+
+``select_bundle`` materializes a replayable subset of a loaded bundle: it
+expands the selection to a complete semantic-group closure, filters the sample
+records, slices the flat per-token tensor payloads, and filters per-sample
+expected lists — so the per-sample/per-token adapters run unchanged on the
+subset. Cohort-level stages (``loss.policy``) are *not* subset-replayable and
+are handled by the runner (see :mod:`relax.utils.replay.runner`).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from relax.utils.replay.bundle import LoadedBundle
+from relax.utils.replay.identity import expand_selection
+from relax.utils.replay.schema import BundleIndex, SampleRecord
+
+
+def _slice_flat(tensor: torch.Tensor, full_samples: list[SampleRecord], selected_ids: list[str]) -> torch.Tensor:
+    """Slice a flat per-token tensor to the selected samples' token spans."""
+    offsets: dict[str, int] = {}
+    lengths: dict[str, int] = {}
+    offset = 0
+    for record in full_samples:
+        offsets[record.sample_id] = offset
+        lengths[record.sample_id] = record.response_length
+        offset += record.response_length
+    chunks = [tensor[offsets[sample_id] : offsets[sample_id] + lengths[sample_id]] for sample_id in selected_ids]
+    if not chunks:
+        return tensor.new_empty((0,), dtype=tensor.dtype)
+    return torch.cat(chunks, dim=0)
+
+
+def _filter_expected(
+    expected: dict[str, object], full_samples: list[SampleRecord], selected_ids: list[str]
+) -> dict[str, object]:
+    """Filter per-sample expected lists (length == sample count) to the
+    selection."""
+    sample_count = len(full_samples)
+    positions = {record.sample_id: index for index, record in enumerate(full_samples)}
+    selected_positions = [positions[sample_id] for sample_id in selected_ids]
+
+    def convert(value: object) -> object:
+        if isinstance(value, list) and len(value) == sample_count:
+            return [value[index] for index in selected_positions]
+        if isinstance(value, dict):
+            return {key: convert(item) for key, item in value.items()}
+        return value
+
+    return {key: convert(value) for key, value in expected.items()}
+
+
+def select_bundle(
+    bundle: LoadedBundle,
+    *,
+    sample_ids: list[str] | None = None,
+    group_ids: list[str] | None = None,
+    batch_ids: list[str] | None = None,
+) -> LoadedBundle:
+    """Return a subset bundle over the selection's semantic-group closure.
+
+    The identity, manifest and per-step expected outputs are preserved; only
+    the sample records, flat tensors and per-sample expected lists are
+    narrowed. A selection that expands to the whole bundle is returned
+    unchanged.
+    """
+    closure = expand_selection(bundle.index, sample_ids=sample_ids, group_ids=group_ids, batch_ids=batch_ids)
+    full_samples = bundle.index.samples
+    if len(closure.sample_ids) == len(full_samples):
+        return bundle
+
+    selected_ids = closure.sample_ids
+    records_by_id = {record.sample_id: record for record in full_samples}
+    samples = [records_by_id[sample_id] for sample_id in selected_ids]
+
+    tensors = {name: _slice_flat(tensor, full_samples, selected_ids) for name, tensor in bundle.tensors.items()}
+    expected = _filter_expected(bundle.expected, full_samples, selected_ids)
+
+    index = BundleIndex(
+        bundle_id=bundle.index.bundle_id,
+        identity=bundle.index.identity,
+        samples=samples,
+        config=bundle.index.config,
+    )
+    return LoadedBundle(manifest=bundle.manifest, index=index, expected=expected, tensors=tensors)

--- a/relax/utils/replay/selection.py
+++ b/relax/utils/replay/selection.py
@@ -2,12 +2,12 @@
 
 """Bundle subsetting for replay selection.
 
-``select_bundle`` materializes a replayable subset of a loaded bundle: it
-expands the selection to a complete semantic-group closure, filters the sample
-records, slices the flat per-token tensor payloads, and filters per-sample
-expected lists — so the per-sample/per-token adapters run unchanged on the
-subset. Cohort-level stages (``loss.policy``) are *not* subset-replayable and
-are handled by the runner (see :mod:`relax.utils.replay.runner`).
+select_bundle materializes a replayable subset of a loaded bundle: it expands
+the selection to a complete semantic-group closure, filters the sample records,
+slices the flat per-token tensor payloads, and filters per-sample expected
+lists — so the per-sample/per-token adapters run unchanged on the subset.
+Cohort-level stages (loss.policy) are not subset-replayable and are handled by
+the runner (see relax.utils.replay.runner).
 """
 
 from __future__ import annotations

--- a/relax/utils/replay/stages.py
+++ b/relax/utils/replay/stages.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Stage registry and the frozen V1 capability matrix.
+
+Task 34 ships with a *frozen* capability matrix for the first delivery: only
+the GRPO ``CP=1`` main path is declared ``recompute``. Any other topology or
+algorithm is explicitly ``unsupported`` and must fail loudly in the runner
+rather than silently degrade. New capabilities are added only by bumping this
+matrix with fresh parity evidence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.schema import StageCapability, StageId
+
+
+logger = get_logger(__name__)
+
+# Frozen V1 matrix. Keys are ``StageId``; the value is the capability for the
+# only supported topology (GRPO, CP=1, colocated or fully-async). Every other
+# topology is resolved through :func:`capability_for` and yields UNSUPPORTED.
+V1_STAGE_CAPABILITIES: dict[StageId, StageCapability] = {
+    StageId.SAMPLE: StageCapability.RECOMPUTE,
+    StageId.REWARD_RAW: StageCapability.RECOMPUTE,
+    StageId.REWARD_POST_PROCESS: StageCapability.RECOMPUTE,
+    StageId.ADVANTAGE_KL: StageCapability.RECOMPUTE,
+    StageId.ADVANTAGE_ESTIMATE: StageCapability.RECOMPUTE,
+    StageId.LOSS_POLICY: StageCapability.RECOMPUTE,
+    StageId.LOSS_VALUE: StageCapability.UNSUPPORTED,  # PPO value head out of V1 scope
+}
+
+# Stage contracts shipped with the frozen matrix.
+V1_STAGE_VERSIONS: dict[StageId, str] = {stage: "v1" for stage in V1_STAGE_CAPABILITIES}
+
+# Stages that restate production math instead of calling the same kernel. The
+# reward group-norm lives in ``relax.utils.utils.post_process_rewards``, a
+# module that imports Ray at module scope; to keep the offline runner Ray-free
+# we restate the (tiny, stable) group-norm here and pin it with the PR #65
+# parity fixture.
+REIMPLEMENTED_STAGES: frozenset[StageId] = frozenset({StageId.REWARD_POST_PROCESS})
+
+# Adapter callable shape: ``(index, bundle_inputs, expected) -> list[StageResult]``.
+StageAdapter = Callable[..., object]
+
+# Registered by :func:`register_adapter`; read by the runner.
+_ADAPTERS: dict[StageId, StageAdapter] = {}
+
+
+def register_adapter(stage: StageId) -> Callable[[StageAdapter], StageAdapter]:
+    """Decorator registering the replay implementation for ``stage``."""
+
+    def _register(func: StageAdapter) -> StageAdapter:
+        if stage in _ADAPTERS:
+            raise ValueError(f"Duplicate replay adapter for stage {stage.value!r}")
+        _ADAPTERS[stage] = func
+        return func
+
+    return _register
+
+
+def get_adapter(stage: StageId) -> StageAdapter:
+    """Return the registered adapter for ``stage``."""
+    try:
+        return _ADAPTERS[stage]
+    except KeyError as exc:
+        raise ValueError(f"No replay adapter registered for stage {stage.value!r}") from exc
+
+
+def capability_for(stage: StageId, *, advantage_estimator: str, context_parallel: int = 1) -> StageCapability:
+    """Resolve the V1 capability for ``stage`` under a given topology.
+
+    Only GRPO with ``CP=1`` is supported. Everything else — including PPO,
+    SAPO/CISPO and any ``CP>1`` topology — is explicitly ``unsupported`` so a
+    caller can never silently claim a recompute it has not proven.
+    """
+    if advantage_estimator != "grpo" or context_parallel != 1:
+        return StageCapability.UNSUPPORTED
+    return V1_STAGE_CAPABILITIES.get(stage, StageCapability.UNSUPPORTED)

--- a/relax/utils/replay/stages.py
+++ b/relax/utils/replay/stages.py
@@ -2,26 +2,23 @@
 
 """Stage registry and the frozen V1 capability matrix.
 
-Task 34 ships with a *frozen* capability matrix for the first delivery: only
-the GRPO ``CP=1`` main path is declared ``recompute``. Any other topology or
-algorithm is explicitly ``unsupported`` and must fail loudly in the runner
-rather than silently degrade. New capabilities are added only by bumping this
-matrix with fresh parity evidence.
+Task 34 ships with a frozen capability matrix for the first delivery: only the
+GRPO CP=1 main path is declared recompute. Any other topology or algorithm is
+explicitly unsupported and must fail loudly in the runner rather than silently
+degrade. New capabilities are added only by bumping this matrix with fresh
+parity evidence.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.schema import StageCapability, StageId
 
 
-logger = get_logger(__name__)
-
-# Frozen V1 matrix. Keys are ``StageId``; the value is the capability for the
+# Frozen V1 matrix. Keys are StageId; the value is the capability for the
 # only supported topology (GRPO, CP=1, colocated or fully-async). Every other
-# topology is resolved through :func:`capability_for` and yields UNSUPPORTED.
+# topology is resolved through capability_for and yields UNSUPPORTED.
 V1_STAGE_CAPABILITIES: dict[StageId, StageCapability] = {
     StageId.SAMPLE: StageCapability.RECOMPUTE,
     StageId.REWARD_RAW: StageCapability.RECOMPUTE,
@@ -36,21 +33,21 @@ V1_STAGE_CAPABILITIES: dict[StageId, StageCapability] = {
 V1_STAGE_VERSIONS: dict[StageId, str] = {stage: "v1" for stage in V1_STAGE_CAPABILITIES}
 
 # Stages that restate production math instead of calling the same kernel. The
-# reward group-norm lives in ``relax.utils.utils.post_process_rewards``, a
+# reward group-norm lives in relax.utils.utils.post_process_rewards, a
 # module that imports Ray at module scope; to keep the offline runner Ray-free
 # we restate the (tiny, stable) group-norm here and pin it with the PR #65
 # parity fixture.
 REIMPLEMENTED_STAGES: frozenset[StageId] = frozenset({StageId.REWARD_POST_PROCESS})
 
-# Adapter callable shape: ``(index, bundle_inputs, expected) -> list[StageResult]``.
+# Adapter callable shape: (index, bundle_inputs, expected) -> list[StageResult].
 StageAdapter = Callable[..., object]
 
-# Registered by :func:`register_adapter`; read by the runner.
+# Registered by register_adapter; read by the runner.
 _ADAPTERS: dict[StageId, StageAdapter] = {}
 
 
 def register_adapter(stage: StageId) -> Callable[[StageAdapter], StageAdapter]:
-    """Decorator registering the replay implementation for ``stage``."""
+    """Decorator registering the replay implementation for stage."""
 
     def _register(func: StageAdapter) -> StageAdapter:
         if stage in _ADAPTERS:
@@ -62,7 +59,7 @@ def register_adapter(stage: StageId) -> Callable[[StageAdapter], StageAdapter]:
 
 
 def get_adapter(stage: StageId) -> StageAdapter:
-    """Return the registered adapter for ``stage``."""
+    """Return the registered adapter for stage."""
     try:
         return _ADAPTERS[stage]
     except KeyError as exc:
@@ -70,11 +67,11 @@ def get_adapter(stage: StageId) -> StageAdapter:
 
 
 def capability_for(stage: StageId, *, advantage_estimator: str, context_parallel: int = 1) -> StageCapability:
-    """Resolve the V1 capability for ``stage`` under a given topology.
+    """Resolve the V1 capability for stage under a given topology.
 
-    Only GRPO with ``CP=1`` is supported. Everything else — including PPO,
-    SAPO/CISPO and any ``CP>1`` topology — is explicitly ``unsupported`` so a
-    caller can never silently claim a recompute it has not proven.
+    Only GRPO with CP=1 is supported. Everything else — including PPO,
+    SAPO/CISPO and any CP>1 topology — is explicitly unsupported so a caller
+    can never silently claim a recompute it has not proven.
     """
     if advantage_estimator != "grpo" or context_parallel != 1:
         return StageCapability.UNSUPPORTED

--- a/relax/utils/replay/stages.py
+++ b/relax/utils/replay/stages.py
@@ -66,6 +66,11 @@ def get_adapter(stage: StageId) -> StageAdapter:
         raise ValueError(f"No replay adapter registered for stage {stage.value!r}") from exc
 
 
+def topology_supported(*, advantage_estimator: str, context_parallel: int = 1) -> bool:
+    """True when the frozen V1 matrix can recompute this bundle's topology."""
+    return advantage_estimator == "grpo" and context_parallel == 1
+
+
 def capability_for(stage: StageId, *, advantage_estimator: str, context_parallel: int = 1) -> StageCapability:
     """Resolve the V1 capability for stage under a given topology.
 
@@ -73,6 +78,6 @@ def capability_for(stage: StageId, *, advantage_estimator: str, context_parallel
     SAPO/CISPO and any CP>1 topology — is explicitly unsupported so a caller
     can never silently claim a recompute it has not proven.
     """
-    if advantage_estimator != "grpo" or context_parallel != 1:
+    if not topology_supported(advantage_estimator=advantage_estimator, context_parallel=context_parallel):
         return StageCapability.UNSUPPORTED
     return V1_STAGE_CAPABILITIES.get(stage, StageCapability.UNSUPPORTED)

--- a/relax/utils/replay/validate.py
+++ b/relax/utils/replay/validate.py
@@ -2,9 +2,9 @@
 
 """Bundle validation.
 
-``validate`` checks a bundle's format, integrity, safety and dependency closure
-*without* executing any numerical replay. It is the gate that runs before every
-``replay`` so a stage can never start on an incomplete or tampered bundle.
+validate checks a bundle's format, integrity, safety and dependency closure
+without executing any numerical replay. It is the gate that runs before every
+replay so a stage can never start on an incomplete or tampered bundle.
 """
 
 from __future__ import annotations
@@ -15,13 +15,9 @@ from pathlib import Path
 
 import torch
 
-from relax.utils.logging_utils import get_logger
 from relax.utils.replay.bundle import BundleReader, LoadedBundle
-from relax.utils.replay.identity import ClosureError, expand_selection, validate_identity
+from relax.utils.replay.identity import ClosureError, expand_selection, sample_integrity_problems, validate_identity
 from relax.utils.replay.schema import INDEX_KEYS, MANIFEST_KEYS, StageCapability
-
-
-logger = get_logger(__name__)
 
 
 @dataclass
@@ -98,13 +94,8 @@ def _validate_sample_records(bundle: LoadedBundle, result: ValidationResult) -> 
         if record.sample_id in seen:
             result.add_error(f"duplicate sample_id {record.sample_id!r}")
         seen.add(record.sample_id)
-        if record.response_length < 0 or record.total_length < record.response_length:
-            result.add_error(f"sample {record.sample_id!r} has invalid lengths")
-        if len(record.loss_mask) != record.response_length:
-            result.add_error(
-                f"sample {record.sample_id!r} loss_mask length {len(record.loss_mask)} != response_length "
-                f"{record.response_length}"
-            )
+        for _field, message in sample_integrity_problems(record):
+            result.add_error(message)
 
 
 def _validate_capabilities(bundle: LoadedBundle, result: ValidationResult) -> None:

--- a/relax/utils/replay/validate.py
+++ b/relax/utils/replay/validate.py
@@ -105,6 +105,9 @@ def _validate_capabilities(bundle: LoadedBundle, result: ValidationResult) -> No
             result.add_warning(f"stage {stage.value!r} is unsupported in this bundle")
     if config.advantage_estimator != "grpo":
         result.add_error(f"unsupported advantage_estimator {config.advantage_estimator!r} (V1 supports GRPO only)")
+    context_parallel = bundle.index.identity.rank.get("cp", 1)
+    if context_parallel != 1:
+        result.add_error(f"unsupported context parallel cp={context_parallel} (V1 supports CP=1 only)")
 
 
 def _validate_numerics(bundle: LoadedBundle, result: ValidationResult) -> None:

--- a/relax/utils/replay/validate.py
+++ b/relax/utils/replay/validate.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Bundle validation.
+
+``validate`` checks a bundle's format, integrity, safety and dependency closure
+*without* executing any numerical replay. It is the gate that runs before every
+``replay`` so a stage can never start on an incomplete or tampered bundle.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+
+from relax.utils.logging_utils import get_logger
+from relax.utils.replay.bundle import BundleReader, LoadedBundle
+from relax.utils.replay.identity import ClosureError, expand_selection, validate_identity
+from relax.utils.replay.schema import INDEX_KEYS, MANIFEST_KEYS, StageCapability
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of a bundle validation."""
+
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def add_error(self, message: str) -> None:
+        self.valid = False
+        self.errors.append(message)
+
+    def add_warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+
+def validate_bundle(path: str | Path) -> ValidationResult:
+    """Validate format, integrity, safety and closure of a bundle."""
+    result = ValidationResult(valid=True)
+    _validate_unknown_fields(Path(path), result)
+    try:
+        bundle = BundleReader(path).load()
+    except Exception as exc:  # noqa: BLE001 — surface every read failure as a validation error
+        result.add_error(f"bundle read failed: {exc}")
+        return result
+
+    _validate_identity(bundle, result)
+    _validate_sample_records(bundle, result)
+    _validate_capabilities(bundle, result)
+    _validate_numerics(bundle, result)
+    _validate_closure(bundle, result)
+    _validate_producer(bundle, result)
+    return result
+
+
+def _validate_unknown_fields(path: Path, result: ValidationResult) -> None:
+    """Warn on metadata fields the V1 reader does not understand.
+
+    A bundle may carry fields introduced by a newer-but-same-major schema; the
+    reader must not silently drop them, so they surface as warnings.
+    """
+    for filename, allowed in (("manifest.json", MANIFEST_KEYS), ("index.json", INDEX_KEYS)):
+        try:
+            data = json.loads((path / filename).read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue  # the reader's own load() will produce the authoritative error
+        unknown = sorted(set(data) - set(allowed))
+        if unknown:
+            result.add_warning(f"{filename} has unknown field(s) {unknown}; the V1 reader will ignore them")
+
+
+def _validate_producer(bundle: LoadedBundle, result: ValidationResult) -> None:
+    """Flag missing build provenance so same-code-version replay is
+    explicit."""
+    if not bundle.manifest.producer.commit:
+        result.add_warning("producer commit is unset; cannot verify the bundle was produced by the same code version")
+
+
+def _validate_identity(bundle: LoadedBundle, result: ValidationResult) -> None:
+    try:
+        validate_identity(bundle.index)
+    except ClosureError as exc:
+        result.add_error(str(exc))
+
+
+def _validate_sample_records(bundle: LoadedBundle, result: ValidationResult) -> None:
+    if not bundle.index.samples:
+        result.add_error("bundle index has no samples")
+        return
+    seen: set[str] = set()
+    for record in bundle.index.samples:
+        if record.sample_id in seen:
+            result.add_error(f"duplicate sample_id {record.sample_id!r}")
+        seen.add(record.sample_id)
+        if record.response_length < 0 or record.total_length < record.response_length:
+            result.add_error(f"sample {record.sample_id!r} has invalid lengths")
+        if len(record.loss_mask) != record.response_length:
+            result.add_error(
+                f"sample {record.sample_id!r} loss_mask length {len(record.loss_mask)} != response_length "
+                f"{record.response_length}"
+            )
+
+
+def _validate_capabilities(bundle: LoadedBundle, result: ValidationResult) -> None:
+    config = bundle.index.config
+    for stage, contract in bundle.manifest.stage_contracts.items():
+        if contract.capability == StageCapability.UNSUPPORTED:
+            result.add_warning(f"stage {stage.value!r} is unsupported in this bundle")
+    if config.advantage_estimator != "grpo":
+        result.add_error(f"unsupported advantage_estimator {config.advantage_estimator!r} (V1 supports GRPO only)")
+
+
+def _validate_numerics(bundle: LoadedBundle, result: ValidationResult) -> None:
+    for name, tensor in bundle.tensors.items():
+        if not torch.isfinite(tensor).all():
+            result.add_error(f"payload {name!r} contains NaN or Inf")
+        if tensor.dtype not in (torch.float32, torch.float64):
+            result.add_warning(f"payload {name!r} has dtype {tensor.dtype}; expect float for replay")
+
+
+def _validate_closure(bundle: LoadedBundle, result: ValidationResult) -> None:
+    try:
+        closure = expand_selection(bundle.index)
+        if len(closure.sample_ids) != len(bundle.index.samples):
+            result.add_error("dependency closure does not cover all samples")
+    except ClosureError as exc:
+        result.add_error(str(exc))

--- a/relax/utils/training/data_fields.py
+++ b/relax/utils/training/data_fields.py
@@ -12,6 +12,7 @@ def _base_rollout_fields(args: Namespace) -> list[str]:
         "rollout_log_probs",
         "rewards",
         "raw_reward",
+        "group_index",
     ]
     if getattr(args, "use_rollout_routing_replay", False):
         fields.append("rollout_routed_experts")

--- a/relax/utils/utils.py
+++ b/relax/utils/utils.py
@@ -106,6 +106,9 @@ def convert_samples_to_train_data(args: Any, samples: list[Sample] | list[list[S
         # we could use key to select the reward.
         "rewards": rewards,
         "raw_reward": raw_rewards,
+        # Semantic group index (prompt group for GRPO reward normalization); needed
+        # by the per-rollout replay capture to recompute reward.post_process.
+        "group_index": [sample.group_index if sample.group_index is not None else 0 for sample in samples],
         "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
         "sample_indices": [sample.index for sample in samples],
     }

--- a/tests/backends/megatron/test_sft_train_data_fields.py
+++ b/tests/backends/megatron/test_sft_train_data_fields.py
@@ -48,7 +48,7 @@ def test_rl_data_fields_unchanged():
     args = _mk_actor_args(loss_type="policy_loss")
     fields = build_data_fields(args)
 
-    for required in ("tokens", "loss_masks", "rollout_log_probs", "rewards", "raw_reward"):
+    for required in ("tokens", "loss_masks", "rollout_log_probs", "rewards", "raw_reward", "group_index"):
         assert required in fields
 
 

--- a/tests/utils/replay/helpers.py
+++ b/tests/utils/replay/helpers.py
@@ -3,11 +3,11 @@
 """Test helpers that build small, hand-checkable GRPO replay bundles.
 
 The fixture is deliberately tiny and deterministic: 4 samples in 2 semantic
-groups of 2 (``n_samples_per_prompt=2``), each with 2 response tokens. Expected
-outputs are computed from *pristine* inputs with reference implementations that
-are independent of the adapters under test; a ``corrupt=...`` option then
-tampers only the *inputs* written to the bundle, so replay must detect the
-divergence against the pristine expected outputs.
+groups of 2 (n_samples_per_prompt=2), each with 2 response tokens. Expected
+outputs are computed from pristine inputs with reference implementations that
+are independent of the adapters under test; a corrupt=... option then tampers
+only the inputs written to the bundle, so replay must detect the divergence
+against the pristine expected outputs.
 """
 
 from __future__ import annotations
@@ -167,7 +167,7 @@ def build_grpo_bundle(
     ref_log_probs: torch.Tensor | None = None,
     loss_masks: list[list[int]] | None = None,
 ) -> tuple[Path, BundleIndex, dict[str, Any]]:
-    """Build a GRPO CP=1 bundle and return ``(path, index, expected)``."""
+    """Build a GRPO CP=1 bundle and return (path, index, expected)."""
     raw_rewards = list(raw_rewards) if raw_rewards is not None else list(RAW_REWARDS)
     loss_masks = [list(mask) for mask in (loss_masks or LOSS_MASKS)]
 
@@ -256,12 +256,11 @@ def build_grpo_bundle(
 
 
 def make_capture_record(bundle_id: str = "b-capture", ratio_one: bool = True) -> CaptureRecord:
-    """Build a pristine GRPO CP=1 ``CaptureRecord`` (same reference data as
-    ``build_grpo_bundle``).
+    """Build a pristine GRPO CP=1 CaptureRecord (same reference data as
+    build_grpo_bundle).
 
     This is the production-capture equivalent of the PR A fixture: a record the
-    ``CaptureManager``/``build_bundle_from_record`` turns into a replayable
-    bundle.
+    CaptureManager/build_bundle_from_record turns into a replayable bundle.
     """
     config = RecomputeConfig(
         advantage_estimator="grpo",
@@ -325,10 +324,10 @@ def make_capture_record(bundle_id: str = "b-capture", ratio_one: bool = True) ->
 
 
 def make_rollout_capture_record(bundle_id: str = "b-rollout-capture") -> CaptureRecord:
-    """Build a pristine rollout-level (reward → advantage) ``CaptureRecord``.
+    """Build a pristine rollout-level (reward → advantage) CaptureRecord.
 
-    Mirrors the production ``capture_hooks.capture_rollout_advantage`` payload:
-    an identity anchored by ``rollout_id``, raw per-sample metadata as deferred
+    Mirrors the production capture_hooks.capture_rollout_advantage payload: an
+    identity anchored by rollout_id, raw per-sample metadata as deferred
     tensors, and only the reward/advantage stages declared (no loss stage).
     """
     config = RecomputeConfig(

--- a/tests/utils/replay/helpers.py
+++ b/tests/utils/replay/helpers.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Test helpers that build small, hand-checkable GRPO replay bundles.
+
+The fixture is deliberately tiny and deterministic: 4 samples in 2 semantic
+groups of 2 (``n_samples_per_prompt=2``), each with 2 response tokens. Expected
+outputs are computed from *pristine* inputs with reference implementations that
+are independent of the adapters under test; a ``corrupt=...`` option then
+tampers only the *inputs* written to the bundle, so replay must detect the
+divergence against the pristine expected outputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from relax.utils.replay.bundle import BundleWriter
+from relax.utils.replay.capture import CaptureRecord
+from relax.utils.replay.schema import (
+    ActorStepId,
+    BundleIndex,
+    ComparisonPolicy,
+    Identity,
+    Manifest,
+    ProducerInfo,
+    RecomputeConfig,
+    SampleRecord,
+    StageCapability,
+    StageContract,
+    StageId,
+    WeightLineage,
+)
+from relax.utils.training.ppo_utils import compute_approx_kl, compute_policy_loss, get_grpo_returns
+
+
+GROUP_INDICES = [0, 0, 1, 1]
+RAW_REWARDS = [1.0, 3.0, 10.0, 12.0]
+RESPONSE_LENGTHS = [2, 2, 2, 2]
+TOTAL_LENGTHS = [3, 3, 3, 3]
+LOSS_MASKS = [[1, 1], [1, 1], [1, 1], [1, 1]]
+# Two physical micro-batches: s-0/s-1 in mb-0007, s-2/s-3 in mb-0008 (each is
+# also a complete semantic group, so batch selection has a well-defined closure).
+MICRO_BATCH_IDS = ["mb-0007", "mb-0007", "mb-0008", "mb-0008"]
+
+# Hand-derived ground truth for the default fixture (ratio == 1, no std norm).
+# group0 rewards [1, 3] -> mean 2 -> [-1, 1]; group1 [10, 12] -> mean 11 -> [-1, 1].
+NORMALIZED_REWARDS = [-1.0, 1.0, -1.0, 1.0]
+# get_grpo_returns broadcasts each reward to its response length (2 tokens).
+ADVANTAGES = [-1.0, -1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 1.0]
+# ratio == 1 => pg_loss == -advantage, per-sample mean sums to 0; entropy_loss == 2.0.
+DEFAULT_LOSS = -0.01 * 2.0
+
+
+def _group_normalize(
+    raw_rewards: list[float], group_indices: list[int], n_samples_per_prompt: int, std_norm: bool
+) -> list[float]:
+    """Reference group normalization, independent of the reward adapter."""
+    rewards = torch.tensor(raw_rewards, dtype=torch.float)
+    positions: dict[int, list[int]] = {}
+    for position, group_index in enumerate(group_indices):
+        positions.setdefault(group_index, []).append(position)
+    normalized = torch.empty_like(rewards)
+    for group_index, group_positions in positions.items():
+        assert len(group_positions) == n_samples_per_prompt, group_index
+        group_rewards = rewards[group_positions]
+        group_rewards = group_rewards - group_rewards.mean()
+        if std_norm:
+            group_rewards = group_rewards / (group_rewards.std() + 1e-6)
+        normalized[group_positions] = group_rewards
+    return normalized.tolist()
+
+
+def _reduce(x: torch.Tensor, response_lengths: list[int], loss_masks: list[list[int]]) -> float:
+    """Reference CP=1 reduction, independent of the loss adapter."""
+    total = 0.0
+    for chunk, mask in zip(torch.split(x, response_lengths), loss_masks, strict=False):
+        mask_t = torch.tensor(mask, dtype=x.dtype)
+        total += (chunk * mask_t).sum() / torch.clamp_min(mask_t.sum(), 1)
+    return float(total.item())
+
+
+def _build_manifest(bundle_id: str) -> Manifest:
+    stage_contracts = {
+        stage: StageContract(
+            stage=stage,
+            version="v1",
+            capability=StageCapability.RECOMPUTE,
+            implementation="reimplemented" if stage == StageId.REWARD_POST_PROCESS else "reuse",
+        )
+        for stage in (
+            StageId.SAMPLE,
+            StageId.REWARD_RAW,
+            StageId.REWARD_POST_PROCESS,
+            StageId.ADVANTAGE_KL,
+            StageId.ADVANTAGE_ESTIMATE,
+            StageId.LOSS_POLICY,
+        )
+    }
+    stage_contracts[StageId.LOSS_VALUE] = StageContract(
+        stage=StageId.LOSS_VALUE,
+        version="v1",
+        capability=StageCapability.UNSUPPORTED,
+    )
+    return Manifest(
+        format_version="1.0.0",
+        bundle_id=bundle_id,
+        producer=ProducerInfo(commit="test", dirty_patch_digest="", torch_version=torch.__version__),
+        stage_contracts=stage_contracts,
+        payloads={},
+        comparison_policy=ComparisonPolicy(
+            exact_fields=["sample_id", "loss_mask", "group_index"],
+            tolerances={},
+        ),
+        redaction={"prompt": "hash", "response": "truncate:64"},
+    )
+
+
+def _make_index(
+    bundle_id: str, config: RecomputeConfig, raw_rewards: list[float], loss_masks: list[list[int]]
+) -> BundleIndex:
+    samples = [
+        SampleRecord(
+            sample_id=f"s-{index}",
+            group_index=GROUP_INDICES[index],
+            response_length=RESPONSE_LENGTHS[index],
+            total_length=TOTAL_LENGTHS[index],
+            loss_mask=list(loss_masks[index]),
+            raw_reward=raw_rewards[index],
+            reward=raw_rewards[index],
+            label_hash="hash:label",
+            micro_batch_id=MICRO_BATCH_IDS[index],
+        )
+        for index in range(len(raw_rewards))
+    ]
+    return BundleIndex(
+        bundle_id=bundle_id,
+        identity=Identity(
+            actor_step_id=ActorStepId(rollout_id=120, step_id=0),
+            rollout_partition_ids=["rollout-119"],
+            consumer_batch_ids=["tq-7"],
+            micro_batch_ids=["mb-0007"],
+            semantic_group_ids=["g-0", "g-1"],
+            normalization_cohort_ids=["g-0", "g-1"],
+            weight_lineage=WeightLineage(rollout_weight="w-119", actor_weight="w-120"),
+            rank={"dp": 0, "tp": 0, "pp": 0, "cp": 1},
+        ),
+        samples=samples,
+        config=config,
+    )
+
+
+def build_grpo_bundle(
+    path: str | Path,
+    *,
+    bundle_id: str = "b-00001",
+    ratio_one: bool = True,
+    pr65_bug: bool = False,
+    kl_coef: float = 0.1,
+    entropy_coef: float = 0.01,
+    corrupt: str | None = None,
+    raw_rewards: list[float] | None = None,
+    old_log_probs: torch.Tensor | None = None,
+    log_probs: torch.Tensor | None = None,
+    ref_log_probs: torch.Tensor | None = None,
+    loss_masks: list[list[int]] | None = None,
+) -> tuple[Path, BundleIndex, dict[str, Any]]:
+    """Build a GRPO CP=1 bundle and return ``(path, index, expected)``."""
+    raw_rewards = list(raw_rewards) if raw_rewards is not None else list(RAW_REWARDS)
+    loss_masks = [list(mask) for mask in (loss_masks or LOSS_MASKS)]
+
+    num_tokens = sum(RESPONSE_LENGTHS)
+    if old_log_probs is None:
+        old_log_probs = torch.zeros(num_tokens)
+    if log_probs is None:
+        log_probs = torch.zeros(num_tokens) if ratio_one else torch.full((num_tokens,), 0.5)
+    if ref_log_probs is None:
+        # Distinct from the (zero) rollout log-probs so the rollout-vs-ref KL is
+        # actually exercised, matching production compute_advantages_and_returns.
+        ref_log_probs = torch.full((num_tokens,), 0.25)
+    entropy = torch.full((num_tokens,), 0.5)
+
+    config = RecomputeConfig(
+        advantage_estimator="grpo",
+        n_samples_per_prompt=2,
+        grpo_std_normalization=False,
+        kl_loss_type="k1",
+        kl_coef=kl_coef,
+        eps_clip=0.2,
+        eps_clip_high=0.2,
+        entropy_coef=entropy_coef,
+    )
+
+    # Compute expected outputs from PRISTINE inputs.
+    if pr65_bug:
+        # Historical bug: normalize all samples as one physical batch.
+        rewards_tensor = torch.tensor(raw_rewards, dtype=torch.float)
+        rewards_tensor = rewards_tensor - rewards_tensor.mean()
+        normalized_rewards = rewards_tensor.tolist()
+    else:
+        normalized_rewards = _group_normalize(
+            raw_rewards, GROUP_INDICES, config.n_samples_per_prompt, config.grpo_std_normalization
+        )
+
+    kl = (
+        torch.zeros_like(old_log_probs, dtype=torch.float32)
+        if config.kl_coef == 0
+        else compute_approx_kl(old_log_probs, ref_log_probs, kl_loss_type=config.kl_loss_type)
+    )
+    rewards_tensor = torch.tensor(normalized_rewards, dtype=torch.float32)
+    returns = get_grpo_returns(rewards_tensor, list(torch.split(kl, RESPONSE_LENGTHS)))
+    advantages = torch.cat(returns)
+
+    ppo_kl = old_log_probs - log_probs
+    pg_loss, clipfrac = compute_policy_loss(ppo_kl, advantages, config.eps_clip, config.eps_clip_high)
+    expected_loss = {
+        "loss": _reduce(pg_loss, RESPONSE_LENGTHS, loss_masks)
+        - config.entropy_coef * _reduce(entropy, RESPONSE_LENGTHS, loss_masks),
+        "pg_loss": _reduce(pg_loss, RESPONSE_LENGTHS, loss_masks),
+        "entropy_loss": _reduce(entropy, RESPONSE_LENGTHS, loss_masks),
+        "pg_clipfrac": _reduce(clipfrac, RESPONSE_LENGTHS, loss_masks),
+        "ppo_kl": _reduce(ppo_kl, RESPONSE_LENGTHS, loss_masks),
+    }
+    expected = {
+        StageId.REWARD_RAW.value: {"raw_rewards": list(raw_rewards)},
+        StageId.REWARD_POST_PROCESS.value: {"rewards": normalized_rewards},
+        StageId.LOSS_POLICY.value: expected_loss,
+    }
+
+    # Tamper only the INPUTS written to the bundle, keeping expected pristine.
+    if corrupt == "reward":
+        raw_rewards[0] = 2.0
+    elif corrupt == "mask_token":
+        loss_masks[1][0] = 0
+    elif corrupt == "old_log_probability":
+        old_log_probs = old_log_probs.clone()
+        old_log_probs[0] = 0.5
+    elif corrupt == "nan":
+        advantages[0] = float("nan")
+
+    index = _make_index(bundle_id, config, raw_rewards, loss_masks)
+    manifest = _build_manifest(bundle_id)
+
+    writer = BundleWriter(path, manifest, index, expected)
+    writer.write_payload("old_log_probs", old_log_probs.float())
+    writer.write_payload("log_probs", log_probs.float())
+    writer.write_payload("ref_log_probs", ref_log_probs.float())
+    writer.write_payload("entropy", entropy.float())
+    writer.write_payload("kl", kl.float())
+    writer.write_payload("advantages", advantages.float())
+    writer.finalize(ranks=[0])
+
+    return Path(path), index, expected
+
+
+def make_capture_record(bundle_id: str = "b-capture", ratio_one: bool = True) -> CaptureRecord:
+    """Build a pristine GRPO CP=1 ``CaptureRecord`` (same reference data as
+    ``build_grpo_bundle``).
+
+    This is the production-capture equivalent of the PR A fixture: a record the
+    ``CaptureManager``/``build_bundle_from_record`` turns into a replayable
+    bundle.
+    """
+    config = RecomputeConfig(
+        advantage_estimator="grpo",
+        n_samples_per_prompt=2,
+        grpo_std_normalization=False,
+        kl_loss_type="k1",
+        kl_coef=0.1,
+        eps_clip=0.2,
+        eps_clip_high=0.2,
+        entropy_coef=0.01,
+    )
+    num_tokens = sum(RESPONSE_LENGTHS)
+    old_log_probs = torch.zeros(num_tokens)
+    log_probs = torch.zeros(num_tokens) if ratio_one else torch.full((num_tokens,), 0.5)
+    ref_log_probs = torch.full((num_tokens,), 0.25)
+    entropy = torch.full((num_tokens,), 0.5)
+
+    normalized_rewards = _group_normalize(
+        RAW_REWARDS, GROUP_INDICES, config.n_samples_per_prompt, config.grpo_std_normalization
+    )
+    kl = compute_approx_kl(old_log_probs, ref_log_probs, kl_loss_type=config.kl_loss_type)
+    rewards_tensor = torch.tensor(normalized_rewards, dtype=torch.float32)
+    returns = get_grpo_returns(rewards_tensor, list(torch.split(kl, RESPONSE_LENGTHS)))
+    advantages = torch.cat(returns)
+
+    ppo_kl = old_log_probs - log_probs
+    pg_loss, clipfrac = compute_policy_loss(ppo_kl, advantages, config.eps_clip, config.eps_clip_high)
+    expected = {
+        StageId.REWARD_RAW.value: {"raw_rewards": list(RAW_REWARDS)},
+        StageId.REWARD_POST_PROCESS.value: {"rewards": normalized_rewards},
+        StageId.LOSS_POLICY.value: {
+            "loss": _reduce(pg_loss, RESPONSE_LENGTHS, LOSS_MASKS)
+            - config.entropy_coef * _reduce(entropy, RESPONSE_LENGTHS, LOSS_MASKS),
+            "pg_loss": _reduce(pg_loss, RESPONSE_LENGTHS, LOSS_MASKS),
+            "entropy_loss": _reduce(entropy, RESPONSE_LENGTHS, LOSS_MASKS),
+            "pg_clipfrac": _reduce(clipfrac, RESPONSE_LENGTHS, LOSS_MASKS),
+            "ppo_kl": _reduce(ppo_kl, RESPONSE_LENGTHS, LOSS_MASKS),
+        },
+    }
+
+    index = _make_index(bundle_id, config, RAW_REWARDS, LOSS_MASKS)
+    actor_step_id = index.identity.actor_step_id
+    return CaptureRecord(
+        actor_step_id=(actor_step_id.rollout_id, actor_step_id.step_id),
+        identity=index.identity,
+        samples=index.samples,
+        config=config,
+        tensors={
+            "old_log_probs": old_log_probs.float(),
+            "log_probs": log_probs.float(),
+            "ref_log_probs": ref_log_probs.float(),
+            "entropy": entropy.float(),
+            "kl": kl.float(),
+            "advantages": advantages.float(),
+        },
+        expected=expected,
+        bundle_id=bundle_id,
+        producer=ProducerInfo(commit="test", torch_version=torch.__version__),
+        redaction={"prompt": "hash", "response": "truncate:64"},
+    )
+
+
+def make_rollout_capture_record(bundle_id: str = "b-rollout-capture") -> CaptureRecord:
+    """Build a pristine rollout-level (reward → advantage) ``CaptureRecord``.
+
+    Mirrors the production ``capture_hooks.capture_rollout_advantage`` payload:
+    an identity anchored by ``rollout_id``, raw per-sample metadata as deferred
+    tensors, and only the reward/advantage stages declared (no loss stage).
+    """
+    config = RecomputeConfig(
+        advantage_estimator="grpo",
+        n_samples_per_prompt=2,
+        grpo_std_normalization=False,
+        kl_loss_type="k1",
+        kl_coef=0.1,
+        eps_clip=0.2,
+        eps_clip_high=0.2,
+        entropy_coef=0.01,
+    )
+    num_tokens = sum(RESPONSE_LENGTHS)
+    old_log_probs = torch.zeros(num_tokens)
+    ref_log_probs = torch.full((num_tokens,), 0.25)
+
+    normalized_rewards = _group_normalize(
+        RAW_REWARDS, GROUP_INDICES, config.n_samples_per_prompt, config.grpo_std_normalization
+    )
+    kl = compute_approx_kl(old_log_probs, ref_log_probs, kl_loss_type=config.kl_loss_type)
+    rewards_tensor = torch.tensor(normalized_rewards, dtype=torch.float32)
+    returns = get_grpo_returns(rewards_tensor, list(torch.split(kl, RESPONSE_LENGTHS)))
+    advantages = torch.cat(returns)
+
+    identity = Identity(rollout_id=120, rank={"dp": 0, "tp": 0, "pp": 0, "cp": 1})
+    flat_masks = [value for sample_mask in LOSS_MASKS for value in sample_mask]
+    return CaptureRecord(
+        identity=identity,
+        samples=[],
+        config=config,
+        tensors={
+            "old_log_probs": old_log_probs.float(),
+            "ref_log_probs": ref_log_probs.float(),
+            "kl": kl.float(),
+            "advantages": advantages.float(),
+        },
+        expected={},
+        bundle_id=bundle_id,
+        rollout_id=120,
+        producer=ProducerInfo(commit="test", torch_version=torch.__version__),
+        stages={
+            StageId.REWARD_RAW,
+            StageId.REWARD_POST_PROCESS,
+            StageId.ADVANTAGE_KL,
+            StageId.ADVANTAGE_ESTIMATE,
+        },
+        response_lengths=list(RESPONSE_LENGTHS),
+        total_lengths=list(TOTAL_LENGTHS),
+        loss_masks_tensor=torch.tensor(flat_masks, dtype=torch.float32),
+        group_indices_tensor=torch.tensor(GROUP_INDICES, dtype=torch.long),
+        raw_rewards_tensor=torch.tensor(RAW_REWARDS, dtype=torch.float32),
+        rewards_tensor=rewards_tensor,
+    )

--- a/tests/utils/replay/helpers.py
+++ b/tests/utils/replay/helpers.py
@@ -12,12 +12,13 @@ against the pristine expected outputs.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
 import torch
 
-from relax.utils.replay.bundle import BundleWriter
+from relax.utils.replay.bundle import BundleWriter, metadata_checksums
 from relax.utils.replay.capture import CaptureRecord
 from relax.utils.replay.schema import (
     ActorStepId,
@@ -253,6 +254,19 @@ def build_grpo_bundle(
     writer.finalize(ranks=[0])
 
     return Path(path), index, expected
+
+
+def resign_metadata_checksums(bundle: Path) -> None:
+    """Recompute COMPLETE / COMPLETE.<rank> metadata hashes after a test mutates files."""
+    checksums = metadata_checksums(bundle)
+    complete_path = bundle / "COMPLETE"
+    complete = json.loads(complete_path.read_text(encoding="utf-8"))
+    complete["metadata"] = checksums
+    complete_path.write_text(json.dumps(complete, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+    for shard in sorted(bundle.glob("COMPLETE.*")):
+        data = json.loads(shard.read_text(encoding="utf-8"))
+        data["metadata"] = checksums
+        shard.write_text(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
 def make_capture_record(bundle_id: str = "b-capture", ratio_one: bool = True) -> CaptureRecord:

--- a/tests/utils/replay/helpers.py
+++ b/tests/utils/replay/helpers.py
@@ -257,7 +257,8 @@ def build_grpo_bundle(
 
 
 def resign_metadata_checksums(bundle: Path) -> None:
-    """Recompute COMPLETE / COMPLETE.<rank> metadata hashes after a test mutates files."""
+    """Recompute COMPLETE / COMPLETE.<rank> metadata hashes after a test
+    mutates files."""
     checksums = metadata_checksums(bundle)
     complete_path = bundle / "COMPLETE"
     complete = json.loads(complete_path.read_text(encoding="utf-8"))

--- a/tests/utils/replay/helpers.py
+++ b/tests/utils/replay/helpers.py
@@ -262,7 +262,9 @@ def resign_metadata_checksums(bundle: Path) -> None:
     complete_path = bundle / "COMPLETE"
     complete = json.loads(complete_path.read_text(encoding="utf-8"))
     complete["metadata"] = checksums
-    complete_path.write_text(json.dumps(complete, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+    complete_path.write_text(
+        json.dumps(complete, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     for shard in sorted(bundle.glob("COMPLETE.*")):
         data = json.loads(shard.read_text(encoding="utf-8"))
         data["metadata"] = checksums

--- a/tests/utils/replay/test_bundle.py
+++ b/tests/utils/replay/test_bundle.py
@@ -231,3 +231,31 @@ def test_try_finalize_cohort_waits_then_completes(tmp_path):
     assert complete["ranks"] == [0, 1]
     assert complete["shards"]["1"]["payloads"] == {"y": "def"}
     assert try_finalize_cohort(cohort, [0, 1]) is True
+
+
+def test_bundle_reader_requires_parent_cohort_complete(tmp_path):
+    cohort = tmp_path / "cohort"
+    bundle, _, _ = build_grpo_bundle(cohort / "rank-0")
+    complete_path = bundle / "COMPLETE"
+    complete = json.loads(complete_path.read_text(encoding="utf-8"))
+    complete["expected_ranks"] = [0, 1]
+    complete_path.write_text(json.dumps(complete), encoding="utf-8")
+    with pytest.raises(IncompleteBundleError, match="incomplete"):
+        BundleReader(bundle).load()
+
+    (cohort / "COMPLETE").write_text(json.dumps({"ranks": [0, 1], "shards": {}}), encoding="utf-8")
+    loaded = BundleReader(bundle).load()
+    assert loaded.manifest.bundle_id == "b-00001"
+
+
+def test_bundle_reader_infers_expected_ranks_from_parent_shard(tmp_path):
+    cohort = tmp_path / "cohort"
+    bundle, _, _ = build_grpo_bundle(cohort / "rank-0")
+    complete_path = bundle / "COMPLETE"
+    complete = json.loads(complete_path.read_text(encoding="utf-8"))
+    complete.pop("expected_ranks", None)
+    complete_path.write_text(json.dumps(complete), encoding="utf-8")
+    identity = Identity(actor_step_id=ActorStepId(rollout_id=120, step_id=0))
+    write_cohort_shard(cohort, rank=0, identity=identity, expected_ranks=[0, 1], payloads={"x": "abc"})
+    with pytest.raises(IncompleteBundleError, match="incomplete"):
+        BundleReader(bundle).load()

--- a/tests/utils/replay/test_bundle.py
+++ b/tests/utils/replay/test_bundle.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Bundle writer/reader integrity tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from relax.utils.replay.bundle import BundleReader, IncompleteBundleError, sha256_file
+from relax.utils.replay.validate import validate_bundle
+from tests.utils.replay.helpers import build_grpo_bundle
+
+
+def _payload_path(bundle: Path, name: str) -> Path:
+    return bundle / "payloads" / f"{name}.pt"
+
+
+def _rewrite_manifest(bundle: Path, mutate) -> None:
+    manifest_path = bundle / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    mutate(manifest)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _replace_payload(bundle: Path, name: str, obj) -> None:
+    """Re-sign a payload (manifest + rank shard) so checksum checks pass and
+    the reader reaches the type/numerics validation."""
+    path = _payload_path(bundle, name)
+    torch.save(obj, path)
+    new_sha256 = sha256_file(path)
+    new_dtype = str(obj.dtype) if isinstance(obj, torch.Tensor) else "object"
+    new_shape = list(obj.shape) if isinstance(obj, torch.Tensor) else []
+
+    def mutate(manifest):
+        spec = manifest["payloads"][name]
+        spec["bytes"] = path.stat().st_size
+        spec["sha256"] = new_sha256
+        spec["dtype"] = new_dtype
+        spec["shape"] = new_shape
+
+    _rewrite_manifest(bundle, mutate)
+
+    complete_path = bundle / "COMPLETE.0"
+    complete = json.loads(complete_path.read_text(encoding="utf-8"))
+    complete["payloads"][name] = new_sha256
+    complete_path.write_text(json.dumps(complete), encoding="utf-8")
+
+
+def test_bundle_roundtrip(tmp_path):
+    bundle, index, expected = build_grpo_bundle(tmp_path / "bundle")
+    loaded = BundleReader(bundle).load()
+
+    assert loaded.manifest.bundle_id == "b-00001"
+    assert loaded.index.identity.actor_step_id.rollout_id == 120
+    assert loaded.index.identity.actor_step_id.step_id == 0
+    assert len(loaded.index.samples) == 4
+    assert set(loaded.tensors) == {"old_log_probs", "log_probs", "ref_log_probs", "entropy", "kl", "advantages"}
+    assert loaded.tensors["advantages"].tolist() == [-1.0, -1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 1.0]
+    assert loaded.expected["loss.policy"]["loss"] == pytest.approx(expected["loss.policy"]["loss"])
+
+
+def test_bundle_unsupported_version(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+
+    def mutate(manifest):
+        manifest["format_version"] = "2.0.0"
+
+    _rewrite_manifest(bundle, mutate)
+    with pytest.raises(ValueError):
+        BundleReader(bundle).load()
+
+
+def test_bundle_unknown_field_warns(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+
+    def mutate(manifest):
+        manifest["future_field"] = {"x": 1}
+
+    _rewrite_manifest(bundle, mutate)
+    result = validate_bundle(bundle)
+    assert result.valid
+    assert any("unknown field" in warning for warning in result.warnings)
+
+
+def test_bundle_missing_commit_warns(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+
+    def mutate(manifest):
+        manifest["producer"]["commit"] = ""
+
+    _rewrite_manifest(bundle, mutate)
+    result = validate_bundle(bundle)
+    assert result.valid
+    assert any("producer commit" in warning for warning in result.warnings)
+
+
+def test_bundle_missing_payload(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    _payload_path(bundle, "advantages").unlink()
+    with pytest.raises(IncompleteBundleError):
+        BundleReader(bundle).load()
+
+
+def test_bundle_checksum_mismatch(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    path = _payload_path(bundle, "advantages")
+    path.write_bytes(path.read_bytes() + b"\x00")
+    with pytest.raises(IncompleteBundleError):
+        BundleReader(bundle).load()
+
+
+def test_bundle_missing_complete(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    (bundle / "COMPLETE").unlink()
+    with pytest.raises(IncompleteBundleError):
+        BundleReader(bundle).load()
+
+
+def test_bundle_unsafe_object(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    _replace_payload(bundle, "advantages", {"not": "a tensor"})
+    with pytest.raises(IncompleteBundleError):
+        BundleReader(bundle).load()
+
+
+def test_bundle_nan_inf_rejected(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="nan")
+    result = validate_bundle(bundle)
+    assert not result.valid
+    assert any("NaN" in error for error in result.errors)
+
+
+def test_bundle_truncation(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    path = _payload_path(bundle, "advantages")
+    path.write_bytes(path.read_bytes()[:-2])
+    with pytest.raises(IncompleteBundleError):
+        BundleReader(bundle).load()
+
+
+def test_bundle_rollout_identity_valid(tmp_path):
+    from relax.utils.replay.capture import build_bundle_from_record
+    from tests.utils.replay.helpers import make_rollout_capture_record
+
+    bundle_path = build_bundle_from_record(make_rollout_capture_record("b-rid"), tmp_path)
+    assert validate_bundle(bundle_path).valid
+
+
+def _rewrite_index(bundle: Path, mutate) -> None:
+    index_path = bundle / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    mutate(index)
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+
+def test_bundle_identity_anchor_rejected(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+
+    def both_anchors(index):
+        index["identity"]["rollout_id"] = 120
+
+    _rewrite_index(bundle, both_anchors)
+    result = validate_bundle(bundle)
+    assert not result.valid
+    assert any("exactly one" in error for error in result.errors)
+
+    def neither_anchor(index):
+        index["identity"]["actor_step_id"] = None
+        index["identity"]["rollout_id"] = None
+
+    _rewrite_index(bundle, neither_anchor)
+    result = validate_bundle(bundle)
+    assert not result.valid
+    assert any("exactly one" in error for error in result.errors)

--- a/tests/utils/replay/test_bundle.py
+++ b/tests/utils/replay/test_bundle.py
@@ -10,9 +10,16 @@ from pathlib import Path
 import pytest
 import torch
 
-from relax.utils.replay.bundle import BundleReader, IncompleteBundleError, sha256_file
+from relax.utils.replay.bundle import (
+    BundleReader,
+    IncompleteBundleError,
+    sha256_file,
+    try_finalize_cohort,
+    write_cohort_shard,
+)
+from relax.utils.replay.schema import ActorStepId, Identity
 from relax.utils.replay.validate import validate_bundle
-from tests.utils.replay.helpers import build_grpo_bundle
+from tests.utils.replay.helpers import build_grpo_bundle, resign_metadata_checksums
 
 
 def _payload_path(bundle: Path, name: str) -> Path:
@@ -24,6 +31,7 @@ def _rewrite_manifest(bundle: Path, mutate) -> None:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     mutate(manifest)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    resign_metadata_checksums(bundle)
 
 
 def _replace_payload(bundle: Path, name: str, obj) -> None:
@@ -48,6 +56,7 @@ def _replace_payload(bundle: Path, name: str, obj) -> None:
     complete = json.loads(complete_path.read_text(encoding="utf-8"))
     complete["payloads"][name] = new_sha256
     complete_path.write_text(json.dumps(complete), encoding="utf-8")
+    resign_metadata_checksums(bundle)
 
 
 def test_bundle_roundtrip(tmp_path):
@@ -155,6 +164,7 @@ def _rewrite_index(bundle: Path, mutate) -> None:
     index = json.loads(index_path.read_text(encoding="utf-8"))
     mutate(index)
     index_path.write_text(json.dumps(index), encoding="utf-8")
+    resign_metadata_checksums(bundle)
 
 
 def test_bundle_identity_anchor_rejected(tmp_path):
@@ -164,6 +174,7 @@ def test_bundle_identity_anchor_rejected(tmp_path):
         index["identity"]["rollout_id"] = 120
 
     _rewrite_index(bundle, both_anchors)
+    _sync_shard_identity(bundle)
     result = validate_bundle(bundle)
     assert not result.valid
     assert any("exactly one" in error for error in result.errors)
@@ -173,6 +184,50 @@ def test_bundle_identity_anchor_rejected(tmp_path):
         index["identity"]["rollout_id"] = None
 
     _rewrite_index(bundle, neither_anchor)
+    _sync_shard_identity(bundle)
     result = validate_bundle(bundle)
     assert not result.valid
     assert any("exactly one" in error for error in result.errors)
+
+
+def _sync_shard_identity(bundle: Path) -> None:
+    """Copy index.identity onto COMPLETE.0 so reader identity checks pass."""
+    identity = json.loads((bundle / "index.json").read_text(encoding="utf-8"))["identity"]
+    shard_path = bundle / "COMPLETE.0"
+    shard = json.loads(shard_path.read_text(encoding="utf-8"))
+    shard["actor_step_id"] = identity["actor_step_id"]
+    shard["rollout_id"] = identity.get("rollout_id")
+    shard_path.write_text(json.dumps(shard), encoding="utf-8")
+
+
+def test_bundle_metadata_checksum_mismatch(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    expected_path = bundle / "expected.json"
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    expected["loss.policy"]["loss"] = 0.0
+    expected_path.write_text(json.dumps(expected), encoding="utf-8")
+    with pytest.raises(IncompleteBundleError, match="metadata checksum"):
+        BundleReader(bundle).load()
+
+
+def test_bundle_shard_actor_step_mismatch(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    shard_path = bundle / "COMPLETE.0"
+    shard = json.loads(shard_path.read_text(encoding="utf-8"))
+    shard["actor_step_id"] = {"rollout_id": 999, "step_id": 0}
+    shard_path.write_text(json.dumps(shard), encoding="utf-8")
+    with pytest.raises(IncompleteBundleError, match="actor_step_id"):
+        BundleReader(bundle).load()
+
+
+def test_try_finalize_cohort_waits_then_completes(tmp_path):
+    cohort = tmp_path / "cohort"
+    identity = Identity(actor_step_id=ActorStepId(rollout_id=120, step_id=0))
+    write_cohort_shard(cohort, rank=0, identity=identity, expected_ranks=[0, 1], payloads={"x": "abc"})
+    assert try_finalize_cohort(cohort, [0, 1]) is False
+    write_cohort_shard(cohort, rank=1, identity=identity, expected_ranks=[0, 1], payloads={"y": "def"})
+    assert try_finalize_cohort(cohort, [0, 1]) is True
+    complete = json.loads((cohort / "COMPLETE").read_text(encoding="utf-8"))
+    assert complete["ranks"] == [0, 1]
+    assert complete["shards"]["1"]["payloads"] == {"y": "def"}
+    assert try_finalize_cohort(cohort, [0, 1]) is True

--- a/tests/utils/replay/test_capture.py
+++ b/tests/utils/replay/test_capture.py
@@ -15,7 +15,7 @@ import threading
 import pytest
 import torch
 
-from relax.utils.replay import capture
+from relax.utils.replay import capture, capture_hooks
 from relax.utils.replay.bundle import BundleReader
 from relax.utils.replay.capture import (
     CaptureConfig,
@@ -135,18 +135,31 @@ def test_capture_failure_isolation(tmp_path, monkeypatch):
     manager.close()
 
 
-def test_capture_selected_steps(tmp_path):
-    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_steps={(120, 0)}))
+def test_capture_selected_steps_and_rollouts(tmp_path):
+    manager = CaptureManager(
+        CaptureConfig(
+            enabled=True,
+            output_dir=str(tmp_path),
+            selected_steps={(120, 0)},
+            selected_rollouts={120},
+        )
+    )
     assert manager.submit(make_capture_record("b-selected")) is True
+    skipped_step = make_capture_record("b-skipped-step")
+    skipped_step.actor_step_id = (121, 0)
+    assert manager.submit(skipped_step) is False
 
-    other = make_capture_record("b-skipped")
-    other.actor_step_id = (121, 0)
-    assert manager.submit(other) is False
+    assert manager.submit(make_rollout_capture_record("b-rselected")) is True
+    skipped_rollout = make_rollout_capture_record("b-rskipped")
+    skipped_rollout.rollout_id = 121
+    assert manager.submit(skipped_rollout) is False
 
     manager.flush()
     manager.close()
     assert (tmp_path / "b-selected" / "COMPLETE").exists()
-    assert not (tmp_path / "b-skipped").exists()
+    assert (tmp_path / "b-rselected" / "COMPLETE").exists()
+    assert not (tmp_path / "b-skipped-step").exists()
+    assert not (tmp_path / "b-rskipped").exists()
 
 
 def _step_identity() -> Identity:
@@ -193,38 +206,31 @@ def test_capture_step_lifecycle(tmp_path):
     assert replay(tmp_path / "b-step").passed
 
 
-def test_capture_begin_step_disabled_noop():
+def test_capture_hooks_noop_when_disabled():
     disable()
+    assert should_capture((0, 0)) is False
+    assert should_capture_rollout(120) is False
     begin_step((120, 0), identity=_step_identity(), config=_step_config(), bundle_id="b-x")
+    assert current_step() is None
+    begin_rollout(120, identity=Identity(rollout_id=120, rank={"cp": 1}), config=_step_config(), bundle_id="b-x")
     assert current_step() is None
 
 
-def test_capture_begin_step_unselected_noop(tmp_path):
-    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_steps={(0, 0)}))
+def test_capture_unselected_or_empty_does_not_write(tmp_path):
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_steps={(0, 0)}, selected_rollouts={0}))
     begin_step((120, 0), identity=_step_identity(), config=_step_config(), bundle_id="b-x")
     assert current_step() is None
+    begin_rollout(120, identity=Identity(rollout_id=120, rank={"cp": 1}), config=_step_config(), bundle_id="b-x")
+    assert current_step() is None
 
-
-def test_end_step_without_payload_does_not_write(tmp_path):
-    # Non-last PP ranks open an accumulator then end it with no stages filled.
     enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
     begin_step((120, 0), identity=_step_identity(), config=_step_config(), bundle_id="b-empty")
     end_step()
-    disable()
-    assert not (tmp_path / "b-empty").exists()
-
-
-def test_end_rollout_without_payload_does_not_write(tmp_path):
-    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
     begin_rollout(120, identity=Identity(rollout_id=120, rank={"cp": 1}), config=_step_config(), bundle_id="b-empty-r")
     end_rollout()
     disable()
+    assert not (tmp_path / "b-empty").exists()
     assert not (tmp_path / "b-empty-r").exists()
-
-
-def test_capture_should_capture_guard():
-    # Disabled -> False (the hot-path short-circuit contract).
-    assert should_capture((0, 0)) is False
 
 
 def test_capture_loss_only_roundtrip(tmp_path):
@@ -305,39 +311,12 @@ def test_capture_rollout_lifecycle(tmp_path):
     assert replay(tmp_path / "b-rollout-step").passed
 
 
-def test_capture_selected_rollouts(tmp_path):
-    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_rollouts={120}))
-    assert manager.submit(make_rollout_capture_record("b-rselected")) is True
-
-    other = make_rollout_capture_record("b-rskipped")
-    other.rollout_id = 121
-    assert manager.submit(other) is False
-
-    manager.flush()
-    manager.close()
-    assert (tmp_path / "b-rselected" / "COMPLETE").exists()
-    assert not (tmp_path / "b-rskipped").exists()
-
-
-def test_capture_should_capture_rollout_guard():
-    # Disabled -> False (the rollout hot-path short-circuit contract).
-    assert should_capture_rollout(120) is False
-
-
-def test_capture_begin_rollout_unselected_noop(tmp_path):
-    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_rollouts={0}))
-    begin_rollout(120, identity=Identity(rollout_id=120, rank={"cp": 1}), config=_step_config(), bundle_id="b-x")
-    assert current_step() is None
-
-
-def test_config_from_env_disabled(monkeypatch):
-    monkeypatch.delenv("RELAX_REPLAY_CAPTURE", raising=False)
-    monkeypatch.delenv("RELAX_REPLAY_CAPTURE_DIR", raising=False)
-    assert config_from_env() is None
-
-
-def test_config_from_env_missing_dir_stays_disabled(monkeypatch):
-    monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+@pytest.mark.parametrize("set_capture", [False, True])
+def test_config_from_env_stays_disabled_without_dir(monkeypatch, set_capture):
+    if set_capture:
+        monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+    else:
+        monkeypatch.delenv("RELAX_REPLAY_CAPTURE", raising=False)
     monkeypatch.delenv("RELAX_REPLAY_CAPTURE_DIR", raising=False)
     assert config_from_env() is None
 
@@ -371,3 +350,74 @@ def test_maybe_enable_from_env_scopes_rank_dir(monkeypatch, tmp_path):
     assert manager.enabled
     assert active() is manager
     assert str(tmp_path / "rank-3") == manager.output_dir
+
+
+def _policy_reported_loss(old, logp, entropy, advantages, samples, config):
+    from relax.utils.training.ppo_utils import compute_policy_loss
+
+    lengths = [sample.response_length for sample in samples]
+    masks = [sample.loss_mask for sample in samples]
+    ppo_kl = old - logp
+    pg_loss, clipfrac = compute_policy_loss(ppo_kl, advantages, config.eps_clip, config.eps_clip_high)
+
+    def reduce(values: torch.Tensor) -> torch.Tensor:
+        total = values.new_zeros(())
+        for chunk, mask in zip(torch.split(values, lengths), masks, strict=False):
+            mask_t = torch.tensor(mask, dtype=values.dtype)
+            total = total + (chunk * mask_t).sum() / torch.clamp_min(mask_t.sum(), 1)
+        return total
+
+    pg = reduce(pg_loss)
+    entropy_loss = reduce(entropy)
+    return {
+        "loss": pg - config.entropy_coef * entropy_loss,
+        "pg_loss": pg,
+        "entropy_loss": entropy_loss,
+        "pg_clipfrac": reduce(clipfrac),
+        "ppo_kl": reduce(ppo_kl),
+    }
+
+
+def _capture_loss_slice(record, start: int, end: int, micro_batch_index: int) -> None:
+    samples = record.samples[start:end]
+    token_start = sum(sample.response_length for sample in record.samples[:start])
+    token_end = token_start + sum(sample.response_length for sample in samples)
+    sl = slice(token_start, token_end)
+    capture_hooks.capture_policy_loss(
+        old_log_probs=record.tensors["old_log_probs"][sl],
+        log_probs=record.tensors["log_probs"][sl],
+        entropy=record.tensors["entropy"][sl],
+        advantages=record.tensors["advantages"][sl],
+        loss_masks=[torch.tensor(sample.loss_mask) for sample in samples],
+        response_lengths=[sample.response_length for sample in samples],
+        total_lengths=[sample.total_length for sample in samples],
+        reported_loss=_policy_reported_loss(
+            record.tensors["old_log_probs"][sl],
+            record.tensors["log_probs"][sl],
+            record.tensors["entropy"][sl],
+            record.tensors["advantages"][sl],
+            samples,
+            record.config,
+        ),
+        micro_batch_index=micro_batch_index,
+    )
+
+
+def test_capture_policy_loss_records_data_iterator_micro_batches(tmp_path):
+    record = make_capture_record("b-mb")
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    begin_step((120, 0), identity=record.identity, config=record.config, bundle_id="b-mb")
+
+    _capture_loss_slice(record, 0, 2, micro_batch_index=7)
+    _capture_loss_slice(record, 2, 4, micro_batch_index=8)
+    # Activation-checkpoint recompute of mb 7 must not double-count.
+    _capture_loss_slice(record, 0, 2, micro_batch_index=7)
+    end_step()
+    disable()
+
+    loaded = BundleReader(tmp_path / "b-mb").load()
+    assert loaded.index.identity.micro_batch_ids == ["mb-0007", "mb-0008"]
+    assert [sample.micro_batch_id for sample in loaded.index.samples] == ["mb-0007", "mb-0007", "mb-0008", "mb-0008"]
+    assert loaded.tensors["old_log_probs"].numel() == 8
+    assert replay(tmp_path / "b-mb").passed
+    assert replay(tmp_path / "b-mb", batch_ids=["mb-0008"]).passed

--- a/tests/utils/replay/test_capture.py
+++ b/tests/utils/replay/test_capture.py
@@ -1,0 +1,373 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the PR B production-capture data plane.
+
+These exercise ``CaptureRecord`` / ``build_bundle_from_record`` (the pure
+capture→bundle bridge) and ``CaptureManager`` (the async, bounded, failure-
+isolated sink) entirely on CPU — the round-trip parity test proves the captured
+bundle is replayable by the PR A runner.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+import torch
+
+from relax.utils.replay import capture
+from relax.utils.replay.bundle import BundleReader
+from relax.utils.replay.capture import (
+    CaptureConfig,
+    CaptureManager,
+    CaptureRecord,
+    active,
+    begin_rollout,
+    begin_step,
+    build_bundle_from_record,
+    build_manifest_for_record,
+    config_from_env,
+    current_step,
+    disable,
+    enable,
+    end_rollout,
+    end_step,
+    maybe_enable_from_env,
+    should_capture,
+    should_capture_rollout,
+)
+from relax.utils.replay.runner import replay
+from relax.utils.replay.schema import (
+    ActorStepId,
+    Identity,
+    RecomputeConfig,
+    StageCapability,
+    StageId,
+)
+from tests.utils.replay.helpers import make_capture_record, make_rollout_capture_record
+
+
+@pytest.fixture(autouse=True)
+def _reset_capture_global():
+    yield
+    disable()
+
+
+def test_capture_roundtrip_parity(tmp_path):
+    record = make_capture_record("b-capture")
+    bundle_path = build_bundle_from_record(record, tmp_path)
+
+    # The manifest must be derived from the frozen V1 capability matrix, not
+    # hard-coded by the capture layer.
+    manifest = BundleReader(bundle_path).load().manifest
+    for stage in (
+        StageId.SAMPLE,
+        StageId.REWARD_RAW,
+        StageId.REWARD_POST_PROCESS,
+        StageId.ADVANTAGE_KL,
+        StageId.ADVANTAGE_ESTIMATE,
+        StageId.LOSS_POLICY,
+    ):
+        assert manifest.stage_contracts[stage].capability == StageCapability.RECOMPUTE
+    assert manifest.stage_contracts[StageId.LOSS_VALUE].capability == StageCapability.UNSUPPORTED
+
+    report = replay(bundle_path)
+    assert report.passed
+    assert report.first_divergent_stage is None
+
+
+def test_capture_manifest_reimplemented_marker():
+    manifest = build_manifest_for_record(make_capture_record("b-marker"))
+    assert manifest.stage_contracts[StageId.REWARD_POST_PROCESS].implementation == "reimplemented"
+    assert manifest.stage_contracts[StageId.ADVANTAGE_ESTIMATE].implementation == "reuse"
+
+
+def test_capture_manager_disabled_noop(tmp_path):
+    manager = CaptureManager(CaptureConfig(enabled=False, output_dir=str(tmp_path)))
+    assert manager.submit(make_capture_record("b-disabled")) is False
+    assert manager.dropped_count == 0
+    assert not (tmp_path / "b-disabled").exists()
+
+
+def test_capture_manager_enabled_writes_bundle(tmp_path):
+    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    assert manager.submit(make_capture_record("b-async")) is True
+    manager.flush(wait=True)
+    manager.close()
+    assert (tmp_path / "b-async" / "COMPLETE").exists()
+    assert replay(tmp_path / "b-async").passed
+
+
+def test_capture_manager_queue_overflow_drops(tmp_path, monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_build(record, output_dir):
+        entered.set()
+        release.wait(timeout=10)
+        return build_bundle_from_record(record, output_dir)
+
+    monkeypatch.setattr(capture, "build_bundle_from_record", slow_build)
+    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path), queue_capacity=1))
+
+    assert manager.submit(make_capture_record("b-1")) is True
+    assert entered.wait(timeout=5)
+    # Writer is blocked inside build, so the queue is empty. Fill it, then
+    # overflow it: the third submit must be dropped, never back-pressure.
+    assert manager.submit(make_capture_record("b-2")) is True
+    assert manager.submit(make_capture_record("b-3")) is False
+    assert manager.dropped_count == 1
+
+    release.set()
+    manager.close()
+
+
+def test_capture_failure_isolation(tmp_path, monkeypatch):
+    def failing_build(record, output_dir):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(capture, "build_bundle_from_record", failing_build)
+    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+
+    assert manager.submit(make_capture_record("b-fail")) is True  # never raises
+    manager.flush(wait=True)
+    assert manager.error_count == 1
+    manager.close()
+
+
+def test_capture_selected_steps(tmp_path):
+    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_steps={(120, 0)}))
+    assert manager.submit(make_capture_record("b-selected")) is True
+
+    other = make_capture_record("b-skipped")
+    other.actor_step_id = (121, 0)
+    assert manager.submit(other) is False
+
+    manager.flush(wait=True)
+    manager.close()
+    assert (tmp_path / "b-selected" / "COMPLETE").exists()
+    assert not (tmp_path / "b-skipped").exists()
+
+
+def _step_identity() -> Identity:
+    return Identity(actor_step_id=ActorStepId(rollout_id=120, step_id=0), rank={"dp": 0, "tp": 0, "pp": 0, "cp": 1})
+
+
+def _step_config() -> RecomputeConfig:
+    return RecomputeConfig(advantage_estimator="grpo", n_samples_per_prompt=2)
+
+
+def test_capture_enable_disable_active(tmp_path):
+    assert active() is None
+    manager = enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    assert active() is manager
+    assert manager.enabled
+    disable()
+    assert active() is None
+
+
+def test_capture_step_lifecycle(tmp_path):
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    record = make_capture_record("b-step")
+
+    begin_step((120, 0), identity=record.identity, config=record.config, bundle_id="b-step")
+    step = current_step()
+    assert step is not None and step.actor_step_id == (120, 0)
+    step.samples = record.samples
+    step.tensors = record.tensors
+    step.expected = record.expected
+    # end_step drops accumulators that never received a hook payload (stages
+    # stays None). The production hooks always set this; the test must too.
+    step.stages = {
+        StageId.SAMPLE,
+        StageId.REWARD_RAW,
+        StageId.REWARD_POST_PROCESS,
+        StageId.ADVANTAGE_KL,
+        StageId.ADVANTAGE_ESTIMATE,
+        StageId.LOSS_POLICY,
+    }
+    end_step()
+    disable()
+
+    assert (tmp_path / "b-step" / "COMPLETE").exists()
+    assert replay(tmp_path / "b-step").passed
+
+
+def test_capture_begin_step_disabled_noop():
+    disable()
+    begin_step((120, 0), identity=_step_identity(), config=_step_config(), bundle_id="b-x")
+    assert current_step() is None
+
+
+def test_capture_begin_step_unselected_noop(tmp_path):
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_steps={(0, 0)}))
+    begin_step((120, 0), identity=_step_identity(), config=_step_config(), bundle_id="b-x")
+    assert current_step() is None
+
+
+def test_end_step_without_payload_does_not_write(tmp_path):
+    # Non-last PP ranks open an accumulator then end it with no stages filled.
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    begin_step((120, 0), identity=_step_identity(), config=_step_config(), bundle_id="b-empty")
+    end_step()
+    disable()
+    assert not (tmp_path / "b-empty").exists()
+
+
+def test_end_rollout_without_payload_does_not_write(tmp_path):
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    begin_rollout(120, identity=Identity(rollout_id=120, rank={"cp": 1}), config=_step_config(), bundle_id="b-empty-r")
+    end_rollout()
+    disable()
+    assert not (tmp_path / "b-empty-r").exists()
+
+
+def test_capture_should_capture_guard():
+    # Disabled -> False (the hot-path short-circuit contract).
+    assert should_capture((0, 0)) is False
+
+
+def test_capture_loss_only_roundtrip(tmp_path):
+    # A partial (loss-only) capture, as produced by capture_hooks.capture_policy_loss:
+    # positional sample ids built from raw metadata, advantages recorded as a
+    # tensor (not recomputed upstream), and only loss.policy declared.
+    record = make_capture_record("b-loss-only")
+    loss_only = CaptureRecord(
+        actor_step_id=record.actor_step_id,
+        identity=record.identity,
+        samples=[],
+        config=record.config,
+        tensors={name: record.tensors[name] for name in ("old_log_probs", "log_probs", "entropy", "advantages")},
+        expected={StageId.LOSS_POLICY.value: record.expected[StageId.LOSS_POLICY.value]},
+        bundle_id="b-loss-only",
+        stages={StageId.LOSS_POLICY},
+        response_lengths=[sample.response_length for sample in record.samples],
+        total_lengths=[sample.total_length for sample in record.samples],
+        loss_masks_tensor=torch.tensor(
+            [value for sample in record.samples for value in sample.loss_mask], dtype=torch.float32
+        ),
+    )
+
+    bundle_path = build_bundle_from_record(loss_only, tmp_path)
+    loaded = BundleReader(bundle_path).load()
+    assert set(loaded.manifest.stage_contracts) == {StageId.LOSS_POLICY}
+    assert loaded.index.identity.micro_batch_ids == ["mb-0000"]
+    assert all(sample.micro_batch_id == "mb-0000" for sample in loaded.index.samples)
+
+    assert replay(bundle_path).passed
+    assert replay(bundle_path, batch_ids=["mb-0000"]).passed
+
+
+def test_capture_rollout_roundtrip_parity(tmp_path):
+    record = make_rollout_capture_record("b-rollout")
+    bundle_path = build_bundle_from_record(record, tmp_path)
+
+    loaded = BundleReader(bundle_path).load()
+    # A rollout-level bundle declares only the reward → advantage chain; the
+    # per-step loss stages are absent because their payloads are not captured.
+    assert set(loaded.manifest.stage_contracts) == {
+        StageId.REWARD_RAW,
+        StageId.REWARD_POST_PROCESS,
+        StageId.ADVANTAGE_KL,
+        StageId.ADVANTAGE_ESTIMATE,
+    }
+    for contract in loaded.manifest.stage_contracts.values():
+        assert contract.capability == StageCapability.RECOMPUTE
+    assert loaded.index.identity.rollout_id == 120
+    assert loaded.index.identity.actor_step_id is None
+
+    report = replay(bundle_path)
+    assert report.passed
+    assert report.first_divergent_stage is None
+
+
+def test_capture_rollout_lifecycle(tmp_path):
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    record = make_rollout_capture_record("b-rollout-step")
+
+    begin_rollout(120, identity=record.identity, config=record.config, bundle_id="b-rollout-step")
+    step = current_step()
+    assert step is not None and step.rollout_id == 120 and step.actor_step_id is None
+    step.samples = record.samples
+    step.tensors = record.tensors
+    step.expected = record.expected
+    step.stages = record.stages
+    step.response_lengths = record.response_lengths
+    step.total_lengths = record.total_lengths
+    step.loss_masks_tensor = record.loss_masks_tensor
+    step.group_indices_tensor = record.group_indices_tensor
+    step.raw_rewards_tensor = record.raw_rewards_tensor
+    step.rewards_tensor = record.rewards_tensor
+    end_rollout()
+    disable()
+
+    assert (tmp_path / "b-rollout-step" / "COMPLETE").exists()
+    assert replay(tmp_path / "b-rollout-step").passed
+
+
+def test_capture_selected_rollouts(tmp_path):
+    manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_rollouts={120}))
+    assert manager.submit(make_rollout_capture_record("b-rselected")) is True
+
+    other = make_rollout_capture_record("b-rskipped")
+    other.rollout_id = 121
+    assert manager.submit(other) is False
+
+    manager.flush(wait=True)
+    manager.close()
+    assert (tmp_path / "b-rselected" / "COMPLETE").exists()
+    assert not (tmp_path / "b-rskipped").exists()
+
+
+def test_capture_should_capture_rollout_guard():
+    # Disabled -> False (the rollout hot-path short-circuit contract).
+    assert should_capture_rollout(120) is False
+
+
+def test_capture_begin_rollout_unselected_noop(tmp_path):
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path), selected_rollouts={0}))
+    begin_rollout(120, identity=Identity(rollout_id=120, rank={"cp": 1}), config=_step_config(), bundle_id="b-x")
+    assert current_step() is None
+
+
+def test_config_from_env_disabled(monkeypatch):
+    monkeypatch.delenv("RELAX_REPLAY_CAPTURE", raising=False)
+    monkeypatch.delenv("RELAX_REPLAY_CAPTURE_DIR", raising=False)
+    assert config_from_env() is None
+
+
+def test_config_from_env_missing_dir_stays_disabled(monkeypatch):
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+    monkeypatch.delenv("RELAX_REPLAY_CAPTURE_DIR", raising=False)
+    assert config_from_env() is None
+
+
+def test_config_from_env_parses_selectors(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_DIR", str(tmp_path))
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_STEPS", "0:0, 1:2")
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_ROLLOUTS", "0,3")
+    config = config_from_env()
+    assert config is not None
+    assert config.enabled
+    assert config.output_dir == str(tmp_path)
+    assert config.selected_steps == {(0, 0), (1, 2)}
+    assert config.selected_rollouts == {0, 3}
+
+
+def test_config_from_env_rejects_bad_steps(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_DIR", str(tmp_path))
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_STEPS", "not-a-step")
+    with pytest.raises(ValueError, match="RELAX_REPLAY_CAPTURE_STEPS"):
+        config_from_env()
+
+
+def test_maybe_enable_from_env_scopes_rank_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_DIR", str(tmp_path))
+    manager = maybe_enable_from_env(rank=3)
+    assert manager is not None
+    assert manager.enabled
+    assert active() is manager
+    assert str(tmp_path / "rank-3") == manager.output_dir

--- a/tests/utils/replay/test_capture.py
+++ b/tests/utils/replay/test_capture.py
@@ -10,6 +10,7 @@ bundle is replayable by the PR A runner.
 
 from __future__ import annotations
 
+import json
 import threading
 
 import pytest
@@ -51,6 +52,15 @@ from tests.utils.replay.helpers import make_capture_record, make_rollout_capture
 def _reset_capture_global():
     yield
     disable()
+
+
+def test_capture_snapshot_isolates_storage():
+    from relax.utils.replay.capture import _snapshot_record
+
+    record = make_capture_record("b-clone")
+    snapshot = _snapshot_record(record)
+    record.tensors["log_probs"].fill_(99.0)
+    assert torch.equal(snapshot.tensors["log_probs"], torch.zeros_like(record.tensors["log_probs"]))
 
 
 def test_capture_roundtrip_parity(tmp_path):
@@ -206,6 +216,17 @@ def test_capture_step_lifecycle(tmp_path):
     assert replay(tmp_path / "b-step").passed
 
 
+def test_group_indices_from_rollout_uses_tq_or_synthesizes():
+    class _Args:
+        n_samples_per_prompt = 2
+
+    from_tq = capture_hooks._group_indices_from_rollout({"group_index": [3, 3, 9, 9]}, _Args())
+    assert list(from_tq) == [3, 3, 9, 9]
+
+    synthesized = capture_hooks._group_indices_from_rollout({"response_lengths": [1, 1, 1, 1]}, _Args())
+    assert synthesized == [0, 0, 1, 1]
+
+
 def test_capture_hooks_noop_when_disabled():
     disable()
     assert should_capture((0, 0)) is False
@@ -342,14 +363,30 @@ def test_config_from_env_rejects_bad_steps(monkeypatch, tmp_path):
         config_from_env()
 
 
-def test_maybe_enable_from_env_scopes_rank_dir(monkeypatch, tmp_path):
+def test_maybe_enable_from_env_records_rank(monkeypatch, tmp_path):
     monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
     monkeypatch.setenv("RELAX_REPLAY_CAPTURE_DIR", str(tmp_path))
-    manager = maybe_enable_from_env(rank=3)
+    manager = maybe_enable_from_env(rank=3, expected_ranks=[1, 3])
     assert manager is not None
     assert manager.enabled
     assert active() is manager
-    assert str(tmp_path / "rank-3") == manager.output_dir
+    assert manager.output_dir == str(tmp_path)
+    assert manager.rank == 3
+    assert manager.expected_ranks == [1, 3]
+
+
+def test_maybe_enable_for_actor_only_producers(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE", "1")
+    monkeypatch.setenv("RELAX_REPLAY_CAPTURE_DIR", str(tmp_path))
+    monkeypatch.setattr(capture_hooks, "capture_producer_ranks", lambda: [1, 3])
+    monkeypatch.setattr("torch.distributed.get_rank", lambda: 2)
+    assert capture_hooks.maybe_enable_for_actor() is None
+    disable()
+    monkeypatch.setattr("torch.distributed.get_rank", lambda: 3)
+    manager = capture_hooks.maybe_enable_for_actor()
+    assert manager is not None
+    assert manager.rank == 3
+    assert manager.expected_ranks == [1, 3]
 
 
 def _policy_reported_loss(old, logp, entropy, advantages, samples, config):
@@ -421,3 +458,24 @@ def test_capture_policy_loss_records_data_iterator_micro_batches(tmp_path):
     assert loaded.tensors["old_log_probs"].numel() == 8
     assert replay(tmp_path / "b-mb").passed
     assert replay(tmp_path / "b-mb", batch_ids=["mb-0008"]).passed
+
+
+def test_capture_cohort_try_finalize(tmp_path):
+    record0 = make_capture_record("b-cohort")
+    record0.capture_rank = 0
+    record0.expected_ranks = [0, 1]
+    path0 = build_bundle_from_record(record0, tmp_path)
+    cohort = tmp_path / "b-cohort"
+    assert path0 == cohort / "rank-0"
+    assert (cohort / "COMPLETE.0").is_file()
+    assert not (cohort / "COMPLETE").is_file()
+
+    record1 = make_capture_record("b-cohort")
+    record1.capture_rank = 1
+    record1.expected_ranks = [0, 1]
+    path1 = build_bundle_from_record(record1, tmp_path)
+    assert path1 == cohort / "rank-1"
+    complete = json.loads((cohort / "COMPLETE").read_text(encoding="utf-8"))
+    assert complete["ranks"] == [0, 1]
+    assert replay(path0).passed
+    assert replay(path1).passed

--- a/tests/utils/replay/test_capture.py
+++ b/tests/utils/replay/test_capture.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 from relax.utils.replay import capture, capture_hooks
-from relax.utils.replay.bundle import BundleReader
+from relax.utils.replay.bundle import BundleReader, IncompleteBundleError
 from relax.utils.replay.capture import (
     CaptureConfig,
     CaptureManager,
@@ -469,6 +469,11 @@ def test_capture_cohort_try_finalize(tmp_path):
     assert path0 == cohort / "rank-0"
     assert (cohort / "COMPLETE.0").is_file()
     assert not (cohort / "COMPLETE").is_file()
+    rank0_complete = json.loads((path0 / "COMPLETE").read_text(encoding="utf-8"))
+    assert rank0_complete["ranks"] == [0]
+    assert rank0_complete["expected_ranks"] == [0, 1]
+    with pytest.raises(IncompleteBundleError, match="incomplete"):
+        BundleReader(path0).load()
 
     record1 = make_capture_record("b-cohort")
     record1.capture_rank = 1

--- a/tests/utils/replay/test_capture.py
+++ b/tests/utils/replay/test_capture.py
@@ -2,8 +2,8 @@
 
 """Tests for the PR B production-capture data plane.
 
-These exercise ``CaptureRecord`` / ``build_bundle_from_record`` (the pure
-capture→bundle bridge) and ``CaptureManager`` (the async, bounded, failure-
+These exercise CaptureRecord / build_bundle_from_record (the pure
+capture→bundle bridge) and CaptureManager (the async, bounded, failure-
 isolated sink) entirely on CPU — the round-trip parity test proves the captured
 bundle is replayable by the PR A runner.
 """
@@ -92,7 +92,7 @@ def test_capture_manager_disabled_noop(tmp_path):
 def test_capture_manager_enabled_writes_bundle(tmp_path):
     manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
     assert manager.submit(make_capture_record("b-async")) is True
-    manager.flush(wait=True)
+    manager.flush()
     manager.close()
     assert (tmp_path / "b-async" / "COMPLETE").exists()
     assert replay(tmp_path / "b-async").passed
@@ -130,7 +130,7 @@ def test_capture_failure_isolation(tmp_path, monkeypatch):
     manager = CaptureManager(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
 
     assert manager.submit(make_capture_record("b-fail")) is True  # never raises
-    manager.flush(wait=True)
+    manager.flush()
     assert manager.error_count == 1
     manager.close()
 
@@ -143,7 +143,7 @@ def test_capture_selected_steps(tmp_path):
     other.actor_step_id = (121, 0)
     assert manager.submit(other) is False
 
-    manager.flush(wait=True)
+    manager.flush()
     manager.close()
     assert (tmp_path / "b-selected" / "COMPLETE").exists()
     assert not (tmp_path / "b-skipped").exists()
@@ -313,7 +313,7 @@ def test_capture_selected_rollouts(tmp_path):
     other.rollout_id = 121
     assert manager.submit(other) is False
 
-    manager.flush(wait=True)
+    manager.flush()
     manager.close()
     assert (tmp_path / "b-rselected" / "COMPLETE").exists()
     assert not (tmp_path / "b-rskipped").exists()

--- a/tests/utils/replay/test_capture_gpu.py
+++ b/tests/utils/replay/test_capture_gpu.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""GPU smoke test for production capture (PR B).
+
+Runs the real hook path — ``capture_hooks.capture_policy_loss`` with CUDA
+tensors through the async ``CaptureManager`` — and verifies the produced bundle
+replays cleanly on CPU. Skipped on CPU-only hosts.
+
+This is a *semi-integration* smoke: it exercises the actual hook functions and
+the deferred GPU→CPU copy on the writer thread, but not ``build_identity``
+(which needs a Megatron ``mpu`` world). Full DP/TP parity is validated by a
+real training run on the target cluster.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from relax.utils.replay import capture_hooks
+from relax.utils.replay.capture import CaptureConfig, begin_step, disable, enable, end_step
+from relax.utils.replay.runner import replay
+from relax.utils.replay.schema import StageId
+from tests.utils.replay.helpers import make_capture_record
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def test_capture_policy_loss_gpu_roundtrip(tmp_path):
+    device = torch.device("cuda")
+    reference = make_capture_record("b-gpu")
+
+    enable(CaptureConfig(enabled=True, output_dir=str(tmp_path)))
+    begin_step((120, 0), identity=reference.identity, config=reference.config, bundle_id="b-gpu")
+
+    reported_loss = {
+        field: torch.tensor(value, device=device)
+        for field, value in reference.expected[StageId.LOSS_POLICY.value].items()
+    }
+    capture_hooks.capture_policy_loss(
+        old_log_probs=reference.tensors["old_log_probs"].to(device),
+        log_probs=reference.tensors["log_probs"].to(device),
+        entropy=reference.tensors["entropy"].to(device),
+        advantages=reference.tensors["advantages"].to(device),
+        loss_masks=[torch.tensor(sample.loss_mask, device=device) for sample in reference.samples],
+        response_lengths=[sample.response_length for sample in reference.samples],
+        total_lengths=[sample.total_length for sample in reference.samples],
+        reported_loss=reported_loss,
+    )
+    end_step()
+    disable()
+
+    assert (tmp_path / "b-gpu" / "COMPLETE").exists()
+    assert replay(tmp_path / "b-gpu").passed

--- a/tests/utils/replay/test_capture_gpu.py
+++ b/tests/utils/replay/test_capture_gpu.py
@@ -2,13 +2,13 @@
 
 """GPU smoke test for production capture (PR B).
 
-Runs the real hook path — ``capture_hooks.capture_policy_loss`` with CUDA
-tensors through the async ``CaptureManager`` — and verifies the produced bundle
+Runs the real hook path — capture_hooks.capture_policy_loss with CUDA
+tensors through the async CaptureManager — and verifies the produced bundle
 replays cleanly on CPU. Skipped on CPU-only hosts.
 
-This is a *semi-integration* smoke: it exercises the actual hook functions and
-the deferred GPU→CPU copy on the writer thread, but not ``build_identity``
-(which needs a Megatron ``mpu`` world). Full DP/TP parity is validated by a
+This is a semi-integration smoke: it exercises the actual hook functions and
+the deferred GPU→CPU copy on the writer thread, but not build_identity
+(which needs a Megatron mpu world). Full DP/TP parity is validated by a
 real training run on the target cluster.
 """
 

--- a/tests/utils/replay/test_cli.py
+++ b/tests/utils/replay/test_cli.py
@@ -73,8 +73,12 @@ def test_cli_replay_step_requires_cohort_complete(tmp_path):
     record0 = make_capture_record("replay-120-0")
     record0.capture_rank = 0
     record0.expected_ranks = [0, 1]
-    build_bundle_from_record(record0, tmp_path)
+    rank0 = build_bundle_from_record(record0, tmp_path)
     assert main(["replay", str(tmp_path), "--step", "120:0"]) == 1
+    assert main(["replay", str(rank0)]) == 1
+    assert main(["replay", str(tmp_path)]) == 1
+    assert main(["validate", str(rank0)]) == 1
+    assert main(["inspect", str(rank0)]) == 0
 
     record1 = make_capture_record("replay-120-0")
     record1.capture_rank = 1
@@ -82,3 +86,5 @@ def test_cli_replay_step_requires_cohort_complete(tmp_path):
     rank1 = build_bundle_from_record(record1, tmp_path)
     assert main(["replay", str(tmp_path), "--step", "120:0"]) == 0
     assert main(["replay", str(rank1), "--step", "120:0"]) == 0
+    assert main(["replay", str(rank0)]) == 0
+    assert main(["validate", str(rank0)]) == 0

--- a/tests/utils/replay/test_cli.py
+++ b/tests/utils/replay/test_cli.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""CLI entry point tests."""
+
+from __future__ import annotations
+
+from relax.tools.trajectory_replay.cli import main
+from tests.utils.replay.helpers import build_grpo_bundle
+
+
+def test_cli_inspect_valid(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["inspect", str(bundle)]) == 0
+
+
+def test_cli_inspect_missing(tmp_path):
+    assert main(["inspect", str(tmp_path / "nope")]) == 1
+
+
+def test_cli_validate_valid(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["validate", str(bundle)]) == 0
+
+
+def test_cli_validate_invalid(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    (bundle / "COMPLETE").unlink()
+    assert main(["validate", str(bundle)]) == 1
+
+
+def test_cli_replay_valid(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle)]) == 0
+
+
+def test_cli_replay_divergent(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", pr65_bug=True)
+    assert main(["replay", str(bundle)]) == 1
+
+
+def test_cli_replay_sample_selection(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle), "--sample", "s-0"]) == 0
+
+
+def test_cli_replay_batch_selection(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle), "--batch", "mb-0007"]) == 0
+
+
+def test_cli_replay_step_assert_match(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle), "--step", "120:0"]) == 0
+
+
+def test_cli_replay_step_assert_mismatch(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle), "--step", "999:0"]) == 1

--- a/tests/utils/replay/test_cli.py
+++ b/tests/utils/replay/test_cli.py
@@ -1,11 +1,17 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""CLI entry point tests."""
+"""CLI entry point tests.
+
+Happy-path replay, sample/batch selection and PR #65 localization are covered
+by the runner tests. This module only checks argv wiring, exit codes and the
+--step resolver unique to the CLI.
+"""
 
 from __future__ import annotations
 
 from relax.tools.trajectory_replay.cli import main
-from tests.utils.replay.helpers import build_grpo_bundle
+from relax.utils.replay.capture import build_bundle_from_record
+from tests.utils.replay.helpers import build_grpo_bundle, make_rollout_capture_record
 
 
 def test_cli_inspect_valid(tmp_path):
@@ -28,31 +34,25 @@ def test_cli_validate_invalid(tmp_path):
     assert main(["validate", str(bundle)]) == 1
 
 
-def test_cli_replay_valid(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
-    assert main(["replay", str(bundle)]) == 0
-
-
 def test_cli_replay_divergent(tmp_path):
     bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", pr65_bug=True)
     assert main(["replay", str(bundle)]) == 1
 
 
-def test_cli_replay_sample_selection(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
-    assert main(["replay", str(bundle), "--sample", "s-0"]) == 0
-
-
-def test_cli_replay_batch_selection(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
-    assert main(["replay", str(bundle), "--batch", "mb-0007"]) == 0
-
-
-def test_cli_replay_step_assert_match(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
-    assert main(["replay", str(bundle), "--step", "120:0"]) == 0
-
-
 def test_cli_replay_step_assert_mismatch(tmp_path):
     bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
     assert main(["replay", str(bundle), "--step", "999:0"]) == 1
+
+
+def test_cli_replay_step_on_rollout_bundle(tmp_path):
+    bundle = build_bundle_from_record(make_rollout_capture_record("b-rollout"), tmp_path)
+    assert main(["replay", str(bundle), "--step", "120:0"]) == 0
+    assert main(["replay", str(bundle), "--step", "121:0"]) == 1
+
+
+def test_cli_replay_step_picks_from_capture_dir(tmp_path):
+    store = tmp_path / "rank-0"
+    build_grpo_bundle(store / "replay-120-0")
+    build_bundle_from_record(make_rollout_capture_record("replay-rollout-120"), store)
+    assert main(["replay", str(tmp_path), "--step", "120:0"]) == 0
+    assert main(["replay", str(tmp_path), "--step", "999:0"]) == 1

--- a/tests/utils/replay/test_cli.py
+++ b/tests/utils/replay/test_cli.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from relax.tools.trajectory_replay.cli import main
 from relax.utils.replay.capture import build_bundle_from_record
-from tests.utils.replay.helpers import build_grpo_bundle, make_rollout_capture_record
+from tests.utils.replay.helpers import build_grpo_bundle, make_capture_record, make_rollout_capture_record
 
 
 def test_cli_inspect_valid(tmp_path):
@@ -46,13 +46,39 @@ def test_cli_replay_step_assert_mismatch(tmp_path):
 
 def test_cli_replay_step_on_rollout_bundle(tmp_path):
     bundle = build_bundle_from_record(make_rollout_capture_record("b-rollout"), tmp_path)
-    assert main(["replay", str(bundle), "--step", "120:0"]) == 0
-    assert main(["replay", str(bundle), "--step", "121:0"]) == 1
+    assert main(["replay", str(bundle), "--step", "120:0"]) == 1
+    assert main(["replay", str(bundle), "--rollout", "120"]) == 0
+    assert main(["replay", str(bundle), "--rollout", "121"]) == 1
 
 
 def test_cli_replay_step_picks_from_capture_dir(tmp_path):
-    store = tmp_path / "rank-0"
-    build_grpo_bundle(store / "replay-120-0")
-    build_bundle_from_record(make_rollout_capture_record("replay-rollout-120"), store)
+    build_grpo_bundle(tmp_path / "replay-120-0")
+    build_bundle_from_record(make_rollout_capture_record("replay-rollout-120"), tmp_path)
     assert main(["replay", str(tmp_path), "--step", "120:0"]) == 0
+    assert main(["replay", str(tmp_path), "--rollout", "120"]) == 0
     assert main(["replay", str(tmp_path), "--step", "999:0"]) == 1
+
+
+def test_cli_replay_step_and_rollout_exclusive(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle), "--step", "120:0", "--rollout", "120"]) == 1
+
+
+def test_cli_replay_requested_unsupported_stage(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    assert main(["replay", str(bundle), "--stage", "loss.value"]) == 1
+
+
+def test_cli_replay_step_requires_cohort_complete(tmp_path):
+    record0 = make_capture_record("replay-120-0")
+    record0.capture_rank = 0
+    record0.expected_ranks = [0, 1]
+    build_bundle_from_record(record0, tmp_path)
+    assert main(["replay", str(tmp_path), "--step", "120:0"]) == 1
+
+    record1 = make_capture_record("replay-120-0")
+    record1.capture_rank = 1
+    record1.expected_ranks = [0, 1]
+    rank1 = build_bundle_from_record(record1, tmp_path)
+    assert main(["replay", str(tmp_path), "--step", "120:0"]) == 0
+    assert main(["replay", str(rank1), "--step", "120:0"]) == 0

--- a/tests/utils/replay/test_layout.py
+++ b/tests/utils/replay/test_layout.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Tests for the PR C distributed layout primitives (pure CPU)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from relax.utils.replay.layout import (
+    LayoutError,
+    RankTopology,
+    ShardSpec,
+    TensorLayout,
+    compute_offsets,
+    cp_capability,
+    reconstruct_shards,
+    shard_order,
+    validate_dp_completeness,
+)
+from relax.utils.replay.schema import StageCapability, StageId
+
+
+def test_layout_parse_topology():
+    topology = RankTopology.from_rank_dict({"dp": 2, "tp": 1, "pp": 2, "cp": 4})
+    assert topology == RankTopology(dp=2, tp=1, pp=2, cp=4)
+    assert topology.world_size == 16
+    assert RankTopology.from_rank_dict({"cp": 1}).world_size == 1
+
+
+def test_layout_shard_order():
+    assert shard_order([3, 1, 2]) == [1, 2, 3]
+
+
+def test_layout_compute_offsets():
+    layout = compute_offsets("log_probs", lengths=[3, 5], dims=[8])
+    assert layout.dims == (8,)
+    assert layout.shards[0].offsets == (0,) and layout.shards[0].shape == (3,)
+    assert layout.shards[1].offsets == (3,) and layout.shards[1].shape == (5,)
+
+
+def test_layout_compute_offsets_padding():
+    layout = compute_offsets("log_probs", lengths=[3, 5], dims=[8], pad_to=4)
+    assert layout.shards[0].shape == (4,) and layout.shards[0].unpadded_length == 3
+    assert layout.shards[1].shape == (8,) and layout.shards[1].unpadded_length == 5
+    # Offsets are canonical (unpadded) coordinates: rank 1 starts after rank 0's
+    # 3 real elements, regardless of rank 0's padding.
+    assert layout.shards[1].offsets == (3,)
+
+
+def test_layout_dp_completeness_ok():
+    validate_dp_completeness(StageId.REWARD_POST_PROCESS, required_ranks=[0, 1], present_ranks=[1, 0])
+
+
+def test_layout_dp_completeness_missing():
+    with pytest.raises(LayoutError, match="missing DP rank shard"):
+        validate_dp_completeness(StageId.ADVANTAGE_ESTIMATE, required_ranks=[0, 1, 2], present_ranks=[0, 2])
+
+
+def test_layout_reconstruct_contiguous():
+    canonical = torch.arange(8).float()
+    layout = compute_offsets("advantages", lengths=[3, 5], dims=[8])
+    shards = {0: canonical[:3], 1: canonical[3:]}
+    assert torch.equal(reconstruct_shards(layout, shards), canonical)
+
+
+def test_layout_reconstruct_with_padding():
+    canonical = torch.arange(8).float()
+    layout = compute_offsets("advantages", lengths=[3, 5], dims=[8], pad_to=4)
+    # Rank 0 holds 3 real elements padded to 4; rank 1 holds 5 padded to 8.
+    shard0 = torch.zeros(4)
+    shard0[:3] = canonical[:3]
+    shard1 = torch.zeros(8)
+    shard1[:5] = canonical[3:]
+    assert torch.equal(reconstruct_shards(layout, {0: shard0, 1: shard1}), canonical)
+
+
+def test_layout_reconstruct_missing_shard():
+    canonical = torch.arange(8).float()
+    layout = compute_offsets("advantages", lengths=[3, 5], dims=[8])
+    with pytest.raises(LayoutError, match="missing shard"):
+        reconstruct_shards(layout, {0: canonical[:3]})
+
+
+def test_layout_reconstruct_offsets_not_recorded():
+    layout = TensorLayout(name="x", dims=(8,), shards={0: ShardSpec(0, None, (8,))})
+    with pytest.raises(LayoutError, match="offsets not recorded"):
+        reconstruct_shards(layout, {0: torch.arange(8).float()})
+
+
+def test_layout_reconstruct_overlap():
+    canonical = torch.arange(8).float()
+    bad = TensorLayout(
+        name="advantages",
+        dims=(8,),
+        shards={0: ShardSpec(0, (0,), (3,), 3), 1: ShardSpec(1, (2,), (5,), 5)},
+    )
+    with pytest.raises(LayoutError, match="gap or overlap"):
+        reconstruct_shards(bad, {0: canonical[:3], 1: canonical[2:7]})
+
+
+def test_layout_cp_capability_frozen():
+    assert cp_capability(StageId.ADVANTAGE_ESTIMATE, cp=1, reconstructable=True) == StageCapability.RECOMPUTE
+    assert cp_capability(StageId.ADVANTAGE_ESTIMATE, cp=1, reconstructable=False) == StageCapability.UNSUPPORTED
+    # V1 freezes CP>1 as unsupported even when the layout is reconstructable.
+    assert cp_capability(StageId.ADVANTAGE_ESTIMATE, cp=2, reconstructable=True) == StageCapability.UNSUPPORTED
+
+
+def test_layout_json_roundtrip():
+    layout = compute_offsets("log_probs", lengths=[3, 5], dims=[8], pad_to=4)
+    restored = TensorLayout.from_dict(layout.to_dict())
+    assert restored == layout

--- a/tests/utils/replay/test_replay.py
+++ b/tests/utils/replay/test_replay.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Replay pipeline tests: adapters, closure and divergence detection."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+
+from relax.utils.replay.adapters.reward import replay_reward_post_process
+from relax.utils.replay.bundle import BundleReader
+from relax.utils.replay.identity import ClosureError, expand_selection
+from relax.utils.replay.report import StageStatus
+from relax.utils.replay.runner import replay
+from relax.utils.replay.validate import validate_bundle
+from tests.utils.replay.helpers import (
+    ADVANTAGES,
+    DEFAULT_LOSS,
+    NORMALIZED_REWARDS,
+    build_grpo_bundle,
+)
+
+
+def test_reward_group_normalization_reference(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    loaded = BundleReader(bundle).load()
+    ctx: dict = {}
+    result = replay_reward_post_process(loaded, ctx)
+
+    assert result.status == StageStatus.PASS
+    assert ctx["reward.post_process"] == pytest.approx(NORMALIZED_REWARDS)
+
+
+def test_replay_passes_on_valid_bundle(tmp_path):
+    bundle, _, expected = build_grpo_bundle(tmp_path / "bundle")
+    report = replay(bundle)
+
+    assert report.passed is True
+    assert report.first_divergent_stage is None
+    assert all(stage.status != StageStatus.FAIL for stage in report.stages)
+
+
+def test_reward_pr65_fixture(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", pr65_bug=True)
+    report = replay(bundle)
+
+    assert report.first_divergent_stage == "reward.post_process"
+    reward_stage = next(stage for stage in report.stages if stage.stage == "reward.post_process")
+    assert reward_stage.status == StageStatus.FAIL
+
+
+def test_advantage_grpo_layout(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    loaded = BundleReader(bundle).load()
+    assert loaded.tensors["advantages"].tolist() == pytest.approx(ADVANTAGES)
+
+
+def test_loss_ratio_one_reference(tmp_path):
+    bundle, _, expected = build_grpo_bundle(tmp_path / "bundle", ratio_one=True)
+    report = replay(bundle)
+    assert report.passed
+    assert expected["loss.policy"]["loss"] == pytest.approx(DEFAULT_LOSS)
+    assert expected["loss.policy"]["pg_loss"] == pytest.approx(0.0)
+    assert expected["loss.policy"]["entropy_loss"] == pytest.approx(2.0)
+
+
+def test_loss_ratio_not_one(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", ratio_one=False)
+    report = replay(bundle)
+    assert report.passed
+
+
+def test_corrupt_reward_detected(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="reward")
+    report = replay(bundle)
+    assert report.first_divergent_stage == "reward.raw"
+
+
+def test_corrupt_mask_token_detected(tmp_path):
+    # Non-uniform per-token values so masking one token changes the per-sample mean.
+    old_log_probs = torch.tensor([0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5])
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="mask_token", old_log_probs=old_log_probs)
+    report = replay(bundle)
+    assert report.first_divergent_stage == "loss.policy"
+
+
+def test_corrupt_old_log_probability_detected(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="old_log_probability", kl_coef=0.0)
+    report = replay(bundle)
+    assert report.first_divergent_stage == "loss.policy"
+
+
+def test_corrupt_schema_field_detected(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    index_path = bundle / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    del index["samples"][0]["loss_mask"]
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    result = validate_bundle(bundle)
+    assert not result.valid
+
+
+def test_selection_group_closure(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "bundle")
+    closure = expand_selection(index, sample_ids=["s-0"])
+    assert set(closure.sample_ids) == {"s-0", "s-1"}
+    assert closure.group_ids == {"g-0"}
+
+
+def test_selection_missing_group_fails_closed(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "bundle")
+    index.samples[0].group_index = None
+    with pytest.raises(ClosureError):
+        expand_selection(index, sample_ids=["s-0"])

--- a/tests/utils/replay/test_replay.py
+++ b/tests/utils/replay/test_replay.py
@@ -18,6 +18,7 @@ from tests.utils.replay.helpers import (
     DEFAULT_LOSS,
     NORMALIZED_REWARDS,
     build_grpo_bundle,
+    resign_metadata_checksums,
 )
 
 
@@ -88,6 +89,60 @@ def test_corrupt_schema_field_detected(tmp_path):
     index = json.loads(index_path.read_text(encoding="utf-8"))
     del index["samples"][0]["loss_mask"]
     index_path.write_text(json.dumps(index), encoding="utf-8")
+    resign_metadata_checksums(bundle)
 
     result = validate_bundle(bundle)
     assert not result.valid
+
+
+def test_replay_unsupported_estimator_fails(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    index_path = bundle / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["config"]["advantage_estimator"] = "ppo"
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+    resign_metadata_checksums(bundle)
+
+    with pytest.raises(ValueError, match="unsupported replay topology"):
+        replay(bundle)
+
+
+def test_replay_unsupported_cp_fails(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    index_path = bundle / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["identity"]["rank"]["cp"] = 2
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+    resign_metadata_checksums(bundle)
+
+    with pytest.raises(ValueError, match="unsupported replay topology"):
+        replay(bundle)
+
+
+def test_replay_missing_expected_fails(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    expected_path = bundle / "expected.json"
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    del expected["reward.post_process"]
+    expected_path.write_text(json.dumps(expected), encoding="utf-8")
+    resign_metadata_checksums(bundle)
+
+    report = replay(bundle)
+    assert report.passed is False
+    assert report.first_divergent_stage == "reward.post_process"
+
+
+def test_replay_loss_value_skipped_on_grpo(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    report = replay(bundle)
+    loss_value = next(stage for stage in report.stages if stage.stage == "loss.value")
+    assert loss_value.status == StageStatus.SKIPPED
+    assert report.passed is True
+
+
+def test_replay_requested_unsupported_stage_fails(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
+    report = replay(bundle, requested_stages=frozenset({"loss.value"}))
+    loss_value = next(stage for stage in report.stages if stage.stage == "loss.value")
+    assert loss_value.status == StageStatus.FAIL
+    assert report.passed is False

--- a/tests/utils/replay/test_replay.py
+++ b/tests/utils/replay/test_replay.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Relax Authors. All Rights Reserved.
 
-"""Replay pipeline tests: adapters, closure and divergence detection."""
+"""Replay pipeline tests: adapters and divergence detection."""
 
 from __future__ import annotations
 
@@ -11,12 +11,10 @@ import torch
 
 from relax.utils.replay.adapters.reward import replay_reward_post_process
 from relax.utils.replay.bundle import BundleReader
-from relax.utils.replay.identity import ClosureError, expand_selection
 from relax.utils.replay.report import StageStatus
 from relax.utils.replay.runner import replay
 from relax.utils.replay.validate import validate_bundle
 from tests.utils.replay.helpers import (
-    ADVANTAGES,
     DEFAULT_LOSS,
     NORMALIZED_REWARDS,
     build_grpo_bundle,
@@ -34,7 +32,7 @@ def test_reward_group_normalization_reference(tmp_path):
 
 
 def test_replay_passes_on_valid_bundle(tmp_path):
-    bundle, _, expected = build_grpo_bundle(tmp_path / "bundle")
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
     report = replay(bundle)
 
     assert report.passed is True
@@ -49,12 +47,6 @@ def test_reward_pr65_fixture(tmp_path):
     assert report.first_divergent_stage == "reward.post_process"
     reward_stage = next(stage for stage in report.stages if stage.stage == "reward.post_process")
     assert reward_stage.status == StageStatus.FAIL
-
-
-def test_advantage_grpo_layout(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle")
-    loaded = BundleReader(bundle).load()
-    assert loaded.tensors["advantages"].tolist() == pytest.approx(ADVANTAGES)
 
 
 def test_loss_ratio_one_reference(tmp_path):
@@ -72,24 +64,22 @@ def test_loss_ratio_not_one(tmp_path):
     assert report.passed
 
 
-def test_corrupt_reward_detected(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="reward")
+@pytest.mark.parametrize(
+    ("corrupt", "first_stage", "kwargs"),
+    [
+        ("reward", "reward.raw", {}),
+        (
+            "mask_token",
+            "loss.policy",
+            {"old_log_probs": torch.tensor([0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5])},
+        ),
+        ("old_log_probability", "loss.policy", {"kl_coef": 0.0}),
+    ],
+)
+def test_corrupt_input_detected(tmp_path, corrupt, first_stage, kwargs):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt=corrupt, **kwargs)
     report = replay(bundle)
-    assert report.first_divergent_stage == "reward.raw"
-
-
-def test_corrupt_mask_token_detected(tmp_path):
-    # Non-uniform per-token values so masking one token changes the per-sample mean.
-    old_log_probs = torch.tensor([0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5])
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="mask_token", old_log_probs=old_log_probs)
-    report = replay(bundle)
-    assert report.first_divergent_stage == "loss.policy"
-
-
-def test_corrupt_old_log_probability_detected(tmp_path):
-    bundle, _, _ = build_grpo_bundle(tmp_path / "bundle", corrupt="old_log_probability", kl_coef=0.0)
-    report = replay(bundle)
-    assert report.first_divergent_stage == "loss.policy"
+    assert report.first_divergent_stage == first_stage
 
 
 def test_corrupt_schema_field_detected(tmp_path):
@@ -101,17 +91,3 @@ def test_corrupt_schema_field_detected(tmp_path):
 
     result = validate_bundle(bundle)
     assert not result.valid
-
-
-def test_selection_group_closure(tmp_path):
-    bundle, index, _ = build_grpo_bundle(tmp_path / "bundle")
-    closure = expand_selection(index, sample_ids=["s-0"])
-    assert set(closure.sample_ids) == {"s-0", "s-1"}
-    assert closure.group_ids == {"g-0"}
-
-
-def test_selection_missing_group_fails_closed(tmp_path):
-    bundle, index, _ = build_grpo_bundle(tmp_path / "bundle")
-    index.samples[0].group_index = None
-    with pytest.raises(ClosureError):
-        expand_selection(index, sample_ids=["s-0"])

--- a/tests/utils/replay/test_selection.py
+++ b/tests/utils/replay/test_selection.py
@@ -71,6 +71,13 @@ def test_select_missing_batch_fails_closed(tmp_path):
         expand_selection(index, batch_ids=["mb-9999"])
 
 
+def test_select_missing_group_fails_closed(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "b")
+    index.samples[0].group_index = None
+    with pytest.raises(ClosureError):
+        expand_selection(index, sample_ids=["s-0"])
+
+
 def test_select_bundle_slices_tensors_and_expected(tmp_path):
     bundle, _, _ = build_grpo_bundle(tmp_path / "b")
     loaded = BundleReader(bundle).load()

--- a/tests/utils/replay/test_selection.py
+++ b/tests/utils/replay/test_selection.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+
+"""Selection replay tests: single sample / group / micro-batch and closure.
+
+A partial selection expands to its semantic-group closure and replays the per-
+sample/per-token stages; cohort-level stages (``loss.policy``) are skipped
+rather than comparing a subset scalar against a full-cohort expected value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from relax.utils.replay.bundle import BundleReader
+from relax.utils.replay.identity import ClosureError, expand_selection
+from relax.utils.replay.report import StageStatus
+from relax.utils.replay.runner import replay
+from relax.utils.replay.selection import select_bundle
+from tests.utils.replay.helpers import build_grpo_bundle
+
+
+def _stage(report, name: str):
+    return next(stage for stage in report.stages if stage.stage == name)
+
+
+def test_select_single_sample_closure(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "b")
+    closure = expand_selection(index, sample_ids=["s-0"])
+    assert set(closure.sample_ids) == {"s-0", "s-1"}
+    assert closure.group_ids == {"g-0"}
+
+
+def test_select_batch_closure(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "b")
+    closure = expand_selection(index, batch_ids=["mb-0008"])
+    assert set(closure.sample_ids) == {"s-2", "s-3"}
+    assert closure.group_ids == {"g-1"}
+
+
+def test_replay_single_sample_passes_and_skips_loss(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "b")
+    report = replay(bundle, sample_ids=["s-0"])
+    assert report.passed is True
+    assert _stage(report, "advantage.estimate").status == StageStatus.PASS
+    assert _stage(report, "loss.policy").status == StageStatus.SKIPPED
+
+
+def test_replay_single_batch_passes(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "b")
+    report = replay(bundle, batch_ids=["mb-0008"])
+    assert report.passed is True
+    assert _stage(report, "reward.post_process").status == StageStatus.PASS
+
+
+def test_replay_full_selection_still_replays_loss(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "b")
+    report = replay(bundle, group_ids=["g-0", "g-1"])
+    assert report.passed is True
+    assert _stage(report, "loss.policy").status == StageStatus.PASS
+
+
+def test_select_missing_sample_fails_closed(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "b")
+    with pytest.raises(ClosureError):
+        expand_selection(index, sample_ids=["s-99"])
+
+
+def test_select_missing_batch_fails_closed(tmp_path):
+    bundle, index, _ = build_grpo_bundle(tmp_path / "b")
+    with pytest.raises(ClosureError):
+        expand_selection(index, batch_ids=["mb-9999"])
+
+
+def test_select_bundle_slices_tensors_and_expected(tmp_path):
+    bundle, _, _ = build_grpo_bundle(tmp_path / "b")
+    loaded = BundleReader(bundle).load()
+    subset = select_bundle(loaded, sample_ids=["s-0"])
+    assert len(subset.index.samples) == 2
+    assert subset.tensors["old_log_probs"].numel() == 4
+    assert len(subset.expected["reward.raw"]["raw_rewards"]) == 2

--- a/tests/utils/replay/test_selection.py
+++ b/tests/utils/replay/test_selection.py
@@ -3,8 +3,8 @@
 """Selection replay tests: single sample / group / micro-batch and closure.
 
 A partial selection expands to its semantic-group closure and replays the per-
-sample/per-token stages; cohort-level stages (``loss.policy``) are skipped
-rather than comparing a subset scalar against a full-cohort expected value.
+sample/per-token stages; cohort-level stages (loss.policy) are skipped rather
+than comparing a subset scalar against a full-cohort expected value.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## 摘要

本 PR 实现 Relax **任务 34**（Deterministic Trajectory Replay）：把一次训练 step 实际消费的轨迹、reward 输入、post-forward 张量与元数据打成可移植 replay bundle，然后在 **普通 CPU 机器** 上重算 reward / advantage / policy loss，无需启动 Ray Serve、SGLang、Rollout Worker 或 GPU。

这不是把整套在线训练系统搬到本地。模型 forward、backward、gradient 与 optimizer 不在重放边界内（[RFC #171](https://github.com/redai-infra/Relax/issues/171)）。

V1 冻结为 **GRPO + `CP=1`**。其余算法 / 拓扑一律 `unsupported`：显式失败，不做 best-effort 猜测，也不静默丢字段。

文档：[中文](docs/zh/guide/trajectory-replay.md) / [英文](docs/en/guide/trajectory-replay.md)

## 动机

reward / advantage / loss 类问题排查成本高：复现代价随集群规模放大；rollout 带 `--rollout-temperature` 时，同一配置重跑也得不到同一条轨迹。现有 `save_debug_*` dump 没有稳定 schema、没有 expected outputs、没有 identity closure，也不适合安全加载别人给的包。

历史故障 PR #65（streamed prompt group 被当成一个物理 TransferQueue batch 做归一化）是典型场景：最终 `pg_loss` 会变，但 **第一个出错阶段是 `reward.post_process`**。轨迹重放用来定位这类错误，而不是只比较一个最终标量。

## 设计

### 重放边界

```
范围内     sample → reward.raw → reward.post_process → advantage.kl → advantage.estimate → loss.policy
范围外     模型 forward / backward / optimizer；远端 RM / GenRM 执行；完整 logits / checkpoint
```

loss 重放保存紧凑的 post-forward 向量（`log_probs[T]`、`entropy[T]`、advantages、masks），不保存 `logits[T, V]`。

### Bundle

bundle 是自描述目录，不是无结构 `.pt` dump：

```
<bundle>/
├── manifest.json    # 格式版本、producer、stage contract、payload checksum、比较策略
├── index.json       # 身份 + per-sample 记录 + 重算配置
├── expected.json    # 各阶段 JSON 期望输出
├── payloads/        # 仅 torch.Tensor，weights_only=True 加载
└── COMPLETE         # 最后写入（多 rank 时为 COMPLETE.<rank> + 最终 COMPLETE）
```

- 身份必须且只能有一个锚点：`actor_step_id=(rollout_id, step_id)`（step 级 / loss）或 `rollout_id`（rollout 级 / reward-advantage）。
- `--sample` / `--group` / `--batch` 会展开到完整 semantic-group closure；缺 membership 直接失败（避免 PR #65 那种用物理 batch 猜 group）。
- `--step ROLLOUT_ID:STEP_ID`：对单个 bundle 校验身份；路径是抓包目录时（含 `rank-*`）选出匹配的那一份，优先 step 级。rollout 级包按 `rollout_id` 匹配。
- `--batch` 使用 DataIterator 的 micro-batch 序号（`mb-0000`、`mb-0001`、…），不是 actor `step_id`。多个 micro-batch 追加写入；激活重计算同一 mb 时第一次写入生效。
- `format_version` major 不兼容 → `ValueError`。缺必填字段 → validate/load 失败。未知附加字段 → warning，不静默丢弃。

### 生产捕获（默认关闭）

捕获默认关闭，不得改变训练数值。只用环境变量打开（不改 `arguments.py`）：

```bash
export RELAX_REPLAY_CAPTURE=1
export RELAX_REPLAY_CAPTURE_DIR=/path/to/replay-bundles
# 可选过滤；未设置则全部捕获
export RELAX_REPLAY_CAPTURE_STEPS=0:0
export RELAX_REPLAY_CAPTURE_ROLLOUTS=0
```

`MegatronTrainRayActor.init` 调用 `maybe_enable_from_env(rank=...)`。每个 rank 写到 `<DIR>/rank-<rank>/`。只设了 `CAPTURE=1` 但没有 `DIR` 时打 warning，保持关闭。

两类 bundle（尚未合成一条「首个分歧阶段」链）：

| 类型 | 阶段 | 身份 | 打点位置 |
| --- | --- | --- | --- |
| rollout 级 | reward → advantage | `rollout_id` | `train_actor` |
| step 级 | `loss.policy` | `(rollout_id, step_id)` | `train_one_step` + `policy_loss_function` |

热路径：未开启时两次全局读取后返回。开启后训练线程只做 **detach**（不调用 `.item()` / `.tolist()`）；GPU→CPU 拷贝和序列化在有界 writer 线程。队列满则丢弃该条，不反压训练。没有 hook 填过 payload 的 accumulator（例如非 last PP）不会落盘。

### 离线 runner

```bash
python -m relax.tools.trajectory_replay inspect  <bundle 或抓包目录>
python -m relax.tools.trajectory_replay validate <bundle>
python -m relax.tools.trajectory_replay replay   <bundle> \
    [--stage all] [--sample s-0] [--group g-1] [--batch mb-0000] [--step 0:0]
```

`inspect` 可用于不完整 bundle。`validate` / `replay` 需要 `COMPLETE` 和 checksum。退出码 0 通过，1 为分歧或非法 bundle。部分选择会跳过 cohort 级的 `loss.policy`（子集标量无法与全 cohort 期望值比较）。

advantage / loss 适配器复用生产 kernel（`compute_approx_kl`、`get_grpo_returns`、`compute_policy_loss`）。`reward.post_process` 因生产函数所在模块会在 import 时拉 Ray，离线侧重实现，并由 PR #65 fixture 钉住语义；manifest 标记 `implementation="reimplemented"`。

## 涉及文件

- `relax/utils/replay/` — schema、bundle 读写、identity/closure、adapter、runner、capture manager
- `relax/utils/replay/capture_hooks.py` — 训练侧 hook（仅被 actor / loss / model 导入）
- `relax/tools/trajectory_replay/` — CLI
- `relax/backends/megatron/{actor,model,loss,data}.py` — 开启捕获、begin/end、打上 `replay_micro_batch_index`
- `relax/utils/env.py` — 登记 `RELAX_REPLAY_CAPTURE*`
- `docs/{zh,en}/guide/trajectory-replay.md`
- `tests/utils/replay/`

有意未改：`relax/utils/arguments.py`、Controller / Service / Launcher。

## 测试计划

- [x] `pytest tests/utils/replay/ -k "not gpu"` — CPU 套件（bundle 完整性、replay、选择器、capture、CLI、layout）
- [x] Schema：major 不匹配抛错；缺必填字段 validate 失败；未知字段 warning
- [x] 选择器：sample → semantic-group closure；`--batch` 按 DataIterator mb；`--step` 覆盖 step 包 / rollout 包 / 抓包目录；缺 membership 失败
- [x] PR #65 fixture + reward / mask / old-logprob / schema 注入错误
- [x] Capture：关闭路径为空操作；空 PP accumulator 不落盘；队列满丢弃；writer 异常不打进训练；env 开启后目录为 `rank-<n>/`
- [ ] `test_capture_gpu.py` — 无 CUDA 时 skip
- [ ] 一次真实 GRPO 开 capture（例如 1 卡 Qwen3-0.6B，1～2 个 rollout），再对两类 bundle 做 CPU `replay`，对照原张量 / 日志标量

## 已知限制（不在本 PR）

- 两类 bundle 尚未打通，无法在一次报告里从 reward 追到 loss 的「首个分歧阶段」。
- `reward.raw` 对照已记录标量，不从 `(response, label)` 重跑奖励函数。
- fully-async 的 `relax/components/advantages.py` 未接 hook。
- `CP>1`、PPO value loss、OPD、Agentic flattened 仍为 `unsupported`。
- 未测量开启 capture 相对关闭路径的开销。
- prompt/response 按 redaction（hash / 截断）处理，不是完整 sample dump。