### PR TITLE
ci(hooks): use managed Python environments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,8 @@ repos:
       - id: check-conflict-markers
         name: check-conflict-markers
         entry: python .pre-commit-hooks/check_conflict_markers.py
-        language: system
+        language: python
+        language_version: python3
         types: [text]
         exclude: |
             (?x)^(
@@ -66,7 +67,8 @@ repos:
       - id: format-ascii-boxes
         name: format-ascii-boxes
         entry: python .pre-commit-hooks/format_ascii_boxes.py
-        language: system
+        language: python
+        language_version: python3
         files: \.md$
 
   # Gitleaks - Secret detection


### PR DESCRIPTION
## What

Run the `check-conflict-markers` and `format-ascii-boxes` local hooks in pre-commit-managed Python 3 environments.

## Why

Both hooks invoke `python`. With `language: system`, they depend on a `python` executable on the caller's PATH, which can fail on systems that only expose `python3`.

## How

Set `language: python` and `language_version: python3` for both hooks so pre-commit provisions their Python environments.

## Testing

`pre-commit run --all-files --show-diff-on-failure` passed with the existing pre-commit environment's bin directory on PATH.

`pytest tests/` was not run because this change only updates hook configuration. Multi-node GPU integration tests were skipped because they require multi-node GPU hardware and this change does not affect training. New tests and documentation updates are not applicable.

- [x] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Screenshots / Logs
