### PR TITLE
docs(site): render Markdown task lists

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,3 +1,4 @@
+import taskLists from 'markdown-it-task-lists'
 import { defineConfig } from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
@@ -213,32 +214,7 @@ export default defineConfig({
   markdown: {
     math: true,
     config(md) {
-      md.core.ruler.after('inline', 'task-lists', (state) => {
-        for (let index = 2; index < state.tokens.length; index++) {
-          const inlineToken = state.tokens[index]
-          const marker = inlineToken.content.match(/^\[([ xX])\]\s+/)
-          const firstChild = inlineToken.children?.[0]
-
-          if (
-            inlineToken.type !== 'inline' ||
-            state.tokens[index - 1].type !== 'paragraph_open' ||
-            state.tokens[index - 2].type !== 'list_item_open' ||
-            !marker ||
-            firstChild?.type !== 'text'
-          ) {
-            continue
-          }
-
-          inlineToken.content = inlineToken.content.slice(marker[0].length)
-          firstChild.content = firstChild.content.slice(marker[0].length)
-
-          const checkbox = new state.Token('html_inline', '', 0)
-          const checked = marker[1].toLowerCase() === 'x'
-          checkbox.content = `<input class="task-list-item-checkbox" type="checkbox" disabled${checked ? ' checked' : ''}> `
-          inlineToken.children?.unshift(checkbox)
-          state.tokens[index - 2].attrJoin('class', 'task-list-item')
-        }
-      })
+      md.use(taskLists)
     }
   },
   

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -209,9 +209,37 @@ export default defineConfig({
   // Ignore dead links for source code references and placeholder pages
   ignoreDeadLinks: true,
 
-  // Enable LaTeX math rendering
+  // Enable LaTeX math rendering and GitHub-style task lists
   markdown: {
-    math: true
+    math: true,
+    config(md) {
+      md.core.ruler.after('inline', 'task-lists', (state) => {
+        for (let index = 2; index < state.tokens.length; index++) {
+          const inlineToken = state.tokens[index]
+          const marker = inlineToken.content.match(/^\[([ xX])\]\s+/)
+          const firstChild = inlineToken.children?.[0]
+
+          if (
+            inlineToken.type !== 'inline' ||
+            state.tokens[index - 1].type !== 'paragraph_open' ||
+            state.tokens[index - 2].type !== 'list_item_open' ||
+            !marker ||
+            firstChild?.type !== 'text'
+          ) {
+            continue
+          }
+
+          inlineToken.content = inlineToken.content.slice(marker[0].length)
+          firstChild.content = firstChild.content.slice(marker[0].length)
+
+          const checkbox = new state.Token('html_inline', '', 0)
+          const checked = marker[1].toLowerCase() === 'x'
+          checkbox.content = `<input class="task-list-item-checkbox" type="checkbox" disabled${checked ? ' checked' : ''}> `
+          inlineToken.children?.unshift(checkbox)
+          state.tokens[index - 2].attrJoin('class', 'task-list-item')
+        }
+      })
+    }
   },
   
   // 多语言配置

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -162,6 +162,19 @@
 }
 
 /**
+ * Component: Task List
+ * -------------------------------------------------------------------------- */
+
+.vp-doc li.task-list-item {
+  list-style: none;
+}
+
+.vp-doc .task-list-item-checkbox {
+  margin: 0 0.5em 0 -1.4em;
+  vertical-align: middle;
+}
+
+/**
  * ASCII Art Background — Dark Home Page
  * -------------------------------------------------------------------------- */
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.37",
+    "markdown-it-task-lists": "^2.1.1",
     "medium-zoom": "^1.1.0",
     "mermaid": "^10.0.0",
     "swagger-ui-dist": "^5.32.1",


### PR DESCRIPTION
## What

- Render Markdown task-list markers as disabled checkboxes in the VitePress documentation.
- Remove duplicate list bullets and align the generated checkbox controls with their task text.
- Keep the change limited to the documentation renderer, its task-list styling, and the renderer dependency.

## Why

The English and Chinese contribution checklists already store each task on its own valid `- [ ] ...` source line. However, VitePress's Markdown pipeline does not enable GitHub-style task lists by default, so the built pages emitted literal `[ ]` text instead of checkbox controls.

## How

Configure VitePress to use the established [`markdown-it-task-lists`](https://www.npmjs.com/package/markdown-it-task-lists) plugin recommended by the VitePress maintainers in [vuejs/vitepress#1923](https://github.com/vuejs/vitepress/issues/1923#issuecomment-1431479500). The plugin recognizes `[ ]`, `[x]`, and `[X]` list-item markers, emits disabled checkbox inputs, and tags the generated list markup for scoped theme styling.

## Testing

- [x] `pre-commit run --all-files` passes
- [x] Tests pass (`pytest tests/`) — GitHub CI passed on Python 3.10, 3.11, and 3.12
- [ ] New tests added (not applicable; generated HTML was inspected directly)
- [x] Documentation updated (if applicable)

Additional validation:

- `npm run docs:build` — passed; generated all four OpenAPI specs and completed the VitePress build.
- Generated-HTML check — confirmed 72 source task items become 72 disabled checkbox inputs, including five each in the English and Chinese contribution pages.
- Repository-wide Markdown scan — confirmed every checkbox marker is a single standalone task-list item and no source line contains multiple task markers.
- GitHub CI — Pre-commit Checks, Lint, and tests on Python 3.10/3.11/3.12 all passed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

Local VitePress builds of the same Chinese contribution-guide section at `origin/main` and this PR's head:

| Before | After |
| --- | --- |
| ![Before: task markers render as literal bracket text beside list bullets](https://github.com/user-attachments/assets/035e289e-2c30-49dd-b36b-f4ff9c311db3) | ![After: task markers render as aligned checkbox controls](https://github.com/user-attachments/assets/76f6d394-be95-4c7e-a54c-4673c52c1ee7) |


