### PR TITLE
ci(hooks): manage gitleaks in Python environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,12 +70,11 @@ repos:
         language: python
         language_version: python3
         files: \.md$
-
-  # Gitleaks - Secret detection
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
-    hooks:
       - id: gitleaks
+        name: gitleaks
         entry: python .pre-commit-hooks/gitleaks_tracked.py
+        language: python
+        language_version: python3
+        additional_dependencies: ["nogoo9-gitleaks==8.30.1"]
         always_run: true
         pass_filenames: false


### PR DESCRIPTION
## What

Run Gitleaks as a local Python hook with `nogoo9-gitleaks==8.30.1`, moving the scanner from upstream 8.24.2 to the packaged 8.30.1 binary.

## Why

The previous Go hook invokes a Python wrapper but does not provide its interpreter. On systems with `python3` but no `python` on PATH, the hook fails before scanning. A managed Python environment provides both the interpreter and the Gitleaks CLI without a local Go build.

Fixes #306

## How

Define the hook under `repo: local` with `language: python`, `language_version: python3`, and a pinned `additional_dependencies` package. The package supplies the Gitleaks command; supported platform wheels include the binary, while fallback wheels download it on first use.

Keep the existing tracked-file snapshot wrapper, `always_run: true`, and `pass_filenames: false`, preserving scanning scope and redacted output.

## Testing

`pre-commit run --all-files --show-diff-on-failure` and `prek run gitleaks --all-files` passed.

`pytest tests/` was not run for this hook-only change. Multi-node GPU integration tests were skipped because they require multi-node GPU hardware. New tests and documentation updates are not applicable.

- [x] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain the changes. -->
