### PR TITLE
Fix(opd): keep teacher weights across sleep/wake in colocate

### DIFF
--- a/examples/on_policy_distillation/agentic_opd/alfworld/run-alfworld-opd-qwen35-35B-A3B-8xgpu.sh
+++ b/examples/on_policy_distillation/agentic_opd/alfworld/run-alfworld-opd-qwen35-35B-A3B-8xgpu.sh
@@ -157,7 +157,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine ${ROLLOUT_NUM_GPUS_PER_ENGINE:-4}
    --sglang-mem-fraction-static ${STUDENT_MEM_FRACTION:-0.7}
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
    --sglang-max-running-requests 64
 )
 

--- a/examples/on_policy_distillation/agentic_opd/webshop/run-webshop-opd-qwen35-35B-A3B-8xgpu.sh
+++ b/examples/on_policy_distillation/agentic_opd/webshop/run-webshop-opd-qwen35-35B-A3B-8xgpu.sh
@@ -165,7 +165,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine ${ROLLOUT_NUM_GPUS_PER_ENGINE:-4}
    --sglang-mem-fraction-static ${STUDENT_MEM_FRACTION:-0.7}
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
    --sglang-max-running-requests 64
 )
 

--- a/examples/on_policy_distillation/math_opd/run-opd-qwen35-35B-A3B-8xgpu-colocate.sh
+++ b/examples/on_policy_distillation/math_opd/run-opd-qwen35-35B-A3B-8xgpu-colocate.sh
@@ -133,7 +133,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 4
    --sglang-mem-fraction-static 0.6
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
    --sglang-max-running-requests 64
 )
 

--- a/examples/on_policy_distillation/mopd/run-mopd-qwen3-vl-2b-8xgpu-colocate.sh
+++ b/examples/on_policy_distillation/mopd/run-mopd-qwen3-vl-2b-8xgpu-colocate.sh
@@ -163,7 +163,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 1
    --sglang-mem-fraction-static 0.8
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
 )
 
 RESOURCE_JSON="{\"actor\": [1, ${ACTOR_GPUS}], \"rollout\": [1, ${ROLLOUT_GPUS}], \"teacher\": [1, ${TEACHER_GPUS}]}"

--- a/examples/on_policy_distillation/mopd/run-mopd-qwen35-35ba3b-16xgpu-colocate.sh
+++ b/examples/on_policy_distillation/mopd/run-mopd-qwen35-35ba3b-16xgpu-colocate.sh
@@ -176,7 +176,6 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.6
    --sglang-max-running-requests 128
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
 )
 
 PARTIAL_ROLLOUT_ARGS=(

--- a/examples/on_policy_distillation/mopd/run-mopd-qwen35-9b-8xgpu-colocate.sh
+++ b/examples/on_policy_distillation/mopd/run-mopd-qwen35-9b-8xgpu-colocate.sh
@@ -163,7 +163,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 2
    --sglang-mem-fraction-static 0.7
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
 )
 
 RESOURCE_JSON="{\"actor\": [1, ${ACTOR_GPUS}], \"rollout\": [1, ${ROLLOUT_GPUS}], \"teacher\": [1, ${TEACHER_GPUS}]}"

--- a/examples/on_policy_distillation/vision_opd/run-opd-qwen3.5_35ba3b-122ba10b-128xgpu-colocate.sh
+++ b/examples/on_policy_distillation/vision_opd/run-opd-qwen3.5_35ba3b-122ba10b-128xgpu-colocate.sh
@@ -199,7 +199,6 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static ${STUDENT_MEM_FRACTION:-0.7}
    --sglang-load-format dummy
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
-   --sglang-enable-weights-cpu-backup
 )
 
 WANDB_ARGS=(

--- a/examples/on_policy_distillation/vision_opd/run-vision-opd-qwen3.5_9b-35ba3b-8xgpu-2teacher-colocate.sh
+++ b/examples/on_policy_distillation/vision_opd/run-vision-opd-qwen3.5_9b-35ba3b-8xgpu-2teacher-colocate.sh
@@ -129,7 +129,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE:-2}"
    --sglang-mem-fraction-static "${STUDENT_MEM_FRACTION:-0.8}"
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
 )
 

--- a/examples/on_policy_distillation/vision_opd/run-vision-opd-qwen3.5_9b-35ba3b-8xgpu-colocate.sh
+++ b/examples/on_policy_distillation/vision_opd/run-vision-opd-qwen3.5_9b-35ba3b-8xgpu-colocate.sh
@@ -133,7 +133,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE:-2}"
    --sglang-mem-fraction-static "${STUDENT_MEM_FRACTION:-0.8}"
    --sglang-load-format dummy
