### PR TITLE
fix(megatron): cast get_cp_local_num_tokens to torch.int for Megatron int32 token accumulator

### DIFF
--- a/relax/backends/megatron/cp_utils.py
+++ b/relax/backends/megatron/cp_utils.py
@@ -194,7 +194,7 @@ def get_cp_local_num_tokens(
     """
     cp_size = dynamic_cp_size if dynamic_cp_size is not None else mpu.get_context_parallel_world_size()
     if cp_size == 1:
-        return sum([torch.clamp_min(loss_mask.sum(), 1) for loss_mask in loss_masks])
+        return sum([torch.clamp_min(loss_mask.sum(), 1) for loss_mask in loss_masks]).to(torch.int)
 
     # cp_size > 1: mirror the chunk slicing done in get_sum_of_sample_mean so the
     # counted tokens exactly match the ones sum_of_token contributes on this rank.
@@ -221,8 +221,8 @@ def get_cp_local_num_tokens(
 
     if total is None:
         # No samples on this rank: mirror the empty-sum behaviour of cp_size == 1.
-        return sum([loss_mask.sum() for loss_mask in loss_masks])
-    return total
+        return sum([loss_mask.sum() for loss_mask in loss_masks]).to(torch.int)
+    return total.to(torch.int)
 
 
 def all_gather_with_cp(

--- a/tests/backends/megatron/test_rloo_policy_loss_dispatch.py
+++ b/tests/backends/megatron/test_rloo_policy_loss_dispatch.py
@@ -167,7 +167,8 @@ def test_rloo_unequal_lengths_use_global_token_scalar_and_gradient_oracle(monkey
     final_loss = token_sum_loss / normalizer
 
     assert torch.allclose(token_sum_loss, expected_token_sum)
-    assert torch.allclose(normalizer, expected_num_tokens)
+    assert normalizer.dtype == torch.int
+    assert torch.allclose(normalizer.to(expected_num_tokens.dtype), expected_num_tokens)
     assert torch.allclose(final_loss, expected_final_loss)
 
     first_length = response_lengths[0]


### PR DESCRIPTION
## Why

Megatron pipeline schedules accumulate the per-token loss normalizer on an **int** tensor:

- `megatron/core/pipeline_parallel/schedules.py` — `total_num_tokens = torch.zeros([], dtype=torch.int)` (lines 256/652/1144/2363)
- Relax own `relax/backends/megatron/streaming_schedules.py:106,295` uses the same int accumulator

`get_cp_local_num_tokens` returned float32 (aggregated `loss_mask.sum()`), so every training run with `--calculate-per-token-loss` crashes at step 0 on the first `total_num_tokens += num_tokens`:

```
RuntimeError: result type Float can't be cast to the desired output type Int
```

17/30 example launchers enable `--calculate-per-token-loss` (all six sdpo launchers, most OPD/agentic recipes, rloo, mini_swe, nemo_gym).

## How

Cast the three return paths of `get_cp_local_num_tokens` to `torch.int` so the value handed to `forward_backward_*` matches the accumulator dtype. Non-per-token-loss paths are unaffected (their normalizer is `torch.tensor(1)`), and mixing the int32 scalar into `log_values` still produces identical float32 metrics.

## Testing

- `pytest tests/backends/megatron/test_rloo_policy_loss_dispatch.py tests/backends/megatron/test_rloo_cp_reduction.py` passes on CPU.
- `test_rloo_policy_loss_dispatch` now compares the normalizer dtype-safely and pins `normalizer.dtype == torch.int` as the regression contract (the dtype-strict `torch.allclose` would otherwise fail after this fix).

Relates to #285 (touches the same function cp_size == 1 branch).
