### PR TITLE
chore: migrate references from `redai-infra` to `redai-studio`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://redai-infra.github.io/Relax
+    url: https://redai-studio.github.io/Relax
     about: Check the documentation for guides and API reference
   - name: Questions & Discussions
-    url: https://github.com/redai-infra/Relax/discussions
+    url: https://github.com/redai-studio/Relax/discussions
     about: Ask questions and discuss ideas with the community

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.repository == 'redai-infra/Relax'
+    if: github.repository == 'redai-studio/Relax'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.repository == 'redai-infra/Relax'
+    if: github.repository == 'redai-studio/Relax'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ This project follows a standard code of conduct. Please be respectful, inclusive
 
 ```bash
 # Clone the repository
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 cd Relax
 
 # Create virtual environment (recommended)
@@ -155,7 +155,7 @@ feat(rollout): add streaming data consumption for async mode
 
 ## Reporting Bugs
 
-Use the [Bug Report template](https://github.com/redai-infra/Relax/issues/new?template=bug_report.md) and include:
+Use the [Bug Report template](https://github.com/redai-studio/Relax/issues/new?template=bug_report.md) and include:
 
 - **Environment** — OS, Python version, CUDA version, GPU type
 - **Steps to Reproduce** — Minimal commands to trigger the bug
@@ -165,7 +165,7 @@ Use the [Bug Report template](https://github.com/redai-infra/Relax/issues/new?te
 
 ## Requesting Features
 
-Use the [Feature Request template](https://github.com/redai-infra/Relax/issues/new?template=feature_request.md) and include:
+Use the [Feature Request template](https://github.com/redai-studio/Relax/issues/new?template=feature_request.md) and include:
 
 - **Problem Statement** — What problem does this solve?
 - **Proposed Solution** — How should it work?

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@
   <a href="https://arxiv.org/abs/2604.11554">
     <img src="https://img.shields.io/static/v1?label=arXiv&message=Paper&color=red" alt="arXiv">
   </a>
-  <a href="https://redai-infra.github.io/Relax">
+  <a href="https://redai-studio.github.io/Relax">
     <img src="https://img.shields.io/badge/docs-latest-brightgreen.svg" alt="Documentation">
   </a>
-  <a href="https://github.com/redai-infra/Relax/discussions/48" target="_blank">
+  <a href="https://github.com/redai-studio/Relax/discussions/48" target="_blank">
     <img src="https://img.shields.io/badge/WeChat-green?logo=wechat" alt="WeChat QR">
   </a>
-  <a href="https://github.com/redai-infra/Relax/discussions/30" target="_blank">
+  <a href="https://github.com/redai-studio/Relax/discussions/30" target="_blank">
     <img src="https://img.shields.io/badge/Docker-Image-blue?logo=docker" alt="Docker Image">
   </a>
 </p>
@@ -34,7 +34,7 @@
 
 ______________________________________________________________________
 
-**Relax** (**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality) is a high-performance reinforcement learning post-training framework open-sourced by the Xiaohongshu AI Infra Team for multimodal large language models. Built on Ray Serve with a service-oriented architecture, Relax uses Megatron-LM as the training backend and SGLang as the inference engine. Through the [TransferQueue](https://github.com/redai-infra/TransferQueue) data transfer system, it achieves complete decoupling of training and inference, supporting end-to-end multimodal RL training from text to images, videos, and audio.
+**Relax** (**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality) is a high-performance reinforcement learning post-training framework open-sourced by the Xiaohongshu AI Infra Team for multimodal large language models. Built on Ray Serve with a service-oriented architecture, Relax uses Megatron-LM as the training backend and SGLang as the inference engine. Through the [TransferQueue](https://github.com/redai-studio/TransferQueue) data transfer system, it achieves complete decoupling of training and inference, supporting end-to-end multimodal RL training from text to images, videos, and audio.
 
 ______________________________________________________________________
 
@@ -129,15 +129,15 @@ The recommended way to run Relax is via the official Docker image, which ships w
 
 ```bash
 # Pull the official image
-docker pull ghcr.io/redai-infra/relaxrl:latest
+docker pull ghcr.io/redai-studio/relaxrl:latest
 
 # Launch a container with GPUs, shared memory, and your workspace mounted
 docker run -it --gpus all --ipc=host --network=host \
   -v /path/to/your/workspace:/root \
-  ghcr.io/redai-infra/relaxrl:latest bash
+  ghcr.io/redai-studio/relaxrl:latest bash
 
 # Inside the container
-git clone https://github.com/redai-infra/Relax.git /root/Relax
+git clone https://github.com/redai-studio/Relax.git /root/Relax
 cd /root/Relax && pip install -e .
 ```
 
@@ -246,7 +246,7 @@ ______________________________________________________________________
 
 ## 📚 Documentation
 
-Full bilingual documentation is available at **[redai-infra.github.io/Relax](https://redai-infra.github.io/Relax)**.
+Full bilingual documentation is available at **[redai-studio.github.io/Relax](https://redai-studio.github.io/Relax)**.
 
 ______________________________________________________________________
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,13 +16,13 @@
   <a href="https://arxiv.org/abs/2604.11554">
     <img src="https://img.shields.io/static/v1?label=arXiv&message=Paper&color=red" alt="arXiv">
   </a>
-  <a href="https://redai-infra.github.io/Relax">
+  <a href="https://redai-studio.github.io/Relax">
     <img src="https://img.shields.io/badge/docs-latest-brightgreen.svg" alt="Documentation">
   </a>
-  <a href="https://github.com/redai-infra/Relax/discussions/48" target="_blank">
+  <a href="https://github.com/redai-studio/Relax/discussions/48" target="_blank">
     <img src="https://img.shields.io/badge/WeChat-green?logo=wechat" alt="WeChat QR">
   </a>
-  <a href="https://github.com/redai-infra/Relax/discussions/30" target="_blank">
+  <a href="https://github.com/redai-studio/Relax/discussions/30" target="_blank">
     <img src="https://img.shields.io/badge/Docker-Image-blue?logo=docker" alt="Docker Image">
   </a>
 </p>
@@ -34,7 +34,7 @@
 
 ______________________________________________________________________
 
-**Relax**（**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality）是小红书 AI 平台开源的、面向多模态大模型的高性能强化学习后训练框架。Relax 基于 Ray Serve 构建面向服务的架构，以 Megatron-LM 为训练后端、SGLang 为推理引擎，通过 [TransferQueue](https://github.com/redai-infra/TransferQueue) 数据传输系统实现训练与推理的完全解耦，支持从文本到图像、视频、音频的全模态强化学习训练。
+**Relax**（**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality）是小红书 AI 平台开源的、面向多模态大模型的高性能强化学习后训练框架。Relax 基于 Ray Serve 构建面向服务的架构，以 Megatron-LM 为训练后端、SGLang 为推理引擎，通过 [TransferQueue](https://github.com/redai-studio/TransferQueue) 数据传输系统实现训练与推理的完全解耦，支持从文本到图像、视频、音频的全模态强化学习训练。
 
 ______________________________________________________________________
 
@@ -129,15 +129,15 @@ ______________________________________________________________________
 
 ```bash
 # 拉取官方镜像
