### PR TITLE
ci(lint): consolidate Ruff checks in pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -38,7 +38,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Pre-commit checks (ruff check/format, copyright, gitleaks, trailing-whitespace …) ──
+  # ── Pre-commit checks (ruff check/format, copyright, gitleaks, trailing-whitespace etc.) ──
   pre-commit:
     name: Pre-commit Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Pre-commit checks (ruff, copyright, gitleaks, trailing-whitespace …) ──
+  # ── Pre-commit checks (ruff check/format, copyright, gitleaks, trailing-whitespace …) ──
   pre-commit:
     name: Pre-commit Checks
     runs-on: ubuntu-latest
@@ -27,28 +27,6 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
-
-  # ── Lint (ruff check + ruff format --check) ───────────────────────────────
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install ruff
-        run: pip install ruff==0.15.9
-
-      - name: Ruff check
-        run: ruff check relax/ tests/
-
-      - name: Ruff format check
-        run: ruff format --check relax/ tests/
 
   # ── Unit tests (matrix: Python 3.10 / 3.11 / 3.12) ────────────────────────
   test:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository == 'redai-studio/Relax'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
     hooks:
-      - id: ruff
-        # exclude: 'relax/xxx'
-        args: [ --fix ]
-
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix, --no-cache]
       - id: ruff-format
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v0.15.9
     hooks:
       - id: ruff-check
-        args: [--fix, --exit-non-zero-on-fix, --no-cache]
+        args: [--fix]
       - id: ruff-format
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.9


### PR DESCRIPTION
## What

Consolidate Ruff linting and formatting in the existing pre-commit CI job, remove the standalone Lint job, and upgrade `actions/checkout` from v4 to v7.

## Why

CI runs Ruff through both pre-commit and a separate Lint job. Consolidating these checks keeps local and CI validation aligned through the same hook configuration and removes duplicate work.

## How

- Rename the legacy `ruff` hook to `ruff-check`, retaining `--fix` and the following `ruff-format` hook.
- Remove the standalone Ruff lint and format job.
- Upgrade `actions/checkout` to v7 in the CI and documentation deployment workflows.

> [!NOTE]
> After `astral-sh/ruff-pre-commit`'s version >= v0.16.5, ruff format will default formats Python code blocks in Markdown files. If we decide to support this, I can upgrade ruff-pre-commit. It appears to affect some manually aligned code comments, but we can disable formatting locally where needed.

## Testing

- [x] `pre-commit run --all-files --show-diff-on-failure` passes
- [ ] Tests pass (`pytest tests/`) — not run; changes only affect CI and hook configuration.
- [ ] New tests added (if applicable) — not applicable.
- [ ] Documentation updated (if applicable) — not applicable.

Multi-node GPU integration tests were not run because this change only affects CI configuration and those tests require multi-node GPU hardware.

## Type of Change

- [x] CI/CD or build changes

## Screenshots / Logs

All applicable pre-commit hooks passed, including Ruff linting, Ruff formatting, and secret detection.