-   --sglang-enable-weights-cpu-backup
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
 )
 

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -18,6 +18,7 @@ from relax.utils.logging_utils import get_logger
 from relax.utils.opd.opd_utils import (
     add_opd_arguments,
     is_managed_opd_teacher_enabled,
+    maybe_enable_sglang_weights_cpu_backup,
     teacher_sglang_parse_args,
     validate_managed_opd_teacher_colocate_args,
     validate_opd_args,
@@ -3455,6 +3456,7 @@ def slime_validate_args(args):
         args.offload_train = False
     if args.offload_rollout is None:
         args.offload_rollout = False
+    maybe_enable_sglang_weights_cpu_backup(args)
 
     if args.use_critic:
         args.offload_train = True

--- a/relax/utils/opd/opd_utils.py
+++ b/relax/utils/opd/opd_utils.py
@@ -143,6 +143,9 @@ def build_teacher_overrides(args: Any, colocate_sync: bool = False) -> dict[str,
     overrides["model_path"] = args.teacher_hf_checkpoint
     overrides.setdefault("load_format", "auto")
     overrides.setdefault("enable_memory_saver", colocate_sync)
+    if overrides.get("enable_memory_saver"):
+        # Release/resume without a CPU backup leaves weight pages uninitialized (uniform output).
+        overrides.setdefault("enable_weights_cpu_backup", True)
     return overrides
 
 

--- a/relax/utils/opd/opd_utils.py
+++ b/relax/utils/opd/opd_utils.py
@@ -463,6 +463,18 @@ def validate_managed_opd_teacher_colocate_args(args: Any) -> None:
         )
 
 
+def maybe_enable_sglang_weights_cpu_backup(args: Any) -> None:
+    # Rollout sleep/wake without a CPU backup leaves weight pages uninitialized.
+    if not getattr(args, "use_opd", False):
+        return
+    if not getattr(args, "offload_rollout", False):
+        return
+    if getattr(args, "sglang_enable_weights_cpu_backup", False):
+        return
+    logger.info("OPD with offloaded rollout: auto-enabling --sglang-enable-weights-cpu-backup.")
+    args.sglang_enable_weights_cpu_backup = True
+
+
 def add_opd_arguments(parser: Any) -> Any:
     parser.add_argument(
         "--use-opd",

--- a/tests/distributed/ray/test_teacher_sglang_overrides.py
+++ b/tests/distributed/ray/test_teacher_sglang_overrides.py
@@ -6,6 +6,7 @@ from types import ModuleType, SimpleNamespace
 from relax.utils.opd.opd_utils import (
     build_teacher_engine_args,
     build_teacher_overrides,
+    maybe_enable_sglang_weights_cpu_backup,
     teacher_sglang_parse_args,
 )
 
@@ -52,3 +53,35 @@ def test_teacher_sglang_parse_args_only_keeps_explicit_overrides(monkeypatch):
 
     assert args.teacher_sglang_mem_fraction_static == 0.73
     assert not hasattr(args, "teacher_sglang_model_path")
+
+
+def test_opd_with_offloaded_rollout_enables_weights_cpu_backup():
+    args = SimpleNamespace(use_opd=True, offload_rollout=True)
+
+    maybe_enable_sglang_weights_cpu_backup(args)
+
+    assert args.sglang_enable_weights_cpu_backup is True
+
+
+def test_opd_without_offload_keeps_weights_cpu_backup_untouched():
+    args = SimpleNamespace(use_opd=True, offload_rollout=False)
+
+    maybe_enable_sglang_weights_cpu_backup(args)
+
+    assert not hasattr(args, "sglang_enable_weights_cpu_backup")
+
+
+def test_non_opd_keeps_weights_cpu_backup_untouched():
+    args = SimpleNamespace(offload_rollout=True)
+
+    maybe_enable_sglang_weights_cpu_backup(args)
+
+    assert not hasattr(args, "sglang_enable_weights_cpu_backup")
+
+
+def test_explicit_weights_cpu_backup_is_preserved():
+    args = SimpleNamespace(use_opd=True, offload_rollout=True, sglang_enable_weights_cpu_backup=True)
+
+    maybe_enable_sglang_weights_cpu_backup(args)
+
+    assert args.sglang_enable_weights_cpu_backup is True


### PR DESCRIPTION

## 问题
本PR为实现[PR#237](https://github.com/redai-infra/Relax/pull/237)发现并修复的bug。欢迎交流~

colocate 模式下 managed OPD/SDPO teacher 开启了 `enable_memory_saver` 但未开启
`enable_weights_cpu_backup`。teacher 与 actor 共享 GPU，每个训练 step 都经历
`release_memory_occupation` / `resume_memory_occupation`；无 CPU backup 时 resume
重新分配的权重页不恢复内容，teacher 自第一次 wake 起输出均匀分布——所有 token 的
logprob 恒等于 `-ln(vocab_size)`。

蒸馏信号因此完全失效，且方向系统性错误：尖峰 student 对均匀 teacher 的 JSD loss
初始即达理论上界（实测 step-0 `train/loss = 0.688 ≈ ln 2`），随后把 student 推向
均匀分布（entropy_loss 0.41 → 3.56），表现为多语言乱码、EOS 概率消失、回复全部
截断、eval accuracy 崩到 0、loss 伪收敛到 1e-4 量级。

## 触发条件

同时满足以下四项即触发（对应 Relax-managed teacher 的 colocate 形态）：

1. `--use-opd --opd-type=sglang`，且 teacher 走 Relax 托管路径：设置了
   `--teacher-hf-checkpoint`（单 teacher）或 `--opd-teacher-routes`（MOPD），
   并且 `--resource` 含 `teacher` 条目；
2. `--colocate`（非 `--hybrid`），且 `--resource` 同时含 `actor` 与 `rollout`——
   即 `is_managed_opd_teacher_colocate` 为真，teacher 与 actor 共享 placement group；
3. teacher 随训练步做 sleep/wake：`--offload-rollout`（colocate 默认开启）使
   teacher 与 actor 锁步 offload/onload，每个 step 经历
   `release_memory_occupation` → `resume_memory_occupation`。此时
   `build_teacher_overrides(colocate_sync=True)` 把 `enable_memory_saver` 置 True；
4. 用户未显式传 `--teacher-sglang-enable-weights-cpu-backup`（sglang 默认关闭）。

不触发的形态：独立 PG 的 teacher（`enable_memory_saver=False`）、外部
`--opd-teacher-url` 自建 teacher（不经 `build_teacher_overrides`）、非 OPD 训练。
命中时所有 colocate OPD/OPSD/SDPO 配置在第一个训练步后 teacher 即失效，
蒸馏信号系统性错误且无任何报错。

## 修复

```python
overrides.setdefault("enable_memory_saver", colocate_sync)
if overrides.get("enable_memory_saver"):
    # Release/resume without a CPU backup leaves weight pages uninitialized (uniform output).
    overrides.setdefault("enable_weights_cpu_backup", True)
```

- `setdefault`：显式 `--teacher-sglang-enable-weights-cpu-backup` 仍可覆盖
- 非 colocate（独立 PG）teacher 不受影响（`enable_memory_saver` 为 False，guard 不触发）
- 非 OPD 算法不受影响：`build_teacher_overrides` 唯一调用方是
  `relax/distributed/ray/teacher_manager.py` 的 `TeacherManager`，仅 OPD/OPSD/SDPO 路径创建
- 代价：colocate teacher 节点多占一份权重 CPU backup（8B bf16 ≈ 16GB 内存）及
  release/resume 各一次拷贝
- GenRM 路径（`sglang_engine.py`）已使用同一 flag，本 PR 把 managed teacher 对齐

## 验证

1. 确定性复现（Qwen3-0.6B + `--enable-memory-saver`，同 venv sglang 0.5.12.post1）：
   一次 release→resume 后全部 logprob = `-11.9312 = -ln(151936)`；开启
   `enable_weights_cpu_backup` 后 3 个 sleep/wake 循环 logprob 逐位不变（max|Δ|=0）。
2. 真实训练（SciKnowEval Biology, Qwen3-8B, 4×H100 colocate）前后对比（wandb）：

   | run | 状态 | 步骤 | step-0 train/loss | 末尾 train/loss | eval acc 轨迹 | rollout acc |
   | --- | --- | ---: | ---: | ---: | --- | --- |
   | 修复前 `sdpo-sciknoweval-biology-2026-08-20-02:59:55` | 失败 | ~189 | **0.688（≈ln 2 上界）** | **1e-4（伪收敛）** | 0.361 → 0.011 → 0.0 | 0.406 → 骤降 |
   | 修复后 `sdpo-sciknoweval-biology-2026-08-21-06:45:37` | 成功 | ~400（取前 400） | 0.026 | 0.014 | **0.347 → 0.51（稳步上升）** | 最高 0.77 |

   修复前 step-0 `train/loss = 0.688 ≈ ln 2` 即 JSD 理论上界，说明 student 与
   （均匀化）teacher 分布几乎不相交；随后 loss 单调降到 1e-4 是 student 被均匀化的
   伪收敛。修复后 loss 一开始就落在 ~0.03 以下（真实 hint-only JSD 量级），eval
   accuracy 从 0.35 一路升到 0.51，rollout accuracy 最高 0.77，全程无崩塌。