-docker pull ghcr.io/redai-infra/relaxrl:latest
+docker pull ghcr.io/redai-studio/relaxrl:latest
 
 # 启动容器，挂载 GPU、共享内存与工作目录
 docker run -it --gpus all --ipc=host --network=host \
   -v /path/to/your/workspace:/root \
-  ghcr.io/redai-infra/relaxrl:latest bash
+  ghcr.io/redai-studio/relaxrl:latest bash
 
 # 容器内克隆仓库并安装
-git clone https://github.com/redai-infra/Relax.git /root/Relax
+git clone https://github.com/redai-studio/Relax.git /root/Relax
 cd /root/Relax && pip install -e .
 ```
 
@@ -246,7 +246,7 @@ ______________________________________________________________________
 
 ## 📚 文档
 
-完整的双语文档请访问 **[redai-infra.github.io/Relax](https://redai-infra.github.io/Relax)**。
+完整的双语文档请访问 **[redai-studio.github.io/Relax](https://redai-studio.github.io/Relax)**。
 
 ______________________________________________________________________
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN MAX_JOBS=64 \
     rm -rf /opt/flash-attention/
 
 RUN pip -v install --no-cache-dir --no-build-isolation "transformer_engine[pytorch]==2.14.1" && \
-    TMS_CUDA_MAJOR=$(python -c 'import torch; print(torch.version.cuda.split(".")[0])') pip install git+https://github.com/redai-infra/torch_memory_saver.git@afc13785c50119048e2dd8ac497cc9e29ec75bd4 --no-cache-dir --force-reinstall && \
+    TMS_CUDA_MAJOR=$(python -c 'import torch; print(torch.version.cuda.split(".")[0])') pip install git+https://github.com/redai-studio/torch_memory_saver.git@afc13785c50119048e2dd8ac497cc9e29ec75bd4 --no-cache-dir --force-reinstall && \
     pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation --no-cache-dir && \
     pip install "numpy<2" nvidia-cudnn-cu12==9.16.0.29 --no-cache-dir && \
     NVCC_APPEND_FLAGS="--threads 32" \
@@ -116,7 +116,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --ignore-installed PyJWT && \
     pip install -r /tmp/requirements.txt --no-cache-dir && \
     pip install --no-cache-dir "compressed_tensors>=0.13.0" tensordict==0.10.0 pyvers==0.1.0 'nvidia-modelopt[hf]==0.44.0' --no-deps && \
-    pip install "transferqueue @ git+https://github.com/redai-infra/TransferQueue.git@58054a33834aadbcf76aacd6b1e32e25c030f2c9" --no-deps
+    pip install "transferqueue @ git+https://github.com/redai-studio/TransferQueue.git@58054a33834aadbcf76aacd6b1e32e25c030f2c9" --no-deps
 
 # sgl-router: override the official wheel (pulled by requirements.txt above) with
 # slime's r3-capable fork. The official sglang-router drops the routed_experts

--- a/docker/Dockerfile.npu
+++ b/docker/Dockerfile.npu
@@ -79,7 +79,7 @@ RUN pip_install() { pip install "$@" || pip install --index-url https://pypi.org
     cd /root && rm -rf /root/pytorch && \
     pip_install triton-ascend==3.2.0 && \
     pip_install tensordict==0.10.0 pyvers==0.1.0 --no-deps
-RUN git clone https://github.com/redai-infra/TransferQueue.git /root/TransferQueue && \
+RUN git clone https://github.com/redai-studio/TransferQueue.git /root/TransferQueue && \
     cd /root/TransferQueue && \
     git checkout 58054a33834aadbcf76aacd6b1e32e25c030f2c9 && \
     pip install /root/TransferQueue --no-deps --no-build-isolation && \

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -229,7 +229,7 @@ export default defineConfig({
           {
             text: 'Resources',
             items: [
-              { text: 'GitHub', link: 'https://github.com/redai-infra/Relax' },
+              { text: 'GitHub', link: 'https://github.com/redai-studio/Relax' },
               { text: 'Paper', link: 'https://arxiv.org/abs/2604.11554' }
             ]
           }
@@ -345,7 +345,7 @@ export default defineConfig({
           {
             text: '资源',
             items: [
-              { text: 'GitHub', link: 'https://github.com/redai-infra/Relax' },
+              { text: 'GitHub', link: 'https://github.com/redai-studio/Relax' },
               { text: '论文', link: 'https://arxiv.org/abs/2604.11554' }
             ]
           }
@@ -474,7 +474,7 @@ export default defineConfig({
   themeConfig: {
     logo: '/rednote-logo.png',
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/redai-infra/Relax' }
+      { icon: 'github', link: 'https://github.com/redai-studio/Relax' }
     ],
     search: {
       provider: 'local'

--- a/docs/.vitepress/theme/CallToAction.vue
+++ b/docs/.vitepress/theme/CallToAction.vue
@@ -26,8 +26,8 @@ const subtitle = computed(() =>
 const primaryLabel = computed(() => isZh.value ? '参与贡献' : 'Contribute Now')
 const secondaryLabel = computed(() => isZh.value ? '讨论区' : 'Discussion')
 
-const primaryLink = 'https://github.com/redai-infra/Relax/blob/main/CONTRIBUTING.md'
-const secondaryLink = 'https://github.com/redai-infra/Relax/discussions'
+const primaryLink = 'https://github.com/redai-studio/Relax/blob/main/CONTRIBUTING.md'
+const secondaryLink = 'https://github.com/redai-studio/Relax/discussions'
 </script>
 
 <template>

--- a/docs/deploy-docs.sh
+++ b/docs/deploy-docs.sh
@@ -41,7 +41,7 @@ if [ "$1" == "github" ]; then
     fi
     
     # Push to GitHub Pages
-    git push -f git@github.com:redai-infra/Relax.git gh-pages
+    git push -f git@github.com:redai-studio/Relax.git gh-pages
     
     echo "✅ Deployed to GitHub Pages!"
     

--- a/docs/en/api/actor-fwd.md
+++ b/docs/en/api/actor-fwd.md
@@ -37,5 +37,5 @@ The ActorFwd runs a background loop that:
 
 ## Source
 
-- Implementation: [`relax/components/actor_fwd.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/actor_fwd.py)
-- Base class: [`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- Implementation: [`relax/components/actor_fwd.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/actor_fwd.py)
+- Base class: [`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/en/api/actor.md
+++ b/docs/en/api/actor.md
@@ -34,5 +34,5 @@ The Actor runs a background training loop that:
 
 ## Source
 
-- Implementation: [`relax/components/actor.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/actor.py)
-- Base class: [`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- Implementation: [`relax/components/actor.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/actor.py)
+- Base class: [`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/en/api/genrm.md
+++ b/docs/en/api/genrm.md
@@ -45,5 +45,5 @@ See [GenRM example](/en/examples/generative-reward-model) for full configuration
 
 ## Source
 
-- Implementation: [`relax/components/genrm.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/genrm.py)
-- Base class: [`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- Implementation: [`relax/components/genrm.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/genrm.py)
+- Base class: [`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/en/api/rollout.md
+++ b/docs/en/api/rollout.md
@@ -39,5 +39,5 @@ In fully-async mode, the Rollout service coordinates with the Actor for weight u
 
 ## Source
 
-- Implementation: [`relax/components/rollout.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/rollout.py)
-- Base class: [`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- Implementation: [`relax/components/rollout.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/rollout.py)
+- Base class: [`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -519,7 +519,7 @@ SFT also uses the general dataset flags from [Data Configuration](#data-configur
 |-----------|------|---------|-------------|
 | `--autoscaler-config` | str | None | Path to autoscaler YAML configuration file. Enables autoscaling when set, disabled when not set. Example: `--autoscaler-config relax/utils/autoscaler/autoscaler.yaml` |
 
-For autoscaler YAML configuration details, see [`relax/utils/autoscaler/autoscaler.yaml`](https://github.com/redai-infra/Relax/blob/main/relax/utils/autoscaler/autoscaler.yaml).
+For autoscaler YAML configuration details, see [`relax/utils/autoscaler/autoscaler.yaml`](https://github.com/redai-studio/Relax/blob/main/relax/utils/autoscaler/autoscaler.yaml).
 
 ### Scale-Out Operation Parameters
 

--- a/docs/en/guide/customize-training.md
+++ b/docs/en/guide/customize-training.md
@@ -460,6 +460,6 @@ bash scripts/entrypoint/ray-job.sh scripts/training/multimodal/run-qwen35-9B-8xg
 
 ## Getting Help
 
-- [GitHub Issues](https://github.com/redai-infra/Relax/issues)
-- [Discussions](https://github.com/redai-infra/Relax/discussions)
+- [GitHub Issues](https://github.com/redai-studio/Relax/issues)
+- [Discussions](https://github.com/redai-studio/Relax/discussions)
 - [Introduction](../guide/introduction.md)

--- a/docs/en/guide/fully-async-training.md
+++ b/docs/en/guide/fully-async-training.md
@@ -156,7 +156,7 @@ In Fully Async mode, Actor uses `StreamingDataLoader` for **streaming data consu
 #### StreamingDataset
 
 ```python
-# TransferQueue (installed from https://github.com/redai-infra/TransferQueue)
+# TransferQueue (installed from https://github.com/redai-studio/TransferQueue)
 class StreamingDataset(IterableDataset):
     """Streaming dataset that dynamically fetches data from TransferQueue"""
 

--- a/docs/en/guide/how-to-contribute.md
+++ b/docs/en/guide/how-to-contribute.md
@@ -10,7 +10,7 @@ Create a virtual environment and install dependencies:
 
 ```bash
 # Clone the repository
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 cd Relax
 
 # Create virtual environment

--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -21,13 +21,13 @@ Run the following commands to clone the repository, pull the latest image, and s
 
 ```bash
 # Clone the repository
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 
 # Pull the Docker image
-docker pull ghcr.io/redai-infra/relaxrl:latest
+docker pull ghcr.io/redai-studio/relaxrl:latest
 
 # Run the container, mounting the local repository to /root/Relax inside the container
-docker run -it --gpus all -v $(pwd)/Relax:/root/Relax ghcr.io/redai-infra/relaxrl:latest /bin/bash
+docker run -it --gpus all -v $(pwd)/Relax:/root/Relax ghcr.io/redai-studio/relaxrl:latest /bin/bash
 ```
 
 Alternatively, build the image from the Dockerfile:
@@ -57,13 +57,13 @@ DOCKER_BUILDKIT=1 docker build \
   .
 ```
 
-For more details on Docker releases, see [Docker README](https://github.com/redai-infra/Relax/blob/main/docker/README.md).
+For more details on Docker releases, see [Docker README](https://github.com/redai-studio/Relax/blob/main/docker/README.md).
 
 ### Method 2: Install from Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 cd Relax
 
 # Install dependencies
@@ -87,7 +87,7 @@ export MEGATRON="your megatron path"
 export PYTHONPATH=your_megatron_path:$PYTHONPATH
 ```
 
-Additionally, Relax depends on [Megatron Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) for weight conversion. Follow the install steps in [`docker/Dockerfile`](https://github.com/redai-infra/Relax/blob/main/docker/Dockerfile): merge the Bridge sources with the Megatron-LM submodule into a single directory and add it to `PYTHONPATH`:
+Additionally, Relax depends on [Megatron Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) for weight conversion. Follow the install steps in [`docker/Dockerfile`](https://github.com/redai-studio/Relax/blob/main/docker/Dockerfile): merge the Bridge sources with the Megatron-LM submodule into a single directory and add it to `PYTHONPATH`:
 
 ```bash
 export MEGATRON_BRIDGE_COMMIT=2faedbf6fe3c422835a44b2b360cadcb2a116a54

--- a/docs/en/guide/introduction.md
+++ b/docs/en/guide/introduction.md
@@ -2,7 +2,7 @@
 
 ## What is Relax?
 
-**Relax** (**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality) is a high-performance reinforcement learning post-training framework for multimodal large language models. Built on Ray Serve with a service-oriented architecture, Relax uses Megatron-LM as the training backend and SGLang as the inference engine. Through the [TransferQueue](https://github.com/redai-infra/TransferQueue) data transfer system, it achieves complete decoupling of training and inference, supporting end-to-end multimodal RL training from text to images, videos, and audio.
+**Relax** (**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality) is a high-performance reinforcement learning post-training framework for multimodal large language models. Built on Ray Serve with a service-oriented architecture, Relax uses Megatron-LM as the training backend and SGLang as the inference engine. Through the [TransferQueue](https://github.com/redai-studio/TransferQueue) data transfer system, it achieves complete decoupling of training and inference, supporting end-to-end multimodal RL training from text to images, videos, and audio.
 
 ---
 
@@ -26,7 +26,7 @@ Relax adopts a service-oriented six-layer architecture where all components are 
 
 ### ⚡ Fully Asynchronous Training via TransferQueue
 
-Open source at [TransferQueue](https://github.com/redai-infra/TransferQueue). See [Fully Asynchronous Training](./fully-async-training.md) for details.
+Open source at [TransferQueue](https://github.com/redai-studio/TransferQueue). See [Fully Asynchronous Training](./fully-async-training.md) for details.
 
 In fully async mode, five roles—Rollout (inference), Actor (training), ActorFwd (forward pass), Reference (reference model), and Advantages (advantage computation)—run on **independent GPU clusters** and exchange data via TransferQueue, with weights synchronized asynchronously through DCS (Distributed Checkpoint Service).
 

--- a/docs/en/guide/reinforce-plus-plus-training-report.md
+++ b/docs/en/guide/reinforce-plus-plus-training-report.md
@@ -8,7 +8,7 @@ a claim that one algorithm is statistically superior.
 
 ## Scope and evidence boundary
 
-- Proposal: [Task 29 issue #192](https://github.com/redai-infra/Relax/issues/192)
+- Proposal: [Task 29 issue #192](https://github.com/redai-studio/Relax/issues/192)
 - Sanitized reproducibility evidence:
   [logs, expanded commands, metrics and manifest](https://github.com/zheself/Relax/releases/tag/task29-reinforcepp-evidence-c72caf1)
 - Experiment source commit: `5f7cd574372288391bb1c41ca0677422cd31e725`

--- a/docs/en/guide/trajectory-replay.md
+++ b/docs/en/guide/trajectory-replay.md
@@ -190,4 +190,4 @@ writer.finalize(ranks=[0])
 - Production capture is split into two bundle types: rollout-level (reward/advantage, identity `rollout_id`, instrumented in `train_actor`) and step-level (loss, identity `(rollout_id, step_id)`, instrumented in `train_one_step`); cross-bundle propagation of the "first divergent stage" is not yet unified. Enable with `RELAX_REPLAY_CAPTURE=1` and `RELAX_REPLAY_CAPTURE_DIR`.
 - Remote RM/GenRM results are treated as `recorded-only` and are not recomputed offline.
 
-See [Task 34 RFC #171](https://github.com/redai-infra/Relax/issues/171) for the design discussion.
+See [Task 34 RFC #171](https://github.com/redai-studio/Relax/issues/171) for the design discussion.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -9,7 +9,7 @@ hero:
       link: /en/guide/introduction
     - theme: alt
       text: View on GitHub
-      link: https://github.com/redai-infra/Relax
+      link: https://github.com/redai-studio/Relax
 
 features:
   - icon: '<svg viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="icon-teal"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2" fill="currentColor" fill-opacity="0.2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>'

--- a/docs/zh/api/actor-fwd.md
+++ b/docs/zh/api/actor-fwd.md
@@ -37,5 +37,5 @@ ActorFwd 运行后台循环：
 
 ## 源码
 
-- 实现：[`relax/components/actor_fwd.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/actor_fwd.py)
-- 基类：[`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- 实现：[`relax/components/actor_fwd.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/actor_fwd.py)
+- 基类：[`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/zh/api/actor.md
+++ b/docs/zh/api/actor.md
@@ -34,5 +34,5 @@ Actor 运行后台训练循环：
 
 ## 源码
 
-- 实现：[`relax/components/actor.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/actor.py)
-- 基类：[`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- 实现：[`relax/components/actor.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/actor.py)
+- 基类：[`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/zh/api/genrm.md
+++ b/docs/zh/api/genrm.md
@@ -45,5 +45,5 @@ GenRM（生成式奖励模型）服务提供基于 LLM 的响应评估。它以 
 
 ## 源码
 
-- 实现：[`relax/components/genrm.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/genrm.py)
-- 基类：[`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- 实现：[`relax/components/genrm.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/genrm.py)
+- 基类：[`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/zh/api/rollout.md
+++ b/docs/zh/api/rollout.md
@@ -39,5 +39,5 @@ Rollout 运行后台循环：
 
 ## 源码
 
-- 实现：[`relax/components/rollout.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/rollout.py)
-- 基类：[`relax/components/base.py`](https://github.com/redai-infra/Relax/blob/main/relax/components/base.py)
+- 实现：[`relax/components/rollout.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/rollout.py)
+- 基类：[`relax/components/base.py`](https://github.com/redai-studio/Relax/blob/main/relax/components/base.py)

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -519,7 +519,7 @@ SFT 还会用到通用的[数据配置](#数据配置)参数，特别是 `--inpu
 |------|------|--------|------|
 | `--autoscaler-config` | str | None | Autoscaler YAML 配置文件路径。设置后启用自动扩缩容，未设置则禁用。示例：`--autoscaler-config relax/utils/autoscaler/autoscaler.yaml` |
 
-Autoscaler YAML 配置详情请参见 [`relax/utils/autoscaler/autoscaler.yaml`](https://github.com/redai-infra/Relax/blob/main/relax/utils/autoscaler/autoscaler.yaml)。
+Autoscaler YAML 配置详情请参见 [`relax/utils/autoscaler/autoscaler.yaml`](https://github.com/redai-studio/Relax/blob/main/relax/utils/autoscaler/autoscaler.yaml)。
 
 ### Scale-Out 操作参数
 

--- a/docs/zh/guide/customize-training.md
+++ b/docs/zh/guide/customize-training.md
@@ -489,6 +489,6 @@ tail -f /tmp/ray/session_latest/logs/serve/*.log
 
 ## 获取帮助
 
-- [GitHub Issues](https://github.com/redai-infra/Relax/issues)
-- [Discussions](https://github.com/redai-infra/Relax/discussions)
+- [GitHub Issues](https://github.com/redai-studio/Relax/issues)
+- [Discussions](https://github.com/redai-studio/Relax/discussions)
 - [介绍](../guide/introduction.md)

--- a/docs/zh/guide/fully-async-training.md
+++ b/docs/zh/guide/fully-async-training.md
@@ -156,7 +156,7 @@ TransferQueue 必须能同时缓存 `max_staleness + 1` 个 rollout batch 的数
 #### StreamingDataset
 
 ```python
-# TransferQueue (installed from https://github.com/redai-infra/TransferQueue)
+# TransferQueue (installed from https://github.com/redai-studio/TransferQueue)
 class StreamingDataset(IterableDataset):
     """流式数据集，从 TransferQueue 动态获取数据"""
 

--- a/docs/zh/guide/how-to-contribute.md
+++ b/docs/zh/guide/how-to-contribute.md
@@ -10,7 +10,7 @@
 
 ```bash
 # 克隆仓库
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 cd Relax
 
 # 创建虚拟环境

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -21,13 +21,13 @@
 
 ```bash
 # 克隆代码仓库
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 
 # 拉取 Docker 镜像
-docker pull ghcr.io/redai-infra/relaxrl:latest
+docker pull ghcr.io/redai-studio/relaxrl:latest
 
 # 运行容器，将本地代码仓库挂载到容器内的 /root/Relax
-docker run -it --gpus all -v $(pwd)/Relax:/root/Relax ghcr.io/redai-infra/relaxrl:latest /bin/bash
+docker run -it --gpus all -v $(pwd)/Relax:/root/Relax ghcr.io/redai-studio/relaxrl:latest /bin/bash
 ```
 
 或者基于 Dockerfile 构建镜像：
@@ -57,13 +57,13 @@ DOCKER_BUILDKIT=1 docker build \
   .
 ```
 
-更多 Docker 发布信息请参见 [Docker README](https://github.com/redai-infra/Relax/blob/main/docker/README.md)。
+更多 Docker 发布信息请参见 [Docker README](https://github.com/redai-studio/Relax/blob/main/docker/README.md)。
 
 ### 方法 2：从源码安装
 
 ```bash
 # 克隆仓库
-git clone https://github.com/redai-infra/Relax.git
+git clone https://github.com/redai-studio/Relax.git
 cd Relax
 
 # 安装依赖
@@ -87,7 +87,7 @@ export MEGATRON="your megatron path"
 export PYTHONPATH=your_megatron_path:$PYTHONPATH
 ```
 
-此外 Relax 依赖 [Megatron Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) 进行权重转换。安装方式参考 [`docker/Dockerfile`](https://github.com/redai-infra/Relax/blob/main/docker/Dockerfile)，将 Bridge 源码与 Megatron-LM submodule 合并到同一目录后加入 `PYTHONPATH`：
+此外 Relax 依赖 [Megatron Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) 进行权重转换。安装方式参考 [`docker/Dockerfile`](https://github.com/redai-studio/Relax/blob/main/docker/Dockerfile)，将 Bridge 源码与 Megatron-LM submodule 合并到同一目录后加入 `PYTHONPATH`：
 
 ```bash
 export MEGATRON_BRIDGE_COMMIT=2faedbf6fe3c422835a44b2b360cadcb2a116a54

--- a/docs/zh/guide/introduction.md
+++ b/docs/zh/guide/introduction.md
@@ -2,7 +2,7 @@
 
 ## 什么是 Relax？
 
-**Relax**（**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality）是一个面向多模态大模型的高性能强化学习后训练框架。Relax 基于 Ray Serve 构建面向服务的架构，以 Megatron-LM 为训练后端、SGLang 为推理引擎，通过 [TransferQueue](https://github.com/redai-infra/TransferQueue) 数据传输系统实现训练与推理的完全解耦，支持从文本到图像、视频、音频的全模态强化学习训练。
+**Relax**（**R**einforcement **E**ngine **L**everaging **A**gentic **X**-modality）是一个面向多模态大模型的高性能强化学习后训练框架。Relax 基于 Ray Serve 构建面向服务的架构，以 Megatron-LM 为训练后端、SGLang 为推理引擎，通过 [TransferQueue](https://github.com/redai-studio/TransferQueue) 数据传输系统实现训练与推理的完全解耦，支持从文本到图像、视频、音频的全模态强化学习训练。
 
 ---
 
@@ -26,7 +26,7 @@ Relax 采用面向服务的六层架构设计，所有角色均部署为独立�
 
 ### ⚡ 基于 TransferQueue 的全异步训练（Fully Async）
 
-开源地址 [TransferQueue](https://github.com/redai-infra/TransferQueue)，详细介绍见 [全异步训练](./fully-async-training.md)。
+开源地址 [TransferQueue](https://github.com/redai-studio/TransferQueue)，详细介绍见 [全异步训练](./fully-async-training.md)。
 
 在全异步模式下，Rollout（推理）、Actor（训练）、ActorFwd（前向计算）、Reference（参考模型）和 Advantages（优势计算）五个角色运行在**独立的 GPU 集群**上，通过 TransferQueue 交换数据，通过 DCS（Distributed Checkpoint Service）异步同步权重。
 

--- a/docs/zh/guide/reinforce-plus-plus-training-report.md
+++ b/docs/zh/guide/reinforce-plus-plus-training-report.md
@@ -4,7 +4,7 @@
 
 ## 范围与证据边界
 
-- Proposal：[Task 29 issue #192](https://github.com/redai-infra/Relax/issues/192)
+- Proposal：[Task 29 issue #192](https://github.com/redai-studio/Relax/issues/192)
 - 脱敏的可复现证据：[日志、展开命令、指标和 manifest](https://github.com/zheself/Relax/releases/tag/task29-reinforcepp-evidence-c72caf1)
 - 实验源码 commit：`5f7cd574372288391bb1c41ca0677422cd31e725`
 - 实验 upstream base：`b095ba68ce95c7d98762cf128eab630878f394e6`

--- a/docs/zh/guide/trajectory-replay.md
+++ b/docs/zh/guide/trajectory-replay.md
@@ -186,4 +186,4 @@ writer.finalize(ranks=[0])
 - 生产捕获拆成两类 bundle：rollout 级（reward/advantage，身份 `rollout_id`，在 `train_actor` 打点）与 step 级（loss，身份 `(rollout_id, step_id)`，在 `train_one_step` 打点）；两者尚未在同一 bundle 中打通「首个分歧阶段」的跨 bundle 传播。通过 `RELAX_REPLAY_CAPTURE=1` 与 `RELAX_REPLAY_CAPTURE_DIR` 打开。
 - 远端 RM/GenRM 结果按 `recorded-only` 处理，不在离线侧重算。
 
-相关设计讨论见 [Task 34 RFC #171](https://github.com/redai-infra/Relax/issues/171)。
+相关设计讨论见 [Task 34 RFC #171](https://github.com/redai-studio/Relax/issues/171)。

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -9,7 +9,7 @@ hero:
       link: /zh/guide/introduction
     - theme: alt
       text: 在 GitHub 上查看
-      link: https://github.com/redai-infra/Relax
+      link: https://github.com/redai-studio/Relax
 
 features:
   - icon: '<svg viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="icon-teal"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2" fill="currentColor" fill-opacity="0.2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>'

--- a/examples/nemo_gym_agentic/README.md
+++ b/examples/nemo_gym_agentic/README.md
@@ -157,7 +157,7 @@ callback 可能被错误发送到代理。
 
 需要两个运行角色：
 
-1. `RELAX_IMAGE`：公开的标准 Relax 训练镜像 `ghcr.io/redai-infra/relaxrl:latest`，运行 GPU Ray
+1. `RELAX_IMAGE`：公开的标准 Relax 训练镜像 `ghcr.io/redai-studio/relaxrl:latest`，运行 GPU Ray
    cluster 和训练任务；
 2. `NEMO_GYM_IMAGE`：由本目录 Dockerfile 基于 `RELAX_IMAGE` 构建，运行 NeMo Gym 服务。
 
@@ -169,7 +169,7 @@ venv。
 ### 构建 NeMo Gym 镜像
 
 ```bash
-export RELAX_IMAGE="ghcr.io/redai-infra/relaxrl:latest"
+export RELAX_IMAGE="ghcr.io/redai-studio/relaxrl:latest"
 export NEMO_GYM_IMAGE="relax-nemo-gym:a85670e"
 export http_proxy="http://proxy.example.com:3128"   # 无代理时留空
 export https_proxy="${http_proxy}"

--- a/examples/nemo_gym_agentic/recipes/gsm8k/README.md
+++ b/examples/nemo_gym_agentic/recipes/gsm8k/README.md
@@ -48,7 +48,7 @@ Relax managed session
 
 ```bash
 export REPO_ROOT="$(pwd)"
-export RELAX_IMAGE="ghcr.io/redai-infra/relaxrl:latest"
+export RELAX_IMAGE="ghcr.io/redai-studio/relaxrl:latest"
 export NEMO_GYM_IMAGE="relax-nemo-gym:a85670e"
 export DATA_ROOT="/绝对路径/relax-nemo-data"
 export MODEL_DIR="/绝对路径/models"
@@ -79,7 +79,7 @@ DOCKER_BUILDKIT=1 docker build \
   .
 ```
 
-Dockerfile 默认基于 `ghcr.io/redai-infra/relaxrl:latest`。使用其他已有 Relax tag 时，给上述命令
+Dockerfile 默认基于 `ghcr.io/redai-studio/relaxrl:latest`。使用其他已有 Relax tag 时，给上述命令
 增加 `--build-arg RELAX_IMAGE="<image>"`；不需要构建 Relax 镜像。
 
 检查镜像：

--- a/examples/nemo_gym_agentic/recipes/r2e-gym/README.md
+++ b/examples/nemo_gym_agentic/recipes/r2e-gym/README.md
@@ -170,7 +170,7 @@ NeMo Gym 服务本身不需要 GPU。GPU 只由 Relax 模型训练使用。
 
 ```bash
 export REPO_ROOT="$(pwd)"
-export RELAX_IMAGE="ghcr.io/redai-infra/relaxrl:latest"
+export RELAX_IMAGE="ghcr.io/redai-studio/relaxrl:latest"
 export NEMO_GYM_IMAGE="relax-nemo-gym:a85670e"
 export R2E_DATA_DIR="/绝对路径/nemo-gym/r2e-gym"
 export MODEL_DIR="/绝对路径/models"
@@ -206,7 +206,7 @@ DOCKER_BUILDKIT=1 docker build \
   .
 ```
 
-Dockerfile 默认基于 `ghcr.io/redai-infra/relaxrl:latest`。使用其他已有 Relax tag 时，给上述命令
+Dockerfile 默认基于 `ghcr.io/redai-studio/relaxrl:latest`。使用其他已有 Relax tag 时，给上述命令
 增加 `--build-arg RELAX_IMAGE="<image>"`；不需要构建 Relax 镜像。
 
 该镜像固定并 patch：

--- a/examples/nemo_gym_agentic/recipes/workplace-assistant/README.md
+++ b/examples/nemo_gym_agentic/recipes/workplace-assistant/README.md
@@ -61,7 +61,7 @@ resource server 为每条请求创建独立数据库会话。集成 patch 维护
 
 ```bash
 export REPO_ROOT="$(pwd)"
-export RELAX_IMAGE="ghcr.io/redai-infra/relaxrl:latest"
+export RELAX_IMAGE="ghcr.io/redai-studio/relaxrl:latest"
 export NEMO_GYM_IMAGE="relax-nemo-gym:a85670e"
 export DATA_ROOT="/绝对路径/relax-nemo-data"
 export MODEL_DIR="/绝对路径/models"
@@ -90,7 +90,7 @@ DOCKER_BUILDKIT=1 docker build \
   .
 ```
 
-Dockerfile 默认基于 `ghcr.io/redai-infra/relaxrl:latest`。使用其他已有 Relax tag 时，给上述命令
+Dockerfile 默认基于 `ghcr.io/redai-studio/relaxrl:latest`。使用其他已有 Relax tag 时，给上述命令
 增加 `--build-arg RELAX_IMAGE="<image>"`；不需要构建 Relax 镜像。
 
 镜像在构建阶段预建 Gateway、simple agent 和 Workplace resource venv，并应用 session cleanup

--- a/examples/nemo_gym_agentic/service/Dockerfile
+++ b/examples/nemo_gym_agentic/service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG RELAX_IMAGE=ghcr.io/redai-infra/relaxrl:latest
+ARG RELAX_IMAGE=ghcr.io/redai-studio/relaxrl:latest
 FROM ${RELAX_IMAGE}
 
 ARG NEMO_GYM_COMMIT=a85670eb167ba9b48cc53a36a070eed815e6c40d

--- a/relax/backends/megatron/model_provider.py
+++ b/relax/backends/megatron/model_provider.py
@@ -278,7 +278,7 @@ def get_model_provider_func(
             "freeze_vision_projection",
             "freeze_audio_model",
             "freeze_audio_projection",
-            # https://github.com/redai-infra/Megatron-Bridge/commit/960bb5f18800d3e1fb9815e95daa185ab06c09ea
+            # https://github.com/redai-studio/Megatron-Bridge/commit/960bb5f18800d3e1fb9815e95daa185ab06c09ea
             "vision_dp_when_tp",
             "vision_dp_when_cp",
             "calculate_per_token_loss",

--- a/relax/utils/arguments.py
+++ b/relax/utils/arguments.py
@@ -37,7 +37,7 @@ logger = get_logger(__name__)
 # Minimum required TransferQueue version and the command to upgrade to it.
 _MIN_TQ_VERSION = "0.1.10.dev0"
 _TQ_UPGRADE_CMD = (
-    'pip install "transferqueue @ git+https://github.com/redai-infra/'
+    'pip install "transferqueue @ git+https://github.com/redai-studio/'
     'TransferQueue.git@58054a33834aadbcf76aacd6b1e32e25c030f2c9" --no-deps'
 )
 

--- a/relax/utils/data/identity_window_sampler.py
+++ b/relax/utils/data/identity_window_sampler.py
@@ -10,7 +10,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "transfer_queue is out of date (missing StreamingTokenBudgetSampler). Upgrade with:\n"
-        '    pip install "transferqueue @ git+https://github.com/redai-infra/'
+        '    pip install "transferqueue @ git+https://github.com/redai-studio/'
         'TransferQueue.git@58054a33834aadbcf76aacd6b1e32e25c030f2c9" --no-deps\n'
         "or use the latest image."
     ) from e

--- a/relax/utils/visualize/templates.py
+++ b/relax/utils/visualize/templates.py
@@ -1802,7 +1802,7 @@ def get_jsonl_viewer_html(data_dir: str, base_path: str = "") -> str:
                     <span class="logo-icon">📊</span>
                     <div>
                         <h1>
-                            <a href="https://github.com/redai-infra/Relax" target="_blank" rel="noopener"
+                            <a href="https://github.com/redai-studio/Relax" target="_blank" rel="noopener"
                                style="color: inherit; text-decoration: none;">Relax</a>
                             Rollout Result Viewer
                         </h1>
@@ -1810,7 +1810,7 @@ def get_jsonl_viewer_html(data_dir: str, base_path: str = "") -> str:
                     </div>
                 </div>
                 <div class="theme-toggle">
-                    <a class="theme-btn" href="https://github.com/redai-infra/Relax" target="_blank"
+                    <a class="theme-btn" href="https://github.com/redai-studio/Relax" target="_blank"
                        rel="noopener" title="Relax on GitHub"
                        style="text-decoration: none; display: inline-flex; align-items: center;">
                         <svg height="18" width="18" viewBox="0 0 16 16" fill="currentColor"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def main():
         long_description_content_type="text/markdown",
         keywords=["RL", "Agentic", "Multi-modality", "pytorch", "deep learning", "megatron", "vllm", "sglang"],
         license="Apache-2.0",
-        url="https://github.com/redai-infra/Relax",
+        url="https://github.com/redai-studio/Relax",
         package_dir={"": "."},
         package_data={"": ["*.yaml"]},
         packages=find_packages(),

--- a/skills/sglang-upgrade/SKILL.md
+++ b/skills/sglang-upgrade/SKILL.md
@@ -116,7 +116,7 @@ cp /tmp/relax_new.patch /root/data/Relax/docker/patch/latest/sglang.patch
 - `:4` `BASE_IMAGE` → 新 tag。
 - 删除过时的源码 overlay(如 `update-transformers-v5` rsync 段)。
 - CUDA 耦合项:若 `-cuXXX` 变了,复核 tilelang wheel 源、flash-attn/apex/TE 重编、cudnn 版本(注:slime 在 cu129 base 上 tilelang 仍用 cu128)。
-- `torch_memory_saver`:跟进 slime 的 `TMS_CUDA_MAJOR` **自动探测**写法 `$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')`;commit 取 redai-infra fork 的 HEAD(先确认比 slime 用的新,别降级)。
+- `torch_memory_saver`:跟进 slime 的 `TMS_CUDA_MAJOR` **自动探测**写法 `$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')`;commit 取 redai-studio fork 的 HEAD(先确认比 slime 用的新,别降级)。
 - `docker/Dockerfile.npu` 的 `git clone -b <tag>` 同步。
 
 `requirements.txt`(属 CLAUDE.md "Ask First",改前确认):

--- a/skills/sync-github/SKILL.md
+++ b/skills/sync-github/SKILL.md
@@ -79,10 +79,10 @@ test -z "$(git status --porcelain --untracked-files=no)"
 SOURCE_SHA=$(git rev-parse HEAD)
 VALIDATE_BRANCH=sync/validate-github-main-$(git rev-parse --short HEAD)
 git push github HEAD:refs/heads/$VALIDATE_BRANCH
-gh workflow run ci.yml -R redai-infra/Relax --ref $VALIDATE_BRANCH
-gh run list -R redai-infra/Relax --workflow ci.yml --branch $VALIDATE_BRANCH --limit 5
-gh run watch <run-id> -R redai-infra/Relax
-gh run view <run-id> -R redai-infra/Relax --json status,conclusion,headSha,url
+gh workflow run ci.yml -R redai-studio/Relax --ref $VALIDATE_BRANCH
+gh run list -R redai-studio/Relax --workflow ci.yml --branch $VALIDATE_BRANCH --limit 5
+gh run watch <run-id> -R redai-studio/Relax
+gh run view <run-id> -R redai-studio/Relax --json status,conclusion,headSha,url
 ```
 
 门禁规则：
@@ -92,14 +92,14 @@ gh run view <run-id> -R redai-infra/Relax --json status,conclusion,headSha,url
 - 如果失败，先查看失败日志：
 
 ```bash
-gh run view <run-id> -R redai-infra/Relax --log-failed
+gh run view <run-id> -R redai-studio/Relax --log-failed
 ```
 
 - 如果需要改代码：本地修复、提交、push 到同一个验证分支或新验证分支后，重新 `gh workflow run ci.yml`。不要用旧 run 证明新代码。
 - 如果确认是瞬时失败且代码未变，可以只重跑失败 job：
 
 ```bash
-gh run rerun <run-id> -R redai-infra/Relax --failed
+gh run rerun <run-id> -R redai-studio/Relax --failed
 ```
 
 - 在 CI 全绿前禁止执行 `git push github HEAD:refs/heads/main`。

--- a/skills/sync-github/references/prompt-b-dev-to-main.md
+++ b/skills/sync-github/references/prompt-b-dev-to-main.md
@@ -194,15 +194,15 @@ SOURCE_SHA=$(git rev-parse HEAD)
 VALIDATE_BRANCH=sync/validate-github-main-$(git rev-parse --short HEAD)
 
 git push github HEAD:refs/heads/$VALIDATE_BRANCH
-gh workflow run ci.yml -R redai-infra/Relax --ref $VALIDATE_BRANCH
-gh run list -R redai-infra/Relax --workflow ci.yml --branch $VALIDATE_BRANCH --limit 5
+gh workflow run ci.yml -R redai-studio/Relax --ref $VALIDATE_BRANCH
+gh run list -R redai-studio/Relax --workflow ci.yml --branch $VALIDATE_BRANCH --limit 5
 ```
 
 盯 run：
 
 ```bash
-gh run watch <run-id> -R redai-infra/Relax
-gh run view <run-id> -R redai-infra/Relax --json status,conclusion,headBranch,headSha,url
+gh run watch <run-id> -R redai-studio/Relax
+gh run view <run-id> -R redai-studio/Relax --json status,conclusion,headBranch,headSha,url
 ```
 
 门禁：
@@ -215,11 +215,11 @@ gh run view <run-id> -R redai-infra/Relax --json status,conclusion,headBranch,he
 失败处置：
 
 ```bash
-gh run view <run-id> -R redai-infra/Relax --log-failed
+gh run view <run-id> -R redai-studio/Relax --log-failed
 ```
 
 - 需要改代码：本地修 → commit → push 到验证分支 → 重新 `gh workflow run ci.yml`。旧 run 不能证明新代码。
-- 确认瞬时失败且代码未变：`gh run rerun <run-id> -R redai-infra/Relax --failed`。
+- 确认瞬时失败且代码未变：`gh run rerun <run-id> -R redai-studio/Relax --failed`。
 
 CI 全绿前禁止执行下一步。
 


### PR DESCRIPTION
## What

- Replace all remaining `redai-infra` namespace references with `redai-studio` across repository metadata, workflows, documentation, examples, install guidance, and internal skills.
- Update Relax, TransferQueue, torch_memory_saver, and Megatron-Bridge links while preserving existing paths and pinned commits.
- Point documentation deployment guards/targets, GitHub Pages links, and the Relax GHCR image at the active organization.

## Why

The repositories and package have moved to `redai-studio`. Keeping the old namespace leaves stale documentation (the old Pages URL returns 404), prevents the docs workflow from running in the transferred repository, and directs users to an unavailable old GHCR namespace.

## How

This is a mechanical namespace-only migration: 110 occurrences across 49 tracked files were changed from `redai-infra` to `redai-studio`, with no other content changes.

## Testing

- [x] `pre-commit run --all-files` passes (all hooks, using Python 3.11)
- [ ] Tests pass (`pytest tests/`) — not run; no executable behavior changed, and this checkout does not have the project's test dependencies installed
- [ ] New tests added (not applicable to a namespace-only migration)
- [x] Documentation updated
- [x] `npm run docs:build` passes
- [x] `bash -n docs/deploy-docs.sh` and Python compilation checks pass
- [x] All 23 distinct migrated web link targets return HTTP 2xx
- [x] `ghcr.io/redai-studio/relaxrl:latest` returns a valid container manifest (HTTP 200)
- [x] Repository-wide search finds zero remaining `redai-infra` references

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Screenshots / Logs

Not applicable.
