### PR TITLE
ci(actions): upgrade actions and adopt prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
 
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+      - name: Run prek
+        uses: j178/prek-action@v3.0.0
 
   # ── Unit tests (matrix: Python 3.10 / 3.11 / 3.12) ────────────────────────
   test:
@@ -41,12 +41,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,12 +30,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -48,13 +48,13 @@ jobs:
           npm install --no-audit --no-fund --no-save @rollup/rollup-linux-x64-gnu
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build VitePress site
         run: npm run docs:build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## What

<!-- What changes does this PR introduce? -->

Upgrade the actions used by CI and GitHub Pages, replace `pre-commit/action` with `j178/prek-action`, and restrict CI push/PR branch filters to `main`.

## Why

<!-- Why are these changes needed? Link related issues with "Fixes #123" or "Relates to #456". -->

Keep workflow actions current, use `prek` to instead of `pre-commit` in ci, it's faster than `pre-commit` and more efficient in disk space usage, also fully compatible with the original pre-commit configurations and hooks.

## How

<!-- How do the changes work? Describe the technical approach. -->

Update `setup-python` to v7, `setup-node` to v7, `cache` to v6, `configure-pages` to v6, `upload-pages-artifact` to v5, and `deploy-pages` to v5.

Use `j178/prek-action@v3.0.0` to run the existing `.pre-commit-config.yaml`.

Remove `develop` from the CI push and pull-request branch filters.

## Testing

<!-- How were the changes tested? Include commands, test results, or screenshots. -->
`prek run --all-files` passes

- [x] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain the changes. -->

